### PR TITLE
Ctest submit failure

### DIFF
--- a/configuration/scripts/run.suite
+++ b/configuration/scripts/run.suite
@@ -123,16 +123,5 @@ else
   ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg ${baseGen} -report
 endif
 
-# Poll the queue manager to see when all jobs are completed
-./configuration/scripts/tests/cice.poll_queue
-
-cd base_suite.${testid}
-
-./results.csh
-
-./run_ctest.csh
-
-cd ..
-
 echo "---"
 echo "CICE run.suite completed"

--- a/configuration/scripts/run.suite
+++ b/configuration/scripts/run.suite
@@ -123,59 +123,8 @@ else
   ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg ${baseGen} -report >& log.suite
 endif
 
-# Parse the job IDs from log.suite.  This should work for PBS, Slurm, or IBM LFS but needs
-# to be thoroughly tested (so far only tested on PBS)
-set job_id = 0
-foreach line ( "`cat log.suite`" )
-  if ( $job_id == 1 ) then
-    set job_id = 0
-    if ( "$line" != " " ) then
-      # Grep the job number
-      echo "$line" | grep -E -o "([[:digit:]]{2,})" >> log.jobs
-    endif
-  else
-    if ( "$line" =~ *'COMPILE SUCCESSFUL'* ) then
-      set job_id = 1
-    endif
-  endif
-end
-
-# Check if this server uses PBS or Slurm
-which qstat >&/dev/null
-if ( $? == 0 ) then
-  # PBS
-  set queue_check = 'qstat'
-else
-  which squeue
-  if ( $? == 0 ) then
-    # Slurm
-    set queue_check = 'squeue --jobs='
-  else
-    which bjobs
-    if ( $? == 0 ) then
-      # IBM LFS
-      set queue_check = 'bjobs -l '
-    else
-      echo "Unable to determine how to check status of jobs.  Once all jobs are "
-      echo "complete, cd to ${PWD} and run ./results.csh followed by ctest -S steer.cmake"
-    endif
-  endif
-endif
-
-# Wait for all jobs to finish
-foreach job ("`cat log.jobs`")
-  while (1)
-    $queue_check $job >&/dev/null
-    if ($? != 0) then
-      echo "Job $job completed"
-      break
-    endif
-    echo "Waiting for $job to complete"
-    sleep 300   # Sleep for 5 minutes, so as not to overwhelm the queue manager
-  end
-end
-
-rm log.jobs  # Delete the list of job IDs
+# Poll the queue manager to see when all jobs are completed
+./configuration/scripts/tests/cice.poll_queue
 
 cd base_suite.${testid}
 

--- a/configuration/scripts/run.suite
+++ b/configuration/scripts/run.suite
@@ -116,11 +116,11 @@ git clone --recursive https://github.com/CICE-Consortium/CICE.git $gitDir
 
 cd $gitDir
 
-echo "Running ./create.case and storing output in log.suite"
+echo "Running ./create.case"
 if ($baseGen == $spval) then
-  ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -report >& log.suite
+  ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -report
 else
-  ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg ${baseGen} -report >& log.suite
+  ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg ${baseGen} -report
 endif
 
 # Poll the queue manager to see when all jobs are completed
@@ -130,7 +130,7 @@ cd base_suite.${testid}
 
 ./results.csh
 
-ctest -S steer.cmake
+./run_ctest.csh
 
 cd ..
 

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/csh
+#!/bin/csh -f
 
 set initargv = ( $argv[*] )
 

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -60,7 +60,7 @@ if ( $submit_only == 0 ) then
         echo "CTest submission failed.  To try the submission again run "
         echo "    ./run_ctest.csh -submit"
         echo "If you wish to submit the test results from another server, copy the "
-        echo "cice_submit.tgz file to another server and run "
+        echo "cice_ctest.tgz file to another server and run "
         echo "    ./run_ctest.csh -submit"
     else
         echo "Submit Succeeded"

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -1,0 +1,71 @@
+#!/usr/bin/csh
+
+set initargv = ( $argv[*] )
+
+set dash = "-"
+set submit_only=0
+
+# Read in command line arguments
+set argv = ( $initargv[*] )
+
+while (1)
+  if ( $#argv < 1 ) break;
+  if ("$argv[1]" == "${dash}submit") then
+    set submit_only=1
+    shift argv
+    continue
+  endif
+end
+
+if ( $submit_only == 0 ) then
+  ctest -S steer.cmake
+else
+  # Find the filename to submit to CDash
+  set CTEST_TAG="`head -n 1 Testing/TAG`"
+  
+cat > submit.cmake << EOF0
+cmake_minimum_required(VERSION 2.8)
+set(CTEST_DASHBOARD_ROOT   "\$ENV{PWD}")
+set(CTEST_SOURCE_DIRECTORY "\$ENV{PWD}")
+set(CTEST_BINARY_DIRECTORY "\$ENV{PWD}")
+message("source directory = \${CTEST_SOURCE_DIRECTORY}")
+
+include( CTestConfig.cmake )
+
+ctest_start("Experimental")
+ctest_submit(FILES "`pwd`/Testing/${CTEST_TAG}/Test.xml")
+EOF0
+  ctest -S submit.cmake
+endif
+
+if ( $submit_only == 0 ) then
+  if ( -f Testing/TAG ) then
+    set file='Testing/TAG'
+    set CTEST_TAG="`head -n 1 $file`"
+
+    # Check to see if ctest_submit was successful
+    set success=0
+    set submit_file="Testing/Temporary/LastSubmit_$CTEST_TAG.log"
+    foreach line ("`cat $submit_file`")
+        if ( "$line" =~ *'Submission successful'* ) then
+            set success=1
+        endif
+    end
+
+    if ( $success == 0 ) then
+        echo ""
+        set xml_file="Testing/$CTEST_TAG/Test.xml"
+        tar czf cice_ctest.tgz run_ctest.csh CTestConfig.cmake Testing/TAG \
+                                      Testing/${CTEST_TAG}/Test.xml
+        echo "CTest submission failed.  To try the submission again run "
+        echo "    ./run_ctest.csh -submit"
+        echo "If you wish to submit the test results from another server, copy the "
+        echo "cice_test_submit.tgz file to another server and run "
+        echo "    ./run_ctest.csh -submit"
+    else
+        echo "Submit Succeeded"
+    endif
+  else
+    echo "No Testing/TAG file exists.  Ensure that ctest is installed on this system."
+  endif
+endif

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -21,7 +21,7 @@ if ( $submit_only == 0 ) then
   ctest -S steer.cmake
 else
   # Find the filename to submit to CDash
-  set CTEST_TAG="`head -n 1 Testing/TAG`"
+  set CTEST_TAG="`head -n 1 Testing/TAG.submit`"
   
 cat > submit.cmake << EOF0
 cmake_minimum_required(VERSION 2.8)
@@ -55,7 +55,8 @@ if ( $submit_only == 0 ) then
     if ( $success == 0 ) then
         echo ""
         set xml_file="Testing/$CTEST_TAG/Test.xml"
-        tar czf cice_ctest.tgz run_ctest.csh CTestConfig.cmake Testing/TAG \
+        cp Testing/TAG Testing/TAG.submit
+        tar czf cice_ctest.tgz run_ctest.csh CTestConfig.cmake Testing/TAG.submit \
                                       Testing/${CTEST_TAG}/Test.xml
         echo "CTest submission failed.  To try the submission again run "
         echo "    ./run_ctest.csh -submit"

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -60,7 +60,7 @@ if ( $submit_only == 0 ) then
         echo "CTest submission failed.  To try the submission again run "
         echo "    ./run_ctest.csh -submit"
         echo "If you wish to submit the test results from another server, copy the "
-        echo "cice_test_submit.tgz file to another server and run "
+        echo "cice_submit.tgz file to another server and run "
         echo "    ./run_ctest.csh -submit"
     else
         echo "Submit Succeeded"

--- a/configuration/scripts/tests/QC/cice.t-test.py
+++ b/configuration/scripts/tests/QC/cice.t-test.py
@@ -47,6 +47,7 @@ def read_data(base_dir,test_dir):
               "   # of files: {}\n".format(len(files_a)) + \
               "Test directory: {}\n".format(path_b) + \
               "   # of files: {}".format(len(files_b)))
+        sys.exit(-1)
       
     num_files = len(files_a)
     logger.info("Number of files: {}".format(num_files))
@@ -171,7 +172,7 @@ def two_stage_test(data_a,data_b,num_files,data_d):
             logger.info('Two-Stage Test Passed')
             passed = True
         else:
-            logger.error('TEST NOT CONCLUSIVE')
+            logger.error('TWO-STAGE TEST NOT CONCLUSIVE')
             passed = False
     
     else:
@@ -261,6 +262,10 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     
     data_a, data_b, data_d, num_files, path_a, fname = read_data(args.base_dir,args.test_dir)
+
+    if np.ma.all(data_d.mask):
+        logger.info("Data is bit-for-bit.  No need to run QC test")
+        sys.exit(0)
 
     # Run the two-stage test
     passed = two_stage_test(data_a,data_b,num_files,data_d)

--- a/configuration/scripts/tests/cice.poll_queue
+++ b/configuration/scripts/tests/cice.poll_queue
@@ -1,0 +1,55 @@
+#!/bin/csh -f
+
+# Parse the job IDs from log.suite.  This should work for PBS, Slurm, or IBM LFS but needs
+# to be thoroughly tested (so far only tested on PBS)
+set job_id = 0
+foreach line ( "`cat log.suite`" )
+  if ( $job_id == 1 ) then
+    set job_id = 0
+    if ( "$line" != " " ) then
+      # Grep the job number
+      echo "$line" | grep -oP "\d+" | sort -n | tail -1 >> log.jobs
+    endif
+  else
+    if ( "$line" =~ *'COMPILE SUCCESSFUL'* ) then
+      set job_id = 1
+    endif
+  endif
+end
+
+# Check if this server uses PBS or Slurm
+which qstat >&/dev/null
+if ( $? == 0 ) then
+  # PBS
+  set queue_check = 'qstat'
+else
+  which squeue
+  if ( $? == 0 ) then
+    # Slurm
+    set queue_check = 'squeue --jobs='
+  else
+    which bjobs
+    if ( $? == 0 ) then
+      # IBM LFS
+      set queue_check = 'bjobs -l '
+    else
+      echo "Unable to determine how to check status of jobs.  Once all jobs are "
+      echo "complete, cd to ${PWD} and run ./results.csh followed by ctest -S steer.cmake"
+    endif
+  endif
+endif
+
+# Wait for all jobs to finish
+foreach job ("`cat log.jobs`")
+  while (1)
+    $queue_check $job >&/dev/null
+    if ($? != 0) then
+      echo "Job $job completed"
+      break
+    endif
+    echo "Waiting for $job to complete"
+    sleep 300   # Sleep for 5 minutes, so as not to overwhelm the queue manager
+  end
+end
+
+rm log.jobs  # Delete the list of job IDs

--- a/configuration/scripts/tests/test_restart.script
+++ b/configuration/scripts/tests/test_restart.script
@@ -13,10 +13,11 @@ echo "RUN  ${ICE_TESTNAME} run" >> ${ICE_CASEDIR}/test_output
 echo "PEND ${ICE_TESTNAME} exact-restart" >> ${ICE_CASEDIR}/test_output
 
 ./cice.run
+set res="$?"
 
 mv -f ${ICE_CASEDIR}/test_output ${ICE_CASEDIR}/test_output.prev
 cat ${ICE_CASEDIR}/test_output.prev | grep -iv "${ICE_TESTNAME} run" >! ${ICE_CASEDIR}/test_output
-if ( $? != 0 ) then
+if ( $res != 0 ) then
   echo "FAIL ${ICE_TESTNAME} run-initial" >> ${ICE_CASEDIR}/test_output
   exit 99
 else

