### PR TITLE
Revert "Putting overview info in README.md.  Also updating my fork to the upstream Consortium version of CICE."

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,17 @@
-*This repository is under construction, and some resources listed here are not yet available*
+# CICE
 
-## Overview
+Copyright (c) 2017, Los Alamos National Security, LLC 
+All rights reserved.
+                
+Copyright 2017. Los Alamos National Security, LLC. This software was produced under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National Laboratory (LANL), which is operated by Los Alamos National Security, LLC for the U.S. Department of Energy. The U.S. Government has rights to use, reproduce, and distribute this software. NEITHER THE GOVERNMENT NOR LOS ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE. If software is modified to produce derivative works, such modified software should be clearly marked, so as not to confuse it with the version available from LANL.
 
-This repository contains files needed to run versions 6 and higher of the sea ice model CICE, which is now maintained by the CICE Consortium.  Versions prior to v6 are found in the [CICE-svn-trunk repository](https://github.com/CICE-Consortium/CICE-svn-trunk).
+Additionally, redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+                                                
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.                        
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of Los Alamos National Security, LLC, Los Alamos National Laboratory, LANL, the U.S. Government, nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+                    
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-CICE consists of a top level driver and dynamical core plus the Icepack column physics code, which is included in CICE as a git submodule.  Because Icepack is a submodule of CICE, Icepack and CICE development are handled independently with respect to the github repositories even though development and testing may be done together. 
+Use of software in any private development branches of the CICE repository shall be conducted under the distribution policy of the CICE Consortium (see DistributionPolicy.pdf). 
 
-## Obtaining CICE
-
-If you expect to make any changes to the code, we recommend that you first fork both the CICE and Icepack repositories.  Basic instructions for working with CICE and Icepack are found in the Git and Workflow Guide, linked from the wikis in the primary code repositories    
-https://github.com/CICE-Consortium/CICE/wiki    
-https://github.com/CICE-Consortium/Icepack/wiki
-
-CICE may be obtained in several different ways:  [not yet tested]    
-1.  clone the full repository    
-See [Git and Workflow Guide](https://docs.google.com/document/d/1rR6WAvZQT9iAMUp-m_HZ06AUCCI19mguFialsMCYs9o/edit?usp=sharing)    
-2.  check out only a particular branch, version or tag    
-In the workflow for step 1 above, substitute    
-  [check this] git clone -b branch_name --single-branch --recursive https://github.com/CICE-Consortium/CICE.git local_directory_name
-or use svn    
-  svn co https://github.com/CICE-Consortium/CICE/branch_name    
-where "branch name" can also be a version name    
-3.  download a tarball for a particular version    
-[how]
-
-## More information
-
-"Quick Start" instructions are available in [README_v6](https://github.com/CICE-Consortium/CICE/blob/master/README_v6), and instructions for setting up standard tests (e.g. regression, restart) are in [README_test](https://github.com/CICE-Consortium/CICE/blob/master/README_v6).  
-
- [check this]   The wiki pages for each repository contain links to additional information, e.g.    
-- complete documentation 
-- larger files such as the gx1 grid, land mask, and forcing files
-- testing data
-- test results 
-
-The ["About-Us" repository](https://github.com/CICE-Consortium/About-Us) includes background and supporting information about the CICE Consortium, including how to interact with it.    


### PR DESCRIPTION
Reverts CICE-Consortium/CICE#10
Because the link to Icepack became c0582fb with this merge, which is a prior version to what it was before the merge, c1996be.