### PR TITLE
Fastice

### DIFF
--- a/cicecore/cicedynB/analysis/ice_history.F90
+++ b/cicecore/cicedynB/analysis/ice_history.F90
@@ -67,7 +67,7 @@
       use ice_exit, only: abort_ice
       use ice_fileunits, only: nu_nml, nml_filename, nu_diag, &
           get_fileunit, release_fileunit
-      use ice_flux, only: mlt_onset, frz_onset, albcnt
+      use ice_flux, only: mlt_onset, frz_onset, albcnt, taubx, tauby
       use ice_history_shared ! everything
       use ice_history_mechred, only: init_hist_mechred_2D, init_hist_mechred_3Dc
       use ice_history_pond, only: init_hist_pond_2D, init_hist_pond_3Dc
@@ -279,6 +279,8 @@
       call broadcast_scalar (f_strocny, master_task)
       call broadcast_scalar (f_strintx, master_task)
       call broadcast_scalar (f_strinty, master_task)
+      call broadcast_scalar (f_taubx, master_task)
+      call broadcast_scalar (f_tauby, master_task)
       call broadcast_scalar (f_strength, master_task)
       call broadcast_scalar (f_divu, master_task)
       call broadcast_scalar (f_shear, master_task)
@@ -725,6 +727,16 @@
              "internal ice stress (y)",                                  &
              "positive is y direction on U grid", c1, c0,                &
              ns1, f_strinty)
+
+         call define_hist_field(n_taubx,"taubx","N/m^2",ustr2D, ucstr,   &
+             "basal (seabed) stress (x)",                                &
+             "positive is x direction on U grid", c1, c0,                &
+             ns1, f_taubx)
+
+         call define_hist_field(n_tauby,"tauby","N/m^2",ustr2D, ucstr,   &
+             "basal (seabed) stress (y)",                                &
+             "positive is y direction on U grid", c1, c0,                &
+             ns1, f_tauby)
       
          call define_hist_field(n_strength,"strength","N/m",tstr2D, tcstr, &
              "compressive ice strength",                                 &
@@ -1175,7 +1187,7 @@
           melts, meltb, meltt, meltl, fresh, fsalt, fresh_ai, fsalt_ai, &
           fhocn, fhocn_ai, uatm, vatm, fbot, &
           fswthru_ai, strairx, strairy, strtltx, strtlty, strintx, strinty, &
-          strocnx, strocny, fm, daidtt, dvidtt, daidtd, dvidtd, fsurf, &
+          taubx, tauby, strocnx, strocny, fm, daidtt, dvidtt, daidtd, dvidtd, fsurf, &
           fcondtop, fsurfn, fcondtopn, flatn, fsensn, albcnt, prs_sig, &
           stressp_1, stressm_1, stress12_1, &
           stressp_2, stressm_2, stress12_2, &
@@ -1481,6 +1493,10 @@
              call accum_hist_field(n_strintx, iblk, strintx(:,:,iblk), a2D)
          if (f_strinty(1:1) /= 'x') &
              call accum_hist_field(n_strinty, iblk, strinty(:,:,iblk), a2D)
+         if (f_taubx(1:1) /= 'x') &
+             call accum_hist_field(n_taubx, iblk, taubx(:,:,iblk), a2D)
+         if (f_tauby(1:1) /= 'x') &
+             call accum_hist_field(n_tauby, iblk, tauby(:,:,iblk), a2D)
          if (f_strength(1:1)/= 'x') &
              call accum_hist_field(n_strength,iblk, strength(:,:,iblk), a2D)
 

--- a/cicecore/cicedynB/analysis/ice_history_shared.F90
+++ b/cicecore/cicedynB/analysis/ice_history_shared.F90
@@ -222,6 +222,7 @@
            f_strcorx   = 'm', f_strcory    = 'm', &
            f_strocnx   = 'm', f_strocny    = 'm', &
            f_strintx   = 'm', f_strinty    = 'm', &
+           f_taubx     = 'm', f_tauby      = 'm', &
            f_strength  = 'm', &
            f_divu      = 'm', f_shear      = 'm', &
            f_sig1      = 'm', f_sig2       = 'm', &
@@ -308,6 +309,7 @@
            f_strcorx,   f_strcory  , &
            f_strocnx,   f_strocny  , &
            f_strintx,   f_strinty  , &
+           f_taubx,     f_tauby    , &
            f_strength,  &
            f_divu,      f_shear    , &
            f_sig1,      f_sig2     , &
@@ -412,6 +414,7 @@
            n_strcorx    , n_strcory    , &
            n_strocnx    , n_strocny    , &
            n_strintx    , n_strinty    , &
+           n_taubx      , n_tauby      , &
            n_strength   , &
            n_divu       , n_shear      , &
            n_sig1       , n_sig2       , &

--- a/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
@@ -89,12 +89,12 @@
           strairx, strairy, uocn, vocn, ss_tltx, ss_tlty, iceumask, fm, &
           strtltx, strtlty, strocnx, strocny, strintx, strinty, &
           strocnxT, strocnyT, strax, stray, &
-          Cbu, hwater, tau_bu, tau_bv, &
+          Cbu, tau_bu, tau_bv, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
       use ice_grid, only: tmask, umask, dxt, dyt, dxhy, dyhx, cxp, cyp, cxm, cym, &
-          tarear, uarear, tinyarea, to_ugrid, t2ugrid_vector, u2tgrid_vector
+          tarear, uarear, tinyarea, to_ugrid, t2ugrid_vector, u2tgrid_vector, hwater
       use ice_state, only: aice, vice, vsno, uvel, vvel, divu, shear, &
           aice_init, aice0, aicen, vicen, strength
 !      use ice_timers, only: timer_dynamics, timer_bound, &

--- a/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
@@ -89,12 +89,12 @@
           strairx, strairy, uocn, vocn, ss_tltx, ss_tlty, iceumask, fm, &
           strtltx, strtlty, strocnx, strocny, strintx, strinty, &
           strocnxT, strocnyT, strax, stray, &
-          Cbu, tau_bu, tau_bv, &
+          Cbu, taubx, tauby, hwater, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
       use ice_grid, only: tmask, umask, dxt, dyt, dxhy, dyhx, cxp, cyp, cxm, cym, &
-          tarear, uarear, tinyarea, to_ugrid, t2ugrid_vector, u2tgrid_vector, hwater
+          tarear, uarear, tinyarea, to_ugrid, t2ugrid_vector, u2tgrid_vector
       use ice_state, only: aice, vice, vsno, uvel, vvel, divu, shear, &
           aice_init, aice0, aicen, vicen, strength
 !      use ice_timers, only: timer_dynamics, timer_bound, &
@@ -477,8 +477,8 @@
       if ( basalstress ) then
          !$OMP PARALLEL DO PRIVATE(iblk)
          do iblk = 1, nblocks
-            tau_bu(:,:,iblk) = Cbu(:,:,iblk)*uvel(:,:,iblk)
-            tau_bv(:,:,iblk) = Cbu(:,:,iblk)*vvel(:,:,iblk)
+            taubx(:,:,iblk) = Cbu(:,:,iblk)*uvel(:,:,iblk)
+            tauby(:,:,iblk) = Cbu(:,:,iblk)*vvel(:,:,iblk)
          enddo
          !$OMP END PARALLEL DO
       endif

--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -77,13 +77,13 @@
           strairx, strairy, uocn, vocn, ss_tltx, ss_tlty, iceumask, fm, &
           strtltx, strtlty, strocnx, strocny, strintx, strinty, &
           strocnxT, strocnyT, strax, stray, &
-          Cbu, hwater, tau_bu, tau_bv, &
+          Cbu, tau_bu, tau_bv, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
       use ice_grid, only: tmask, umask, dxt, dyt, dxhy, dyhx, cxp, cyp, cxm, cym, &
           tarear, uarear, tinyarea, to_ugrid, t2ugrid_vector, u2tgrid_vector, &
-          grid_type
+          grid_type, hwater
       use ice_state, only: aice, vice, vsno, uvel, vvel, divu, shear, &
           aice_init, aice0, aicen, vicen, strength
       use ice_timers, only: timer_dynamics, timer_bound, &

--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -37,7 +37,7 @@
       use ice_kinds_mod
       use ice_dyn_shared, only: stepu, evp_prep1, evp_prep2, evp_finish, &
           ndte, yield_curve, ecci, denom1, arlx1i, fcor_blk, uvel_init,  &
-          vvel_init 
+          vvel_init, Ktens
 
       implicit none
       private
@@ -521,7 +521,7 @@
                          str )
 
       use ice_constants, only: c0, c4, p027, p055, p111, p166, &
-          p2, p222, p25, p333, p5, puny
+          p2, p222, p25, p333, p5, puny, c1
 
       integer (kind=int_kind), intent(in) :: & 
          nx_block, ny_block, & ! block dimensions
@@ -683,24 +683,24 @@
       ! (1) northeast, (2) northwest, (3) southwest, (4) southeast
       !-----------------------------------------------------------------
 
-         stressp_1(i,j) = (stressp_1(i,j) + c1ne*(divune - Deltane)) &
+         stressp_1(i,j) = (stressp_1(i,j) + c1ne*(divune*(c1+Ktens) - Deltane*(c1-Ktens))) &
                           * denom1
-         stressp_2(i,j) = (stressp_2(i,j) + c1nw*(divunw - Deltanw)) &
+         stressp_2(i,j) = (stressp_2(i,j) + c1nw*(divunw*(c1+Ktens) - Deltanw*(c1-Ktens))) &
                           * denom1
-         stressp_3(i,j) = (stressp_3(i,j) + c1sw*(divusw - Deltasw)) &
+         stressp_3(i,j) = (stressp_3(i,j) + c1sw*(divusw*(c1+Ktens) - Deltasw*(c1-Ktens))) &
                           * denom1
-         stressp_4(i,j) = (stressp_4(i,j) + c1se*(divuse - Deltase)) &
+         stressp_4(i,j) = (stressp_4(i,j) + c1se*(divuse*(c1+Ktens) - Deltase*(c1-Ktens))) &
                           * denom1
 
-         stressm_1(i,j) = (stressm_1(i,j) + c0ne*tensionne) * denom1
-         stressm_2(i,j) = (stressm_2(i,j) + c0nw*tensionnw) * denom1
-         stressm_3(i,j) = (stressm_3(i,j) + c0sw*tensionsw) * denom1
-         stressm_4(i,j) = (stressm_4(i,j) + c0se*tensionse) * denom1
-        
-         stress12_1(i,j) = (stress12_1(i,j) + c0ne*shearne*p5) * denom1
-         stress12_2(i,j) = (stress12_2(i,j) + c0nw*shearnw*p5) * denom1
-         stress12_3(i,j) = (stress12_3(i,j) + c0sw*shearsw*p5) * denom1
-         stress12_4(i,j) = (stress12_4(i,j) + c0se*shearse*p5) * denom1
+         stressm_1(i,j) = (stressm_1(i,j) + c0ne*tensionne*(c1+Ktens)) * denom1
+         stressm_2(i,j) = (stressm_2(i,j) + c0nw*tensionnw*(c1+Ktens)) * denom1
+         stressm_3(i,j) = (stressm_3(i,j) + c0sw*tensionsw*(c1+Ktens)) * denom1
+         stressm_4(i,j) = (stressm_4(i,j) + c0se*tensionse*(c1+Ktens)) * denom1
+
+         stress12_1(i,j) = (stress12_1(i,j) + c0ne*shearne*p5*(c1+Ktens)) * denom1
+         stress12_2(i,j) = (stress12_2(i,j) + c0nw*shearnw*p5*(c1+Ktens)) * denom1
+         stress12_3(i,j) = (stress12_3(i,j) + c0sw*shearsw*p5*(c1+Ktens)) * denom1
+         stress12_4(i,j) = (stress12_4(i,j) + c0se*shearse*p5*(c1+Ktens)) * denom1
 
       !-----------------------------------------------------------------
       ! Eliminate underflows.

--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -77,13 +77,13 @@
           strairx, strairy, uocn, vocn, ss_tltx, ss_tlty, iceumask, fm, &
           strtltx, strtlty, strocnx, strocny, strintx, strinty, &
           strocnxT, strocnyT, strax, stray, &
-          Cbu, tau_bu, tau_bv, &
+          Cbu, taubx, tauby, hwater, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
       use ice_grid, only: tmask, umask, dxt, dyt, dxhy, dyhx, cxp, cyp, cxm, cym, &
           tarear, uarear, tinyarea, to_ugrid, t2ugrid_vector, u2tgrid_vector, &
-          grid_type, hwater
+          grid_type
       use ice_state, only: aice, vice, vsno, uvel, vvel, divu, shear, &
           aice_init, aice0, aicen, vicen, strength
       use ice_timers, only: timer_dynamics, timer_bound, &
@@ -412,8 +412,8 @@
       if ( basalstress ) then
          !$OMP PARALLEL DO PRIVATE(iblk)
          do iblk = 1, nblocks