--- a/configuration/scripts/tests/test_smoke.script
+++ b/configuration/scripts/tests/test_smoke.script
@@ -8,10 +8,11 @@ cat ${ICE_CASEDIR}/test_output.prev | grep -iv "${ICE_TESTNAME} run" >! ${ICE_CA
 echo "RUN  ${ICE_TESTNAME} run" >> ${ICE_CASEDIR}/test_output
 
 ./cice.run
+set res="$?"
 
 mv -f ${ICE_CASEDIR}/test_output ${ICE_CASEDIR}/test_output.prev
 cat ${ICE_CASEDIR}/test_output.prev | grep -iv "${ICE_TESTNAME} run" >! ${ICE_CASEDIR}/test_output
-if ( $? != 0 ) then
+if ( $res != 0 ) then
   # Run failed
   echo "FAIL ${ICE_TESTNAME} run" >> ${ICE_CASEDIR}/test_output
   exit 99

--- a/create.case
+++ b/create.case
@@ -230,6 +230,7 @@ if ( $testsuite != $spval ) then
     cp -f ${ICE_SCRIPTS}/tests/CTest/CTestConfig.cmake ./${tsdir}
     cp -f ${ICE_SCRIPTS}/tests/CTest/CTestTestfile.cmake ./${tsdir}
     cp -f ${ICE_SCRIPTS}/tests/CTest/steer.cmake ./${tsdir}
+    cp -f ${ICE_SCRIPTS}/tests/CTest/run_ctest.csh ./${tsdir}
   endif
 
 cat >! ./${tsdir}/suite.run << EOF0

--- a/create.case
+++ b/create.case
@@ -571,6 +571,9 @@ EOF
   if ($report == 1) then
     echo "Running the suite and storing output in log.suite"
     ./suite.run >& ../log.suite
+    ../configuration/scripts/tests/cice.poll_queue
+    ./results.csh
+    ./run_ctest.csh
   else
     ./suite.run
   endif

--- a/create.case
+++ b/create.case
@@ -570,7 +570,7 @@ EOF
   cd ${tsdir}
   if ($report == 1) then
     echo "Running the suite and storing output in log.suite"
-    ./suite.run >& ../log.suite
+    ./suite.run >& log.suite
     ../configuration/scripts/tests/cice.poll_queue
     ./results.csh
     ./run_ctest.csh

--- a/create.case
+++ b/create.case
@@ -566,10 +566,15 @@ echo "\$failures of \$total tests FAILED"
 echo "\$pends of \$total tests PENDING"
 EOF
 
-# build and submit tests
-cd ${tsdir}
-./suite.run
-cd ${ICE_SANDBOX}
+  # build and submit tests
+  cd ${tsdir}
+  if ($report == 1) then
+    echo "Running the suite and storing output in log.suite"
+    ./suite.run >& ../log.suite
+  else
+    ./suite.run
+  endif
+  cd ${ICE_SANDBOX}
 
 endif
 

--- a/doc/source/cice_3_user_guide.rst
+++ b/doc/source/cice_3_user_guide.rst
@@ -2354,8 +2354,8 @@ If the ``run_ctest.csh`` script is unable to post the testing results to the CDa
 server, a message will be printed to the screen detailing instructions on how to attempt
 to post the results from another server.  If ``run_ctest.csh`` fails to submit the results,
 it will generate a tarball ``cice_ctest.tgz`` that contains the necessary files for 
-submission.  Copy this file to another server, extract the archive, and run
-``./run_ctest.csh -submit``.
+submission.  Copy this file to another server (CMake version 2.8+ required), extract the 
+archive, and run ``./run_ctest.csh -submit``.
 
 
 .. _tabnamelist:

--- a/doc/source/cice_3_user_guide.rst
+++ b/doc/source/cice_3_user_guide.rst
@@ -2331,7 +2331,7 @@ The run.suite script does the following:
 - ``run.suite`` monitors the queue manager to determine when all jobs have 
   finished (pings the queue manager once every 5 minutes).
 - Once all jobs complete, cd to base_suite directory and run ``./results.csh``
-- Run ``ctest -S steer.cmake`` in order to post the test results to the CDash dashboard
+- Run ``./run_ctest.csh`` in order to post the test results to the CDash dashboard
 
 *****************
 Manual Method
@@ -2347,7 +2347,16 @@ users essentially just need to perform all steps available in run.suite, detaile
   queue manager.  
 - After every job has been submitted and completed, ``cd`` to the suite directory.
 - Parse the results, by running ``./results.csh``.
-- Run the CTest / CDash script ``ctest -S steer.cmake``.
+- Run the CTest / CDash script ``./run_ctest.csh``.
+
+
+If the ``run_ctest.csh`` script is unable to post the testing results to the CDash
+server, a message will be printed to the screen detailing instructions on how to attempt
+to post the results from another server.  If ``run_ctest.csh`` fails to submit the results,
+it will generate a tarball ``cice_ctest.tgz`` that contains the necessary files for 
+submission.  Copy this file to another server, extract the archive, and run
+``./run_ctest.csh -submit``.
+
 
 .. _tabnamelist:
 


### PR DESCRIPTION
Add a backup method to submit CTest results if the submission fails
Developer(s):  Matt Turner
Updated documentation (Y/N): Y
Results (bit for bit, roundoff, climate changing): N/A
Code review: 
Other Relevant Details:

