### PR TITLE
Updating machine wolf and adding pinto

### DIFF
--- a/configuration/scripts/cice.run.setup.csh
+++ b/configuration/scripts/cice.run.setup.csh
@@ -74,24 +74,29 @@ EOFB
 
 else if (${CICE_MACHINE} =~ wolf*) then
 cat >> ${jobfile} << EOFB
-#MSUB -A climateacme
-#MSUB -l walltime=01:00:00
-#MSUB -l nodes=1:ppn=4
-#MSUB -N cice
+#SBATCH -J ${CICE_CASENAME}
+#SBATCH -t 0:45:00
+#SBATCH -A ${acct}
+#SBATCH -N ${nnodes}
+#SBATCH -e slurm%j.err
+#SBATCH -o slurm%j.out
+#SBATCH --mail-type END,FAIL
+#SBATCH --mail-user=eclare@lanl.gov
+#SBATCH --qos=low
 EOFB
-#cat >> ${jobfile} << EOFB
-##SBATCH -J ${CICE_CASENAME}
-####SBATCH -p tossdev
-##SBATCH -t 0:45:00
-##SBATCH -A ${acct}
-##SBATCH -N ${nnodes}
-####SBATCH -L SCRATCH
-####SBATCH -C haswell
-##SBATCH -e slurm%j.err
-##SBATCH -o slurm%j.out
-####SBATCH --mail-type FAIL
-####SBATCH --mail-user username@domain.com
-#EOFB
+
+else if (${CICE_MACHINE} =~ pinto*) then
+cat >> ${jobfile} << EOFB
+#SBATCH -J ${CICE_CASENAME}
+#SBATCH -t 0:45:00
+#SBATCH -A ${acct}
+#SBATCH -N ${nnodes}
+#SBATCH -e slurm%j.err
+#SBATCH -o slurm%j.out
+###SBATCH --mail-type END,FAIL
+###SBATCH --mail-user=eclare@lanl.gov
+#SBATCH --qos=standby
+EOFB
 
 endif
 
@@ -156,6 +161,11 @@ srun -n ${ntasks} -c ${nthrds} ./cice >&! \$CICE_RUNLOG_FILE
 EOFR
 
 else if (${CICE_MACHINE} =~ wolf*) then
+cat >> ${jobfile} << EOFR
+mpirun -np ${ntasks} ./cice >&! \$CICE_RUNLOG_FILE
+EOFR
+
+else if (${CICE_MACHINE} =~ pinto*) then
 cat >> ${jobfile} << EOFR
 mpirun -np ${ntasks} ./cice >&! \$CICE_RUNLOG_FILE
 EOFR

--- a/configuration/scripts/machines/Macros.pinto
+++ b/configuration/scripts/machines/Macros.pinto
@@ -1,0 +1,64 @@
+#==============================================================================
+# Macros file for CICE on LANL pinto, intel compiler
+#==============================================================================
+
+CPP        := fpp
+CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${CICE_CPPDEFS}
+CFLAGS     := -c -O2 -fp-model precise   -xHost
+
+FIXEDFLAGS := -132
+FREEFLAGS  := -FR
+FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback   -xHost
+FFLAGS_NOOPT:= -O0
+
+ifeq ($(CICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+else
+  FFLAGS     += -O2
+endif
+
+ifeq ($(CICE_COMMDIR), mpi)
+  FC         := mpif90
+else
+  FC         := ifort
+endif
+
+MPICC:= mpicc
+
+MPIFC:= mpif90
+LD:= $(MPIFC)
+
+# set in Macros file
+NETCDF_PATH := /usr/projects/climate/SHARED_CLIMATE/software/conejo/netcdf/3.6.3/intel-13.0.1
+PNETCDF_PATH := /usr/projects/climate/SHARED_CLIMATE/software/conejo/parallel-netcdf/1.3.1/intel-13.0.1/openmpi-1.6.3
+#LAPACK_LIBDIR := /glade/apps/opt/lapack/3.4.2/intel/12.1.5/lib
+
+PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
+
+INCLDIR := $(INCLDIR) -I$(NETCDF_PATH)/include
+#INCLDIR := $(INCLDIR) -I/usr/projects/climate/SHARED_CLIMATE/software/conejo/netcdf/3.6.3/intel-13.0.1/include
+
+LIB_NETCDF := $(NETCDF_PATH)/lib
+LIB_PNETCDF := $(PNETCDF_PATH)/lib
+LIB_MPI := $(IMPILIBDIR)
+
+#SLIBS   := -L$(LIB_NETCDF) -lnetcdf -L$(LIB_PNETCDF) -lpnetcdf -L$(LAPACK_LIBDIR) -llapack -lblas
+SLIBS   := -L$(LIB_NETCDF) -lnetcdf -L$(LIB_PNETCDF) -lpnetcdf 
+
+SCC:= icc 
+
+SFC:= ifort 
+
+ifeq ($(CICE_THREADED), true) 
+   LDFLAGS += -qopenmp
+   CFLAGS += -qopenmp
+   FFLAGS += -qopenmp
+endif
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first!
+ifeq ($(CICE_IOTYPE), pio)
+   PIO_PATH:=/usr/projects/climate/SHARED_CLIMATE/software/conejo/pio/1.7.2/intel-13.0.1/openmpi-1.6.3/netcdf-3.6.3-parallel-netcdf-1.3.1/include
+   INCLDIR += -I$(PIO_PATH)
+   SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpio
+endif
+

--- a/configuration/scripts/machines/env.pinto
+++ b/configuration/scripts/machines/env.pinto
@@ -17,7 +17,7 @@ setenv PNETCDF_PATH /usr/projects/climate/SHARED_CLIMATE/software/conejo/paralle
 #setenv MP_EUILIB us
 #setenv MP_EAGER_LIMIT 0
 
-setenv CICE_MACHINE_ENVNAME wolf
+setenv CICE_MACHINE_ENVNAME pinto
 setenv CICE_MACHINE_WKDIR /net/scratch3/$user/CICE_RUNS
 setenv CICE_MACHINE_INPUTDATA /usr/projects/climate/eclare/DATA/atm/gx3v2m/NCAR_bulk/
 setenv CICE_MACHINE_SUBMIT "sbatch "


### PR DESCRIPTION
wolf only accepts jobs using at least 5 nodes (80 cores) in the standard
queue, but small jobs can use qos=low (quality of service).  pinto only accepts
jobs using at least 16 cores, but smaller jobs can use the standby queue.