-            tau_bu(:,:,iblk) = Cbu(:,:,iblk)*uvel(:,:,iblk)
-            tau_bv(:,:,iblk) = Cbu(:,:,iblk)*vvel(:,:,iblk)
+            taubx(:,:,iblk) = Cbu(:,:,iblk)*uvel(:,:,iblk)
+            tauby(:,:,iblk) = Cbu(:,:,iblk)*vvel(:,:,iblk)
          enddo
          !$OMP END PARALLEL DO
       endif

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -18,8 +18,7 @@
       implicit none
       private
       public :: init_evp, set_evp_parameters, stepu, principal_stress, &
-                evp_prep1, evp_prep2, evp_finish, basal_stress_coeff, &
-                read_basalstress_bathy
+                evp_prep1, evp_prep2, evp_finish, basal_stress_coeff
       save
 
       ! namelist parameters
@@ -891,73 +890,6 @@
 
       end subroutine basal_stress_coeff
 
-!=======================================================================
-
-! Read bathymetry data for basal stress calculation (grounding scheme for 
-! landfast ice) in CICE stand-alone mode. When CICE is in coupled mode 
-! (e.g. CICE-NEMO), hwater should be uptated at each time level so that 
-! it varies with ocean dynamics.
-!
-! author: Fred Dupont, CMC
-      
-      subroutine read_basalstress_bathy
-
-      ! use module
-      use ice_blocks, only: block, get_block, nx_block, ny_block
-      use ice_domain, only: nblocks, blocks_ice, halo_info, maskhalo_dyn
-      use ice_domain_size, only: max_blocks
-      use ice_flux, only: hwater
-      use ice_read_write
-      use ice_fileunits, only: nu_diag
-      use ice_communicate, only: my_task, master_task
-      use ice_constants, only: field_loc_center, field_type_scalar
-
-
-      ! local variables
-      integer (kind=int_kind) :: &
-         i, j,     &     ! index inside block
-         iblk,     &     ! block index
-         fid_init        ! file id for netCDF init file
-      
-      character (char_len_long) :: &        ! input data file names
-         init_file, &
-         fieldname
-
-      logical (kind=log_kind) :: diag=.true.
-
-      init_file='bathymetry.nc'
-
-      if (my_task == master_task) then
-
-          write (nu_diag,*) ' '
-          write (nu_diag,*) 'Initial ice file: ', trim(init_file)
-          write (*,*) 'Initial ice file: ', trim(init_file)
-          call flush(nu_diag)
-
-      endif
-
-      call ice_open_nc(init_file,fid_init)
-
-      fieldname='Bathymetry'
-
-      if (my_task == master_task) then
-         write(nu_diag,*) 'reading ',TRIM(fieldname)
-         write(*,*) 'reading ',TRIM(fieldname)
-         call flush(nu_diag)
-      endif
-      call ice_read_nc(fid_init,1,fieldname,hwater,diag, &
-                    field_loc=field_loc_center, &
-                    field_type=field_type_scalar)
-
-      call ice_close_nc(fid_init)
-
-      if (my_task == master_task) then
-         write(nu_diag,*) 'closing file ',TRIM(init_file)
-         call flush(nu_diag)
-      endif
-
-      end subroutine read_basalstress_bathy
-      
 !=======================================================================
 
 ! Computes principal stresses for comparison with the theoretical

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -18,7 +18,8 @@
       implicit none
       private
       public :: init_evp, set_evp_parameters, stepu, principal_stress, &
-                evp_prep1, evp_prep2, evp_finish
+                evp_prep1, evp_prep2, evp_finish, basal_stress_coeff, &
+                read_basalstress_bathy
       save
 
       ! namelist parameters
@@ -62,9 +63,12 @@
          uvel_init, & ! x-component of velocity (m/s), beginning of timestep
          vvel_init    ! y-component of velocity (m/s), beginning of timestep
          
-       ! ice isotropic tensile strength parameter
+      ! ice isotropic tensile strength parameter
       real (kind=dbl_kind), public :: &
          Ktens         ! T=Ktens*P (tensile strength: see Konig and Holland, 2010)   
+
+      logical (kind=log_kind), public :: &
+         basalstress   ! if true, basal stress for landfast on
 
 !=======================================================================
 
@@ -378,7 +382,8 @@
                             stress12_1, stress12_2, & 
                             stress12_3, stress12_4, & 
                             uvel_init,  vvel_init,  &
-                            uvel,       vvel)
+                            uvel,       vvel,       &
+                            Cbu)
 
       use ice_constants, only: c0, c1, gravit
 
@@ -425,6 +430,7 @@
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), & 
          intent(out) :: &
+         Cbu,      & ! coefficient for basal stress
          uvel_init,& ! x-component of velocity (m/s), beginning of time step
          vvel_init,& ! y-component of velocity (m/s), beginning of time step
          umassdti, & ! mass of U-cell/dt (kg/m^2 s)
@@ -467,6 +473,7 @@
          forcex   (i,j) = c0
          forcey   (i,j) = c0
          umassdti (i,j) = c0
+         Cbu      (i,j) = c0
 
          if (revp==1) then               ! revised evp
             stressp_1 (i,j) = c0
@@ -605,7 +612,8 @@
                         strocnx,    strocny,  &
                         strintx,    strinty,  &
                         uvel_init,  vvel_init,&
-                        uvel,       vvel)
+                        uvel,       vvel,     &
+                        Cbu)
 
       integer (kind=int_kind), intent(in) :: &
          nx_block, ny_block, & ! block dimensions
@@ -617,6 +625,7 @@
          indxuj      ! compressed index in j-direction
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
+         Cbu,      & ! coefficient for basal stress
          uvel_init,& ! x-component of velocity (m/s), beginning of timestep
          vvel_init,& ! y-component of velocity (m/s), beginning of timestep
          aiu     , & ! ice fraction on u-grid
@@ -680,7 +689,7 @@
          tauy = vrel*watery(i,j) ! ocn stress term
 
          ! revp = 0 for classic evp, 1 for revised evp
-         cca = (brlx + revp)*umassdti(i,j) + vrel * cosw ! kg/m^2 s
+         cca = (brlx + revp)*umassdti(i,j) + vrel * cosw + Cbu(i,j) ! kg/m^2 s
          ccb = fm(i,j) + sign(c1,fm(i,j)) * vrel * sinw ! kg/m^2 s
 
          ab2 = cca**2 + ccb**2
@@ -807,6 +816,148 @@
 
       end subroutine evp_finish
 
+!=======================================================================
+! Computes basal stress Cb coefficients (landfast ice)
+!
+! Lemieux, J. F., B. Tremblay, F. Dupont, M. Plante, G. Smith, D. Dumont (2015). 
+! A basal stress parameterization form modeling landfast ice. J. Geophys. Res. 
+! Oceans, 120, 3157-3173.
+!
+! author: Philippe Blain, CMC (coop summer 2015)
+!
+      subroutine basal_stress_coeff (nx_block, ny_block, icellu, &
+                                     indxui,   indxuj,           &
+                                     vice,     aice,             &
+                                     hwater,                     &
+                                     uold,     vold,             &
+                                     Cbu)
+
+      integer (kind=int_kind), intent(in) :: &
+         nx_block, ny_block, &  ! block dimensions
+         icellu                 ! no. of cells where icetmask = 1
+
+      integer (kind=int_kind), dimension (nx_block*ny_block), &
+         intent(in) :: &
+         indxui   , & ! compressed index in i-direction
+         indxuj       ! compressed index in j-direction
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
+         aice    , & ! concentration of ice at tracer location
+         vice    , & ! volume per unit area of ice at tracer location
+         hwater  , & ! water depth at tracer location
+         uold    , & ! u component of ice speed at previous iteration
+         vold        ! v component of ice speed at previous iteration
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(inout) :: &
+         Cbu         ! coefficient for basal stress
+
+!
+!EOP
+
+      real (kind=dbl_kind) :: &
+         au,  & ! concentration of ice at u location
+         hu,  & ! volume per unit area of ice at u location (mean thickness)
+         hwu, & ! water depth at u location
+         hcu, & ! critical thickness at u location
+         k1 = 8.0_dbl_kind , &  ! first free parameter for landfast parametrization 
+         k2 = 15.0_dbl_kind, &  ! second free parameter (Nm^-3) for landfast parametrization 
+         u0 = 5e-5_dbl_kind, &  ! residual velocity (m/s)
+         CC = 20.0_dbl_kind     ! CC=Cb factor in Lemieux et al 2015
+
+      integer (kind=int_kind) :: &
+         i, j, ij
+
+      do ij = 1, icellu
+         i = indxui(ij)
+         j = indxuj(ij)
+
+         ! convert quantities to u-location
+         au  = max(aice(i,j),aice(i+1,j),aice(i,j+1),aice(i+1,j+1))
+         hwu = min(hwater(i,j),hwater(i+1,j),hwater(i,j+1),hwater(i+1,j+1))
+         hu  = max(vice(i,j),vice(i+1,j),vice(i,j+1),vice(i+1,j+1))
+
+         ! calculate basal stress factor
+         ! 1- calculate critical thickness
+         hcu = au * hwu / k1
+
+         ! 2- calculate stress factor
+         if (au > p01 .and. hu > hcu ) then
+   !       endif
+           Cbu(i,j) = ( k2 / (sqrt(uold(i,j)**2 + vold(i,j)**2) + u0) ) &
+                      * (hu - hcu) * exp(-CC * (1 - au))
+         endif
+
+      enddo                     ! ij
+
+      end subroutine basal_stress_coeff
+
+!=======================================================================
+
+! Read bathymetry data for basal stress calculation (grounding scheme for 
+! landfast ice) in CICE stand-alone mode. When CICE is in coupled mode 
+! (e.g. CICE-NEMO), hwater should be uptated at each time level so that 
+! it varies with ocean dynamics.
+!
+! author: Fred Dupont, CMC
+      
+      subroutine read_basalstress_bathy
+
+      ! use module
+      use ice_blocks, only: block, get_block, nx_block, ny_block
+      use ice_domain, only: nblocks, blocks_ice, halo_info, maskhalo_dyn
+      use ice_domain_size, only: max_blocks
+      use ice_flux, only: hwater
+      use ice_read_write
+      use ice_fileunits, only: nu_diag
+      use ice_communicate, only: my_task, master_task
+      use ice_constants, only: field_loc_center, field_type_scalar
+
+
+      ! local variables
+      integer (kind=int_kind) :: &
+         i, j,     &     ! index inside block
+         iblk,     &     ! block index
+         fid_init        ! file id for netCDF init file
+      
+      character (char_len_long) :: &        ! input data file names
+         init_file, &
+         fieldname
+
+      logical (kind=log_kind) :: diag=.true.
+
+      init_file='bathymetry.nc'
+
+      if (my_task == master_task) then
+
+          write (nu_diag,*) ' '
+          write (nu_diag,*) 'Initial ice file: ', trim(init_file)
+          write (*,*) 'Initial ice file: ', trim(init_file)
+          call flush(nu_diag)
+
+      endif
+
+      call ice_open_nc(init_file,fid_init)
+
+      fieldname='Bathymetry'
+
+      if (my_task == master_task) then
+         write(nu_diag,*) 'reading ',TRIM(fieldname)
+         write(*,*) 'reading ',TRIM(fieldname)
+         call flush(nu_diag)
+      endif
+      call ice_read_nc(fid_init,1,fieldname,hwater,diag, &
+                    field_loc=field_loc_center, &
+                    field_type=field_type_scalar)
+
+      call ice_close_nc(fid_init)
+
+      if (my_task == master_task) then
+         write(nu_diag,*) 'closing file ',TRIM(init_file)
+         call flush(nu_diag)
+      endif
+
+      end subroutine read_basalstress_bathy
+      
 !=======================================================================
 
 ! Computes principal stresses for comparison with the theoretical

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -45,6 +45,7 @@
 
       real (kind=dbl_kind), public :: &
          revp     , & ! 0 for classic EVP, 1 for revised EVP
+         e_ratio  , & ! e = EVP ellipse aspect ratio 
          ecci     , & ! 1/e^2
          dtei     , & ! 1/dte, where dte is subcycling timestep (1/s)
          dte2T    , & ! dte/2T
@@ -60,6 +61,10 @@
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: & 
          uvel_init, & ! x-component of velocity (m/s), beginning of timestep
          vvel_init    ! y-component of velocity (m/s), beginning of timestep
+         
+       ! ice isotropic tensile strength parameter
+      real (kind=dbl_kind), public :: &
+         Ktens         ! T=Ktens*P (tensile strength: see Konig and Holland, 2010)   
 
 !=======================================================================
 
@@ -184,8 +189,8 @@
       dtei = c1/dte              ! 1/s
 
       ! major/minor axis length ratio, squared
-      ecc  = c4
-      ecci = p25                  ! 1/ecc
+      ecc  = e_ratio**2
+      ecci = c1/ecc               ! 1/ecc
 
       ! constants for stress equation
       tdamp2 = c2*eyc*dt                    ! s

--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -41,6 +41,7 @@
          vocn    , & ! ocean current, y-direction (m/s)
          ss_tltx , & ! sea surface slope, x-direction (m/m)
          ss_tlty , & ! sea surface slope, y-direction
+         hwater  , & ! water depth for basal stress calc (landfast ice) 
 
        ! out to atmosphere
          strairxT, & ! stress on ice by air, x-direction
@@ -56,8 +57,8 @@
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
          sig1    , & ! principal stress component
          sig2    , & ! principal stress component
-         tau_bu  , & ! basal stress (x) (N/m^2)
-         tau_bv  , & ! basal stress (y) (N/m^2)
+         taubx   , & ! basal stress (x) (N/m^2)
+         tauby   , & ! basal stress (y) (N/m^2)
          strairx , & ! stress on ice by air, x-direction
          strairy , & ! stress on ice by air, y-direction
          strocnx , & ! ice-ocean stress, x-direction
@@ -331,6 +332,7 @@
       use ice_flux_bgc, only: flux_bio_atm, flux_bio, faero_atm, &
            fnit, famm, fsil, fdmsp, fdms, fhum, fdust, falgalN, &
            fdoc, fdon, fdic, ffed, ffep
+      use ice_grid, only: bathymetry
 
       integer (kind=int_kind) :: n
 
@@ -442,7 +444,8 @@
       sst   (:,:,:) = Tf(:,:,:)       ! sea surface temp (C)
 #endif
       qdp   (:,:,:) = c0              ! deep ocean heat flux (W/m^2)
-      hmix  (:,:,:) = c20             ! ocean mixed layer depth
+      hmix  (:,:,:) = c20             ! ocean mixed layer depth (m)
+      hwater(:,:,:) = bathymetry(:,:,:) ! ocean water depth (m)
       daice_da(:,:,:) = c0            ! data assimilation increment rate
 
       !-----------------------------------------------------------------
@@ -656,8 +659,8 @@
 
       sig1    (:,:,:) = c0
       sig2    (:,:,:) = c0
-      tau_bu  (:,:,:) = c0
-      tau_bv  (:,:,:) = c0
+      taubx   (:,:,:) = c0
+      tauby   (:,:,:) = c0
       strocnx (:,:,:) = c0
       strocny (:,:,:) = c0
       strairx (:,:,:) = c0

--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -41,6 +41,7 @@
          vocn    , & ! ocean current, y-direction (m/s)
          ss_tltx , & ! sea surface slope, x-direction (m/m)
          ss_tlty , & ! sea surface slope, y-direction
+         hwater  , & ! water depth for basal stress calc (landfast ice) 
 
        ! out to atmosphere
          strairxT, & ! stress on ice by air, x-direction
@@ -56,6 +57,8 @@
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
          sig1    , & ! principal stress component
          sig2    , & ! principal stress component
+         tau_bu  , & ! basal stress (x) (N/m^2)
+         tau_bv  , & ! basal stress (y) (N/m^2)
          strairx , & ! stress on ice by air, x-direction
          strairy , & ! stress on ice by air, y-direction
          strocnx , & ! ice-ocean stress, x-direction
@@ -103,7 +106,8 @@
 
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
          prs_sig  , & ! replacement pressure, for stress calc
-         fm           ! Coriolis param. * mass in U-cell (kg/s)
+         fm       , & ! Coriolis param. * mass in U-cell (kg/s)
+         Cbu          ! coefficient for basal stress (landfast ice)
 
       !-----------------------------------------------------------------
       ! Thermodynamic component
@@ -426,6 +430,7 @@
       vocn  (:,:,:) = c0
       frzmlt(:,:,:) = c0              ! freezing/melting potential (W/m^2)
       sss   (:,:,:) = 34.0_dbl_kind   ! sea surface salinity (ppt)
+      hwater(:,:,:) = 10000.0_dbl_kind! water depth for basal stress calc (landfast ice)
 
       do iblk = 1, size(Tf,3)
       do j = 1, size(Tf,2)
@@ -653,6 +658,8 @@
 
       sig1    (:,:,:) = c0
       sig2    (:,:,:) = c0
+      tau_bu  (:,:,:) = c0
+      tau_bv  (:,:,:) = c0
       strocnx (:,:,:) = c0
       strocny (:,:,:) = c0
       strairx (:,:,:) = c0

--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -41,7 +41,6 @@
          vocn    , & ! ocean current, y-direction (m/s)
          ss_tltx , & ! sea surface slope, x-direction (m/m)
          ss_tlty , & ! sea surface slope, y-direction
-         hwater  , & ! water depth for basal stress calc (landfast ice) 
 
        ! out to atmosphere
          strairxT, & ! stress on ice by air, x-direction
@@ -430,7 +429,6 @@
       vocn  (:,:,:) = c0
       frzmlt(:,:,:) = c0              ! freezing/melting potential (W/m^2)
       sss   (:,:,:) = 34.0_dbl_kind   ! sea surface salinity (ppt)
-      hwater(:,:,:) = 10000.0_dbl_kind! water depth for basal stress calc (landfast ice)
 
       do iblk = 1, size(Tf,3)
       do j = 1, size(Tf,2)

--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -75,7 +75,7 @@
           oceanmixed_file, restore_sst,   trestore
       use ice_grid, only: grid_file, gridcpl_file, kmt_file, grid_type, grid_format
       use ice_dyn_shared, only: ndte, kdyn, revised_evp, yield_curve, &
-                                Ktens, e_ratio
+                                basalstress, Ktens, e_ratio
       use ice_transport_driver, only: advection
       use icepack_intfc_tracers, only: tr_iage, tr_FY, tr_lvl, tr_pond, &
                              tr_pond_cesm, tr_pond_lvl, tr_pond_topo, &
@@ -134,7 +134,7 @@
         kdyn,           ndte,           revised_evp,    yield_curve,    &
         advection,                                                      &
         kstrength,      krdg_partic,    krdg_redist,    mu_rdg,         &
-        e_ratio,        Ktens,          Cf
+        e_ratio,        Ktens,          Cf,             basalstress
 
       namelist /shortwave_nml/ &
         shortwave,      albedo_type,                                    &
@@ -228,6 +228,7 @@
       krdg_redist = 1        ! 1 = new redistribution, 0 = Hibler 80
       mu_rdg = 3             ! e-folding scale of ridged ice, krdg_partic=1 (m^0.5)
       Cf = 17.0_dbl_kind     ! ratio of ridging work to PE change in ridging 
+      basalstress= .false.   ! if true, basal stress for landfast is on
       Ktens = 0.0_dbl_kind   ! T=Ktens*P (tensile strength: see Konig and Holland, 2010)
       e_ratio = 2.0_dbl_kind ! EVP ellipse aspect ratio
       advection  = 'remap'   ! incremental remapping transport scheme
@@ -688,6 +689,7 @@
       call broadcast_scalar(krdg_redist,        master_task)
       call broadcast_scalar(mu_rdg,             master_task)
       call broadcast_scalar(Cf,                 master_task)
