### PR TITLE
End to end Documentation (+ bugfix)

### DIFF
--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -36,7 +36,7 @@ EOF0
 
 #==========================================
 
-else if (${ICE_MACHINE} =~ cheyenne*) then
+if (${ICE_MACHINE} =~ cheyenne*) then
 cat >> ${jobfile} << EOFB
 #PBS -j oe 
 #PBS -m ae 

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -12,7 +12,7 @@ set nthrds = ${ICE_NTHRDS}
 
 #==========================================
 
-else if (${ICE_MACHINE} =~ cheyenne*) then
+if (${ICE_MACHINE} =~ cheyenne*) then
 cat >> ${jobfile} << EOFR
 mpiexec_mpt -n ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR

--- a/doc/source/cice_3_user_guide.rst
+++ b/doc/source/cice_3_user_guide.rst
@@ -2349,7 +2349,6 @@ users essentially just need to perform all steps available in run.suite, detaile
 - Parse the results, by running ``./results.csh``.
 - Run the CTest / CDash script ``./run_ctest.csh``.
 
-
 If the ``run_ctest.csh`` script is unable to post the testing results to the CDash
 server, a message will be printed to the screen detailing instructions on how to attempt
 to post the results from another server.  If ``run_ctest.csh`` fails to submit the results,
@@ -2357,6 +2356,56 @@ it will generate a tarball ``cice_ctest.tgz`` that contains the necessary files 
 submission.  Copy this file to another server (CMake version 2.8+ required), extract the 
 archive, and run ``./run_ctest.csh -submit``.
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+End-To-End Testing Procedure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below is an example of a step-by-step procedure for testing a code change that results
+in non-bit-for-bit results:
+
+.. code-block:: bash
+
+  # Create a baseline dataset (only necessary if no baseline exists on the system)
+  ./create.case -m onyx -ts base_suite -testid base0 -bg cicev6.0.0 -a <account_number>
+
+  # Check out the updated code, or clone from a pull request
+
+  # Run the test with the new code
+  ./create.case -m onyx -ts base_suite -testid test0 -bc cicev6.0.0 -a <account_number>
+
+  # Check the results
+  cd base_suite.test0
+  ./results.csh
+
+  #### If the BFB tests fail, perform the compliance testing ####
+  # Create a QC baseline
+  ./create.case -m onyx -t smoke -g gx1 -p 44x1 -testid qc_base -s qc,medium -a <account_number>
+  cd onyx_smoke_gx1_44x1_medium_qc.qc_base
+  ./cice.build
+  ./cice.submit
+
+  # Check out the updated code or clone from a pull request
+
+  # Create the t-test testing data
+  ./create.case -m onyx -t smoke -g gx1 -p 44x1 -testid qc_test -s qc,medium -a <account_number>
+  cd onyx_smoke_gx1_44x1_medium_qc.qc_test
+  ./cice.build
+  ./cice.submit
+
+  # Wait for runs to finish
+  
+  # Perform the QC test
+  cp configuration/scripts/tests/QC/cice.t-test.py
+  ./cice.t-test.py /p/work/turner/CICE_RUNS/onyx_smoke_gx1_44x1_medium_qc.qc_base \
+                   /p/work/turner/CICE_RUNS/onyx_smoke_gx1_44x1_medium_qc.qc_test
+
+  # Example output:
+  INFO:__main__:Number of files: 1825
+  INFO:__main__:Two-Stage Test Passed
+  INFO:__main__:Quadratic Skill Test Passed for Northern Hemisphere
+  INFO:__main__:Quadratic Skill Test Passed for Southern Hemisphere
+  INFO:__main__:
+  INFO:__main__:Quality Control Test PASSED
 
 .. _tabnamelist:
 


### PR DESCRIPTION
Add documentation for an end-to-end testing procedure.  Also include a bugfix for cice.batch.csh and cice.launch.csh that showed up when Yellowstone was removed from machines.
Developer(s): Matt Turner
Are the code changes bit for bit, different at roundoff level, or more substantial? bfb
Is the documentation being updated with this PR? (Y/N) Y
If not, does the documentation need to be updated separately? (Y/N)
"Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://cice-consortium.github.io/CICE/ 
Please suggest code reviewers in the column at right. 
Other Relevant Details:
