### PR TITLE
Ctest timings

### DIFF
--- a/configuration/scripts/tests/CTest/parse_timings.csh
+++ b/configuration/scripts/tests/CTest/parse_timings.csh
@@ -1,0 +1,46 @@
+#!/bin/csh -f
+
+# This script parses the timings from the tests in the test suite and writes them to the CTest
+# Test.xml file prior to submitting to CDash.
+
+# Loop through each line of the Test.xml file
+set CTEST_TAG="`head -n 1 Testing/TAG`"
+set testfile="`ls Testing/${CTEST_TAG}/Test.xml`"
+set outfile="Testing/${CTEST_TAG}/Test.xml.generated"
+set save_time=0
+foreach line ("`cat $testfile`")
+  if ( "$line" =~ *"Test Status"* ) then
+    if ( "$line" =~ *"passed"* ) then
+      set save_time=1
+    else
+      set save_time=0
+    endif
+  endif
+  if ( "$line" =~ *"FullName"* ) then
+    if ( "$line" =~ *"_run<"* && $save_time == 1) then
+      set save_time=1
+      # Grab the case name
+      set casename=`echo $line | grep -oP '(?<=<FullName>\.\/).*?(?=</FullName>)' | rev | cut -c 5- | rev`
+    else
+      set save_time=0
+    endif
+  endif
+  if ( "$line" =~ *"Execution Time"* && $save_time == 1 ) then
+    # Find the case runlog
+    set runlog=`ls ./${casename}.*/logs/*runlog*`
+    foreach line1 ("`cat $runlog`")
+      if ( "$line1" =~ *"Timer   2:"*) then
+        set runtime=`echo $line1 | grep -oP "\d+\.(\d+)?" | sort -n | tail -1`
+      endif
+    end
+    set local_runtime=`echo $line | grep -oP "\d+\.(\d+)?" | sort -n | tail -1`
+    # Grab the leading whitespace
+    # Replace the timing in Test.xml with the timing from the runlog file
+    set line=`echo "$line" | sed "s/^\(.*<Value>\)${local_runtime}\(<\/Value>\)/\1${runtime}<\/Value>/"`
+    set save_time=0
+  endif
+  echo "$line" >> $outfile
+end
+
+mv $testfile ${testfile}.bak
+mv $outfile $testfile

--- a/configuration/scripts/tests/CTest/run_ctest.csh
+++ b/configuration/scripts/tests/CTest/run_ctest.csh
@@ -5,6 +5,15 @@ set initargv = ( $argv[*] )
 set dash = "-"
 set submit_only=0
 
+# Check if any of the results could not find the baseline dataset
+grep --quiet 'baseline-does-not-exist' results.log
+if ($status == 0) then
+  echo "Tests were not able to find the baseline datasets.  No results"
+  echo "will be posted to CDash"
+  grep 'baseline-does-not-exist' results.log
+  exit -1
+endif
+
 # Read in command line arguments
 set argv = ( $initargv[*] )
 

--- a/configuration/scripts/tests/CTest/steer.cmake
+++ b/configuration/scripts/tests/CTest/steer.cmake
@@ -38,5 +38,6 @@ message("source directory = ${CTEST_SOURCE_DIRECTORY}")
 
 ctest_start(${MODEL} TRACK ${MODEL})
 ctest_test( BUILD "${CTEST_BINARY_DIRECTORY}" RETURN_VALUE res)
-
+message("Parsing timings into Test.xml")
+execute_process(COMMAND "./parse_timings.csh")
 ctest_submit(           RETURN_VALUE res)

--- a/create.case
+++ b/create.case
@@ -231,6 +231,7 @@ if ( $testsuite != $spval ) then
     cp -f ${ICE_SCRIPTS}/tests/CTest/CTestTestfile.cmake ./${tsdir}
     cp -f ${ICE_SCRIPTS}/tests/CTest/steer.cmake ./${tsdir}
     cp -f ${ICE_SCRIPTS}/tests/CTest/run_ctest.csh ./${tsdir}
+    cp -f ${ICE_SCRIPTS}/tests/CTest/parse_timings.csh ./${tsdir}
   endif
 
 cat >! ./${tsdir}/suite.run << EOF0


### PR DESCRIPTION
Add timing information to the CDash online dashboard
Developer(s): Matt Turner
Updated documentation (Y/N): N
Results (bit for bit, roundoff, climate changing): N/A
Code review: 
Other Relevant Details:

- Timing information is posted for every *_run* test
