### PR TITLE
correcting openmp flag

### DIFF
--- a/configuration/scripts/machines/Macros.wolf
+++ b/configuration/scripts/machines/Macros.wolf
@@ -50,9 +50,9 @@ SCC:= icc
 SFC:= ifort 
 
 ifeq ($(CICE_THREADED), true) 
-   LDFLAGS += -qopenmp
-   CFLAGS += -qopenmp
-   FFLAGS += -qopenmp
+   LDFLAGS += -openmp
+   CFLAGS += -openmp
+   FFLAGS += -openmp
 endif
 
 ### if using parallel I/O, load all 3 libraries.  PIO must be first!


### PR DESCRIPTION
This fixes the test suite problems on wolf, some of which were failing.  Now they all pass.