### PR TITLE
Add an option to pass an account number (-a) via create.case.

### DIFF
--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -14,7 +14,7 @@ set jobfile = $1
 set ntasks = ${ICE_NTASKS}
 set nthrds = ${ICE_NTHRDS}
 set maxtpn = ${ICE_MACHINE_TPNODE}
-set acct   = ${ICE_MACHINE_ACCT}
+set acct   = ${ICE_ACCOUNT}
 
 @ taskpernode = ${maxtpn} / $nthrds
 @ nnodes = ${ntasks} / ${taskpernode}

--- a/configuration/scripts/cice.settings
+++ b/configuration/scripts/cice.settings
@@ -32,6 +32,7 @@ setenv ICE_BASECOM    undefined
 setenv ICE_BFBCOMP    undefined
 setenv ICE_SPVAL      undefined
 setenv ICE_RUNLENGTH  00:10:00
+setenv ICE_ACCOUNT    undefined
 
 #======================================================
 

--- a/configuration/scripts/machines/env.cheyenne
+++ b/configuration/scripts/machines/env.cheyenne
@@ -18,8 +18,3 @@ setenv ICE_MACHINE_SUBMIT "qsub"
 setenv ICE_MACHINE_TPNODE 36
 setenv ICE_MACHINE_ACCT P0000000
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.conrad
+++ b/configuration/scripts/machines/env.conrad
@@ -37,11 +37,6 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE ~/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT ARLAP96070PET
+setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.cori
+++ b/configuration/scripts/machines/env.cori
@@ -42,8 +42,3 @@ setenv ICE_MACHINE_SUBMIT "sbatch "
 setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.gordon
+++ b/configuration/scripts/machines/env.gordon
@@ -40,8 +40,3 @@ setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.onyx
+++ b/configuration/scripts/machines/env.onyx
@@ -37,11 +37,6 @@ setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/home/turner/CICE-atm/
 setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
-setenv ICE_MACHINE_ACCT ARLAP96070PET
+setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 44    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 12
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.pinto
+++ b/configuration/scripts/machines/env.pinto
@@ -26,8 +26,3 @@ setenv ICE_MACHINE_SUBMIT "sbatch "
 setenv ICE_MACHINE_ACCT climateacme
 setenv ICE_MACHINE_TPNODE 16
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.testmachine
+++ b/configuration/scripts/machines/env.testmachine
@@ -9,8 +9,3 @@ setenv ICE_MACHINE_SUBMIT "qsub"
 setenv ICE_MACHINE_TPNODE 4
 setenv ICE_MACHINE_ACCT P0000000
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.thunder
+++ b/configuration/scripts/machines/env.thunder
@@ -34,8 +34,3 @@ setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 36    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.wolf
+++ b/configuration/scripts/machines/env.wolf
@@ -26,8 +26,3 @@ setenv ICE_MACHINE_SUBMIT "sbatch "
 setenv ICE_MACHINE_ACCT climateacme
 setenv ICE_MACHINE_TPNODE 16
 setenv ICE_MACHINE_BLDTHRDS 1
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/machines/env.yellowstone
+++ b/configuration/scripts/machines/env.yellowstone
@@ -30,8 +30,3 @@ setenv ICE_MACHINE_SUBMIT "bsub < "
 setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_TPNODE 32
 setenv ICE_MACHINE_BLDTHRDS 4
-
-if (-e ~/.cice_proj) then
-   set account_name = `head -1 ~/.cice_proj`
-   setenv ICE_MACHINE_ACCT ${account_name}
-endif

--- a/configuration/scripts/run.suite
+++ b/configuration/scripts/run.suite
@@ -11,6 +11,8 @@ set spval = "UnDeFiNeD"
 set mach = $spval
 set baseCom = $spval
 set baseGen = $spval
+set testid = $spval
+set acct = $spval
 
 if ($#argv < 1) then
   set helpheader = 1
@@ -38,6 +40,7 @@ NAME
                 3. Run the full base_suite
                 4. Post the results of the suite to CDash
         -h help
+        -1 account number for queue manager (default is defined in env.<machine>)
         -m machine, machine name (required)
            Available -m options are in configuration/scripts/machines and include:
 EOF1
@@ -83,6 +86,9 @@ while (1)
     case "-m":
       set mach = $argv[1]
       breaksw
+    case "-a":
+      set acct = $argv[1]
+      breaksw
     case "-bc":
       set baseCom = $argv[1]
       breaksw
@@ -117,10 +123,19 @@ git clone --recursive https://github.com/CICE-Consortium/CICE.git $gitDir
 cd $gitDir
 
 echo "Running ./create.case"
-if ($baseGen == $spval) then
-  ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -report
+if ($acct = $spval) then
+  if ($baseGen == $spval) then
+    ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -report
+  else
+    ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg ${baseGen} -report
+  endif
 else
-  ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg ${baseGen} -report
+  if ($baseGen == $spval) then
+    ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -report -a $acct
+  else
+    ./create.case -m ${mach} -ts base_suite -testid ${testid} -bc ${baseCom} -bg ${baseGen} \
+                  -report -a $acct
+  endif
 endif
 
 echo "---"

--- a/create.case
+++ b/create.case
@@ -19,6 +19,7 @@ set sets = ""
 set bdir = $spval
 set testid = $spval
 set testsuite = $spval
+set acct = $spval
 set baseCom = $spval  # Baseline compare
 set baseGen = $spval  # Baseline generate
 set bfbcomp = $spval  # BFB compare
@@ -57,6 +58,7 @@ EOF1
       end
 cat << EOF1
         -p tasks x threads, mxn (default is 4x1)
+        -a account number for the queue manager (default is defined in env.<machine>)
         -g grid, grid (default = gx3)
         -s build and namelist mod files, comma separated with no spaces (default = " ")
            Available -s options are in configuration/scripts/options and include:
@@ -141,6 +143,9 @@ while (1)
       breaksw
     case "-p":
       set pesx = $argv[1]
+      breaksw
+    case "-a":
+      set acct = $argv[1]
       breaksw
     case "-s":
       set sets = $argv[1]
@@ -449,6 +454,17 @@ if ($test != $spval) then
 else
   echo "setenv ICE_TEST     ${spval}" >> ${fsmods}
   echo "setenv ICE_TESTNAME ${spval}" >> ${fsmods}
+endif
+
+if ($acct != $spval) then
+  echo "setenv ICE_ACCOUNT ${acct}" >> ${fsmods}
+else
+  if(-e ~/.cice_proj) then
+    set account_name = `head -1 ~/.cice_proj`
+    echo "setenv ICE_ACCOUNT ${account_name}" >> ${fsmods}
+  else
+    echo "setenv ICE_ACCOUNT ${ICE_MACHINE_ACCT}" >> ${fsmods}
+  endif
 endif
 
 if ($sets != "") then


### PR DESCRIPTION
Allow users to pass an account number from the command line to create.case.
Developer(s): Matt Turner
Are the code changes bit for bit, different at roundoff level, or more substantial? N/A
Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately? (Y/N) Y.  The entire "Scripting" section of the documentation needs to be written
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/CICE/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:

- This implementation is nearly identical to the Icepack implementation.
