### PR TITLE
Add byteswapio to LDFLAGS for CCE

### DIFF
--- a/configuration/scripts/machines/Macros.conrad_cray
+++ b/configuration/scripts/machines/Macros.conrad_cray
@@ -10,6 +10,7 @@ FIXEDFLAGS := -132
 FREEFLAGS  := 
 FFLAGS     := -h fp0 -h byteswapio 
 FFLAGS_NOOPT:= -O0
+LDFLAGS    := -h byteswapio
 
 ifeq ($(ICE_BLDDEBUG), true)
   FFLAGS     += -O0 -g -Rbcdps

--- a/configuration/scripts/machines/Macros.onyx_cray
+++ b/configuration/scripts/machines/Macros.onyx_cray
@@ -10,6 +10,7 @@ FIXEDFLAGS := -132
 FREEFLAGS  := 
 FFLAGS     := -h fp0 -h byteswapio 
 FFLAGS_NOOPT:= -O0
+LDFLAGS    := -h byteswapio
 
 ifeq ($(ICE_BLDDEBUG), true)
   FFLAGS     += -O0 -g -Rbcdps


### PR DESCRIPTION
Add the `-h byteswapio` flag to LDFLAGS for all `Macros.*_cray` files.

- Developer(s):  Matt Turner

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial?  More substantial, but this fixes a bug that caused runs with CCE to not complete

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
This addresses https://github.com/CICE-Consortium/CICE/issues/119
The `Macros.*_cray` files had `-h byteswapio` in `FFLAGS`, but not in `LDFLAGS`.  However, according to the Cray documentation "[b]yteswapio is implemented during the linker phase so that it can be uniformly applied across the entire executable", so `-h byteswapio` has to be included in `LDFLAGS`.