+      call broadcast_scalar(basalstress,        master_task)
       call broadcast_scalar(Ktens,              master_task)
       call broadcast_scalar(e_ratio,            master_task)
       call broadcast_scalar(advection,          master_task)
@@ -862,6 +864,7 @@
          write(nu_diag,1000) ' mu_rdg                    = ', mu_rdg
          if (kstrength == 1) &
          write(nu_diag,1000) ' Cf                        = ', Cf
+         write(nu_diag,1010) ' basalstress               = ', basalstress
          write(nu_diag,1005) ' Ktens                     = ', Ktens
          write(nu_diag,1005) ' e_ratio                   = ', e_ratio    
          write(nu_diag,1030) ' advection                 = ', &

--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -74,7 +74,8 @@
           sss_data_type,   sst_data_type, ocn_data_dir, &
           oceanmixed_file, restore_sst,   trestore
       use ice_grid, only: grid_file, gridcpl_file, kmt_file, grid_type, grid_format
-      use ice_dyn_shared, only: ndte, kdyn, revised_evp, yield_curve
+      use ice_dyn_shared, only: ndte, kdyn, revised_evp, yield_curve, &
+                                Ktens, e_ratio
       use ice_transport_driver, only: advection
       use icepack_intfc_tracers, only: tr_iage, tr_FY, tr_lvl, tr_pond, &
                              tr_pond_cesm, tr_pond_lvl, tr_pond_topo, &
@@ -133,7 +134,7 @@
         kdyn,           ndte,           revised_evp,    yield_curve,    &
         advection,                                                      &
         kstrength,      krdg_partic,    krdg_redist,    mu_rdg,         &
-        Cf
+        e_ratio,        Ktens,          Cf
 
       namelist /shortwave_nml/ &
         shortwave,      albedo_type,                                    &
@@ -227,6 +228,8 @@
       krdg_redist = 1        ! 1 = new redistribution, 0 = Hibler 80
       mu_rdg = 3             ! e-folding scale of ridged ice, krdg_partic=1 (m^0.5)
       Cf = 17.0_dbl_kind     ! ratio of ridging work to PE change in ridging 
+      Ktens = 0.0_dbl_kind   ! T=Ktens*P (tensile strength: see Konig and Holland, 2010)
+      e_ratio = 2.0_dbl_kind ! EVP ellipse aspect ratio
       advection  = 'remap'   ! incremental remapping transport scheme
       shortwave = 'default'  ! 'default' or 'dEdd' (delta-Eddington)
       albedo_type = 'default'! or 'constant'
@@ -685,6 +688,8 @@
       call broadcast_scalar(krdg_redist,        master_task)
       call broadcast_scalar(mu_rdg,             master_task)
       call broadcast_scalar(Cf,                 master_task)
+      call broadcast_scalar(Ktens,              master_task)
+      call broadcast_scalar(e_ratio,            master_task)
       call broadcast_scalar(advection,          master_task)
       call broadcast_scalar(shortwave,          master_task)
       call broadcast_scalar(albedo_type,        master_task)
@@ -857,6 +862,8 @@
          write(nu_diag,1000) ' mu_rdg                    = ', mu_rdg
          if (kstrength == 1) &
          write(nu_diag,1000) ' Cf                        = ', Cf
+         write(nu_diag,1005) ' Ktens                     = ', Ktens
+         write(nu_diag,1005) ' e_ratio                   = ', e_ratio    
          write(nu_diag,1030) ' advection                 = ', &
                                trim(advection)
          write(nu_diag,1030) ' shortwave                 = ', &

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -62,7 +62,6 @@
          TLAT   , & ! latitude of temp pts (radians)
          ANGLE  , & ! for conversions between POP grid and lat/lon
          ANGLET , & ! ANGLE converted to T-cells
-         hwater , & ! water depth for basal stress calc (landfast ice) 
          bathymetry      , & ! ocean depth, for grounding keels and bergs (m)
          ocn_gridcell_frac   ! only relevant for lat-lon grids
                              ! gridcell value of [1 - (land fraction)] (T-cell)
@@ -2162,8 +2161,6 @@
          enddo
       enddo
 
-      hwater = bathymetry
-
       end subroutine get_bathymetry
 
 !=======================================================================
@@ -2218,7 +2215,7 @@
          write(*,*) 'reading ',TRIM(fieldname)
          call flush(nu_diag)
       endif
-      call ice_read_nc(fid_init,1,fieldname,hwater,diag, &
+      call ice_read_nc(fid_init,1,fieldname,bathymetry,diag, &
                     field_loc=field_loc_center, &
                     field_type=field_type_scalar)
 

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -62,6 +62,7 @@
          TLAT   , & ! latitude of temp pts (radians)
          ANGLE  , & ! for conversions between POP grid and lat/lon
          ANGLET , & ! ANGLE converted to T-cells
+         hwater , & ! water depth for basal stress calc (landfast ice) 
          bathymetry      , & ! ocean depth, for grounding keels and bergs (m)
          ocn_gridcell_frac   ! only relevant for lat-lon grids
                              ! gridcell value of [1 - (land fraction)] (T-cell)
@@ -2119,7 +2120,6 @@
       subroutine get_bathymetry
 
       use ice_constants, only: puny
-      use ice_flux, only: hwater     ! or replace hwater with bathymetry
 
       integer (kind=int_kind) :: &
          i, j, k, iblk      ! loop indices
@@ -2181,7 +2181,6 @@
       use ice_blocks, only: block, get_block, nx_block, ny_block
       use ice_domain, only: nblocks, blocks_ice, halo_info, maskhalo_dyn
       use ice_domain_size, only: max_blocks
-      use ice_flux, only: hwater
       use ice_read_write
       use ice_fileunits, only: nu_diag
       use ice_communicate, only: my_task, master_task

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -283,12 +283,6 @@
       endif
 
       !-----------------------------------------------------------------
-      ! bathymetry
-      !-----------------------------------------------------------------
-
-      call get_bathymetry
-
-      !-----------------------------------------------------------------
       ! T-grid cell and U-grid cell quantities
       !-----------------------------------------------------------------
 
@@ -450,6 +444,12 @@
       call makemask          ! velocity mask, hemisphere masks
 
       call Tlatlon           ! get lat, lon on the T grid
+
+      !-----------------------------------------------------------------
+      ! bathymetry
+      !-----------------------------------------------------------------
+
+      call get_bathymetry
 
       !----------------------------------------------------------------
       ! Corner coordinates for CF compliant history files
@@ -1432,6 +1432,8 @@
          this_block           ! block information for current block
 
       call ice_timer_start(timer_bound)
+      call ice_HaloUpdate (kmt,               halo_info, &
+                           field_loc_center, field_type_scalar)
       call ice_HaloUpdate (hm,               halo_info, &
                            field_loc_center, field_type_scalar)
       call ice_timer_stop(timer_bound)
@@ -2148,7 +2150,7 @@
       ! convert to total depth
       depth(1) = thick(1)
       do k = 2, nlevel
-         depth(k) = depth(k) + depth(k-1)
+         depth(k) = depth(k-1) + thick(k)
       enddo
 
       do iblk = 1, nblocks

--- a/cicecore/drivers/cice/CICE_InitMod.F90
+++ b/cicecore/drivers/cice/CICE_InitMod.F90
@@ -63,7 +63,6 @@
       use ice_domain_size, only: ncat
       use ice_dyn_eap, only: init_eap
       use ice_dyn_shared, only: kdyn, init_evp, basalstress
-!          read_basalstress_bathy
       use ice_fileunits, only: init_fileunits, nu_diag
       use ice_flux, only: init_coupler_flux, init_history_therm, &
           init_history_dyn, init_flux_atm, init_flux_ocn
@@ -128,8 +127,6 @@
       call calendar(time)       ! determine the initial date
 
       call init_forcing_ocn(dt) ! initialize sss and sst from data
-!      if (basalstress) &
-!      call read_basalstress_bathy ! read bathy for basalstress calc (standalone mode)
       call init_state           ! initialize the ice state
       call init_transport       ! initialize horizontal transport
       call ice_HaloRestore_init ! restored boundary conditions

--- a/cicecore/drivers/cice/CICE_InitMod.F90
+++ b/cicecore/drivers/cice/CICE_InitMod.F90
@@ -62,7 +62,8 @@
       use ice_domain, only: init_domain_blocks
       use ice_domain_size, only: ncat
       use ice_dyn_eap, only: init_eap
-      use ice_dyn_shared, only: kdyn, init_evp
+      use ice_dyn_shared, only: kdyn, init_evp, basalstress
+!          read_basalstress_bathy
       use ice_fileunits, only: init_fileunits, nu_diag
       use ice_flux, only: init_coupler_flux, init_history_therm, &
           init_history_dyn, init_flux_atm, init_flux_ocn
@@ -127,6 +128,8 @@
       call calendar(time)       ! determine the initial date
 
       call init_forcing_ocn(dt) ! initialize sss and sst from data
+!      if (basalstress) &
+!      call read_basalstress_bathy ! read bathy for basalstress calc (standalone mode)
       call init_state           ! initialize the ice state
       call init_transport       ! initialize horizontal transport
       call ice_HaloRestore_init ! restored boundary conditions

--- a/cicecore/drivers/hadgem3/CICE_InitMod.F90
+++ b/cicecore/drivers/hadgem3/CICE_InitMod.F90
@@ -62,7 +62,6 @@
       use ice_domain_size, only: ncat
       use ice_dyn_eap, only: init_eap
       use ice_dyn_shared, only: kdyn, init_evp, basalstress
-!          read_basalstress_bathy
       use ice_fileunits, only: init_fileunits, nu_diag
       use ice_flux, only: init_coupler_flux, init_history_therm, &
           init_history_dyn, init_flux_atm, init_flux_ocn
@@ -118,8 +117,6 @@
 
 #ifndef CICE_IN_NEMO
       call init_forcing_ocn(dt) ! initialize sss and sst from data
-!      if (basalstress) &
-!      call read_basalstress_bathy ! read bathy for basalstress calculation (standalone mode).
 #endif
       call init_state           ! initialize the ice state
       call init_transport       ! initialize horizontal transport

--- a/cicecore/drivers/hadgem3/CICE_InitMod.F90
+++ b/cicecore/drivers/hadgem3/CICE_InitMod.F90
@@ -61,7 +61,8 @@
       use ice_domain, only: init_domain_blocks
       use ice_domain_size, only: ncat
       use ice_dyn_eap, only: init_eap
-      use ice_dyn_shared, only: kdyn, init_evp
+      use ice_dyn_shared, only: kdyn, init_evp, basalstress
+!          read_basalstress_bathy
       use ice_fileunits, only: init_fileunits, nu_diag
       use ice_flux, only: init_coupler_flux, init_history_therm, &
           init_history_dyn, init_flux_atm, init_flux_ocn
@@ -83,7 +84,7 @@
 #ifdef popcice
       use drv_forcing, only: sst_sss
 #endif
-
+      
       call init_communicate     ! initial setup for message passing
       call init_fileunits       ! unit numbers
       call input_data           ! namelist variables
@@ -117,6 +118,8 @@
 
 #ifndef CICE_IN_NEMO
       call init_forcing_ocn(dt) ! initialize sss and sst from data
+!      if (basalstress) &
+!      call read_basalstress_bathy ! read bathy for basalstress calculation (standalone mode).
 #endif
       call init_state           ! initialize the ice state
       call init_transport       ! initialize horizontal transport

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -143,6 +143,19 @@ cat >> ${jobfile} << EOFB
 #SBATCH --qos=standby
 EOFB
 
+else if (${ICE_MACHINE} =~ fram*) then
+cat >> ${jobfile} << EOFB
+#SBATCH -J ${ICE_CASENAME}
+#SBATCH -t ${ICE_RUNLENGTH}
+#SBATCH -A ${acct}
+#SBATCH -N ${nnodes}
+#SBATCH -e slurm%j.err
+#SBATCH -o slurm%j.out
+###SBATCH --mail-type END,FAIL
+###SBATCH --mail-user=armnjfl@ec.gc.ca
+#SBATCH --qos=standby
+EOFB
+
 else if (${ICE_MACHINE} =~ testmachine*) then
 cat >> ${jobfile} << EOFB
 # nothing to do

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -130,6 +130,19 @@ cat >> ${jobfile} << EOFB
 #SBATCH --qos=standard
 EOFB
 
+else if (${ICE_MACHINE} =~ fram*) then
+cat >> ${jobfile} << EOFB
+#SBATCH -J ${ICE_CASENAME}
+#SBATCH -t ${ICE_RUNLENGTH}
+#SBATCH -A ${acct}
+#SBATCH -N ${nnodes}
+#SBATCH -e slurm%j.err
+#SBATCH -o slurm%j.out
+###SBATCH --mail-type END,FAIL
+###SBATCH --mail-user=armnjfl@ec.gc.ca
+#SBATCH --qos=standby
+EOFB
+
 else if (${ICE_MACHINE} =~ testmachine*) then
 cat >> ${jobfile} << EOFB
 # nothing to do

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -53,6 +53,11 @@ cat >> ${jobfile} << EOFR
 mpirun -np ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
 
+else if (${ICE_MACHINE} =~ fram*) then
+cat >> ${jobfile} << EOFR
+mpirun -np ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+
 else if (${ICE_MACHINE} =~ testmachine*) then
 cat >> ${jobfile} << EOFR
 ./cice >&! \$ICE_RUNLOG_FILE

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -100,6 +100,8 @@
     krdg_redist     = 1
     mu_rdg          = 3
     Cf              = 17.
+    Ktens           = 0.
+    e_ratio         = 2.
 /
 
 &shortwave_nml

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -413,6 +413,8 @@
     f_strocny      = 'x' 
     f_strintx      = 'x' 
     f_strinty      = 'x'
+    f_taubx        = 'x'
+    f_tauby        = 'x'
     f_strength     = 'm'
     f_divu         = 'm'
     f_shear        = 'm'

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -102,6 +102,7 @@
     Cf              = 17.
     Ktens           = 0.
     e_ratio         = 2.
+    basalstress     = .false.
 /
 
 &shortwave_nml

--- a/configuration/scripts/machines/Macros.fram
+++ b/configuration/scripts/machines/Macros.fram
@@ -1,0 +1,70 @@
+#==============================================================================
+# Makefile macros for "fram"
+#==============================================================================
+# For use with intel compiler
+#==============================================================================
+
+CPP        := fpp
+CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${CICE_CPPDEFS}
+CFLAGS     := -c -O2 -fp-model precise
+#-xHost
+
+FIXEDFLAGS := -132
+FREEFLAGS  := -FR
+FFLAGS     := -O2 -fp-model precise -convert big_endian -assume byterecl -ftz -traceback
+#-xHost
+FFLAGS_NOOPT:= -O0
+
+ifeq ($(CICE_COMMDIR), mpi)
+  FC         := s.f90 -mpi
+else
+  FC         := s.f90
+endif
+
+MPICC:= s.cc -mpi
+
+MPIFC:= s.f90 -mpi
+LD:= $(MPIFC)
+
+NETCDF_PATH := $(NETCDF)
+
+PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
+
+#PNETCDF_PATH := $(PNETCDF)
+#PNETCDF_PATH := /glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/lib
+
+INCLDIR := $(INCLDIR)
+
+LIB_NETCDF := $(NETCDF_PATH)/lib
+LIB_PNETCDF := $(PNETCDF_PATH)/lib
+LIB_MPI := $(IMPILIBDIR)
+
+#SLIBS   := -L$(LIB_NETCDF) -lnetcdff -lnetcdf -L$(LIB_PNETCDF) -lpnetcdf -lgptl
+SLIBS   := -L$(LIB_NETCDF) -lnetcdff -lnetcdf
+
+SCC:= s.cc
+
+SFC:= s.f90
+
+ifeq ($(compile_threaded), true) 
+   LDFLAGS += -openmp 
+   CFLAGS += -openmp 
+   FFLAGS += -openmp 
+endif
+
+ifeq ($(DITTO), yes)
+   CPPDEFS :=  $(CPPDEFS) -DREPRODUCIBLE
+endif
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first!
+ifeq ($(IO_TYPE), pio)
+   PIO_PATH:=/glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/lib
+   INCLDIR += -I/glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/include
+   SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpiof
+
+   CPPDEFS :=  $(CPPDEFS) -Dncdf
+endif
+
+ifeq ($(IO_TYPE), netcdf)
+   CPPDEFS :=  $(CPPDEFS) -Dncdf
+endif

--- a/configuration/scripts/machines/env.fram
+++ b/configuration/scripts/machines/env.fram
@@ -1,0 +1,21 @@
+#!/bin/csh -f
+
+#. ssmuse-sh -d /fs/ssm/eccc/mrd/rpn/OCEAN/cncpt-3.1.2
+#source NEMO_compiler.ksh
+
+setenv ICE_MACHINE_ENVNAME fram
+setenv ICE_MACHINE_MAKE make
+setenv ICE_MACHINE_WKDIR /users/dor/armn/jfl/local1/CICE6/tests/CICE_RUNS
+setenv ICE_MACHINE_INPUTDATA /fs/cetus/fs1/cmd/e/afsg/fdu/models/fdm/CICE/code/cice_6.0/CICE/configuration/data/gx3Ncar
+setenv ICE_MACHINE_BASELINE /users/dor/armn/jfl/local1/CICE6/tests/CICE_BASELINE
+setenv ICE_MACHINE_SUBMIT "qsub"
+setenv ICE_MACHINE_TPNODE 36
+setenv ICE_MACHINE_ACCT P0000000
+setenv ICE_MACHINE_BLDTHRDS 1
+
+if (-e ~/.cice_proj) then
+   set account_name = `head -1 ~/.cice_proj`
+   setenv CICE_ACCT ${account_name}
+endif
+
+echo "je suis dans env"

--- a/configuration/scripts/options/set_nml.basal
+++ b/configuration/scripts/options/set_nml.basal
@@ -1,0 +1,3 @@
+Ktens          = 0.
+e_ratio        = 2.
+basalstress    = .true.


### PR DESCRIPTION
Fast-ice parameterization (merged from JF's fork)
Developer(s):  Jean-Francois Lemieux, Fred Dupont
Updated documentation (Y/N):  N
Results (bit for bit, roundoff, climate changing):  BFB
Code review:  
Other Relevant Details:
JF's fork had conflicts with the main repository due to changes after his PR, so I merged them into my fork so that I could fix them.  I will close his PRs.  Tested tensile changes separately (in tensile branch), then merged full fastice branch.  Ran base_suite and also a 1-year gx3 test with standard parameter settings.  The usual tests fail.

Modifications from JF’s version:
- changed the namelist flag from l_basalstress to basalstress
- moved read_basal_bathy to ice_grid.F90, for safe-keeping, but it is not called.   I don’t have the file this routine reads, so I created a default bathymetry to go with the gx3, gx1 grids using POP’s 40-level vertical grid.  Bathymetric input should be included with individual grids, henceforth. 
- created set_nml.basal for testing the basalstress option.  
- removed JF's hard-wired path directories from ice_in.  This should work correctly now, if the data is put into the location specified in the machine file (env.fram).

Still needs to be done:
- add units to Cbu declaration in the code
- replace hwater with bathymetry (are they the same units, i.e. m?)
- add POP's 40-level vertical grid to standard grid info that is read in?
- How should Ktens and e_ratio be set in set_nml.basal?  Are other namelist changes needed for this test?
- add documentation for Ktens, e_ratio, basalstress, and the entire fast ice parameterization

Is there history output specific to this parameterization?  How do you identify fast ice in the output?


