### PR TITLE
Modif doc16 may2018

### DIFF
--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -756,6 +756,28 @@
   pages = {1329-1353},
   url = {https://doi.org/10.1175/JPO-D-13-0215.1}
 }
+
+@Article{KH2010
+  author = "C. Konig Beatty and D.M. Holland",
+  title = "{Modeling landfast ice by adding tensile strength}",
+  journal = JPO,
+  year = "2010",
+  volume = {40},
+  pages = {185-198},
+  url = {https://doi.org/10.1175/2009JPO4105.1}
+}
+
+@Article{Lemieux2016
+  author = "J.F. Lemieux and F.Dupont and P. Blain and F. Roy and G.C. Smith and G.M. Flato",
+  title = "{Improving the simulation of landfast ice by combining tensile strength and a parameterization for
+grounded ridges,}",
+  journal = JGRO,
+  year = "2016",
+  volume = {121},
+  pages = {},
+  url = {https://doi.org/10.1002/2016JC012006}
+}
+
 @article{Hunke2018,
   author = {Hunke, Elizabeth and Roberts, Andrew and Allard, Richard and Lemieux, Jean-Fran{\c{c}}ois and Turner, Matthew and Craig, Tony and DuVivier, Alice and Bailey, David and Holland, Marika and Winton, Michael and Dupont, Frederic and Grumbine, Robert},
   title = {{The CICE Consortium Sea Ice Modeling Suite}},

--- a/doc/source/science_guide/sg_modelcomps.rst
+++ b/doc/source/science_guide/sg_modelcomps.rst
@@ -1585,17 +1585,21 @@ terms of :math:`\sigma_1=\sigma_{11}+\sigma_{22}`,
 divergence, :math:`D_D`, and the horizontal tension and shearing
 strain rates, :math:`D_T` and :math:`D_S` respectively.
 
+CICE now outputs the internal ice pressure which is an important field to support navigation in ice-infested water.
+The internal ice pressure :math:`(sigP)` is the average of the normal stresses multiplied by :math:`-1` and 
+is therefore simply equal to :math:`-\sigma_1/2`.
+
 *Elastic-Viscous-Plastic*
 
 In the EVP model the internal stress tensor is determined from a
 regularized version of the VP constitutive law. Following the approach of :cite:`KH2010` (see also :cite:`Lemieux2016`), the 
 elliptical yield curve can be modified such that the ice has isotropic tensile strength. 
-The tensile strength :math:`T` is expressed as a fraction of the ice strength :math:`P`, that is :math:`T=k_t P` 
+The tensile strength :math:`T_p` is expressed as a fraction of the ice strength :math:`P`, that is :math:`T_p=k_t P` 
 where :math:`k_t` should be set to a value between 0 and 1. The constitutive law is therefore 
 
 .. math::
    {1\over E}{\partial\sigma_1\over\partial t} + {\sigma_1\over 2\zeta} 
-     + {p(1-k_t)\over 2\zeta} = D_D, \\
+     + {P_R(1-k_t)\over 2\zeta} = D_D, \\
    :label: sig1 
 
 .. math::
@@ -1630,12 +1634,11 @@ where
 .. math::
    \Delta = \left[D_D^2 + {1\over e^2}\left(D_T^2 + D_S^2\right)\right]^{1/2},
 
-and :math:`p` is a “replacement pressure” (see :cite:`GHA98`, for
+and :math:`P_R` is a “replacement pressure” (see :cite:`GHA98`, for
 example), which serves to prevent residual ice motion due to spatial
 variations of :math:`P` when the rates of strain are exactly zero. The ice strength :math:`P` 
 is a function of the ice thickness and concentration
-as it is described in Section :ref:`mech-red`. JFL CHECK HERE...only small p is modified by the 
-replacement pressure...not the P in the viscous coeff.
+as it is described in Section :ref:`mech-red`.
 
 Viscosities are updated during the subcycling, so that the entire
 dynamics component is subcycled within the time step, and the elastic
@@ -1652,16 +1655,14 @@ become
 .. math::
    \begin{aligned}
    {\partial\sigma_1\over\partial t} + {\sigma_1\over 2T} 
-     + {p(1-k_t)\over 2T} &=& {P(1+k_t)\over 2T\Delta} D_D, \\
+     + {P_R(1-k_t)\over 2T} &=& {P(1+k_t)\over 2T\Delta} D_D, \\
    {\partial\sigma_2\over\partial t} + {e^2\sigma_2\over 2T} &=& {P(1+k_t)\over
      2T\Delta} D_T,\\
    {\partial\sigma_{12}\over\partial t} + {e^2\sigma_{12}\over  2T} &=&
      {P(1+k_t)\over 4T\Delta}D_S.\end{aligned}
 
 All coefficients on the left-hand side are constant except for
-:math:`P`, JFL NOT TRUE FOR REP PRESSURE? IN FACT I WOULD REMOVE THE FIRST 
-2 sentences of this paragraph...which changes only on the longer time step :math:`\Delta t`.
-This modification compensates for the decreased efficiency of including
+:math:`P_R`. This modification compensates for the decreased efficiency of including
 the viscosity terms in the subcycling. (Note that the viscosities do not
 appear explicitly.) Choices of the parameters used to define :math:`E`,
 :math:`T` and :math:`\Delta t_e` are discussed in

--- a/doc/source/science_guide/sg_modelcomps.rst
+++ b/doc/source/science_guide/sg_modelcomps.rst
@@ -3,7 +3,7 @@
 .. _modelcomps:
 
 Model components
-================
+================ jfl
 
 The Arctic and Antarctic sea ice packs are mixtures of open water, thin
 first-year ice, thicker multiyear ice, and thick pressure ridges. The

--- a/doc/source/science_guide/sg_modelcomps.rst
+++ b/doc/source/science_guide/sg_modelcomps.rst
@@ -3,7 +3,7 @@
 .. _modelcomps:
 
 Model components
-================ jfl1
+================
 
 The Arctic and Antarctic sea ice packs are mixtures of open water, thin
 first-year ice, thicker multiyear ice, and thick pressure ridges. The
@@ -1434,12 +1434,14 @@ vertical direction:
 
 .. math::
    m{\partial {\bf u}\over\partial t} = \nabla\cdot{\bf \sigma}
-   + \vec{\tau}_a+\vec{\tau}_w - \hat{k}\times mf{\bf u} - mg\nabla H_\circ,
+   + \vec{\tau}_a+\vec{\tau}_w + \vec{\tau}_b - \hat{k}\times mf{\bf u} - mg\nabla H_\circ,
    :label: vpmom
 
 where :math:`m` is the combined mass of ice and snow per unit area and
 :math:`\vec{\tau}_a` and :math:`\vec{\tau}_w` are wind and ocean
-stresses, respectively. The strength of the ice is represented by the
+stresses, respectively. The term :math:`\vec{\tau}_b` is a 
+seabed stress (also referred to as basal stress) that represents the grounding of pressure
+ridges in shallow water :cite:`Lemieux2016`. The strength of the ice is represented by the
 internal stress tensor :math:`\sigma_{ij}`, and the other two terms on
 the right hand side are stresses due to Coriolis effects and the sea
 surface slope. The parameterization for the wind and ice–ocean stress
@@ -1457,20 +1459,21 @@ EVP approach. First, for clarity, the two components of Equation :eq:`vpmom` are
    m{\partial u\over\partial t} &=& {\partial\sigma_{1j}\over\partial x_j} + \tau_{ax} + 
      a_i c_w \rho_w
      \left|{\bf U}_w - {\bf u}\right| \left[\left(U_w-u\right)\cos\theta - \left(V_w-v\right)\sin\theta\right]
-     +mfv - mg{\partial H_\circ\over\partial x}, \\
+     -C_bu +mfv - mg{\partial H_\circ\over\partial x}, \\
    m{\partial v\over\partial t} &=& {\partial\sigma_{2j}\over\partial x_j} + \tau_{ay} + 
      a_i c_w \rho_w
      \left|{\bf U}_w - {\bf u}\right| \left[\left(U_w-u\right)\sin\theta - \left(V_w-v\right)\cos\theta\right]
-     -mfu - mg{\partial H_\circ\over\partial y}. \end{aligned}
+     -C_bv-mfu - mg{\partial H_\circ\over\partial y}. \end{aligned}
 
 In the code,
-:math:`{\tt vrel}=a_i c_w \rho_w\left|{\bf U}_w - {\bf u}^k\right|`,
+:math:`{\tt vrel}=a_i c_w \rho_w\left|{\bf U}_w - {\bf u}^k\right|` and 
+:math:`C_b=T_b \left( \sqrt{(u^k)^2+(v^k)^2}+u_0 \right)`, 
 where :math:`k` denotes the subcycling step. The following equations
 illustrate the time discretization and define some of the other
 variables used in the code.
 
 .. math::
-   \underbrace{\left({m\over\Delta t_e}+{\tt vrel} \cos\theta\right)}_{\tt cca} u^{k+1} 
+   \underbrace{\left({m\over\Delta t_e}+{\tt vrel} \cos\theta\ + C_b \right)}_{\tt cca} u^{k+1} 
    - \underbrace{\left(mf+{\tt vrel}\sin\theta\right)}_{\tt ccb}v^{k+1}
     =  \underbrace{{\partial\sigma_{1j}^{k+1}\over\partial x_j}}_{\tt strintx} 
     + \underbrace{\tau_{ax} - mg{\partial H_\circ\over\partial x} }_{\tt forcex}
@@ -1479,7 +1482,7 @@ variables used in the code.
 
 .. math::
     \underbrace{\left(mf+{\tt vrel}\sin\theta\right)}_{\tt ccb} u^{k+1} 
-   + \underbrace{\left({m\over\Delta t_e}+{\tt vrel} \cos\theta\right)}_{\tt cca}v^{k+1}
+   + \underbrace{\left({m\over\Delta t_e}+{\tt vrel} \cos\theta + C_b \right)}_{\tt cca}v^{k+1}
     =  \underbrace{{\partial\sigma_{2j}^{k+1}\over\partial x_j}}_{\tt strinty} 
     + \underbrace{\tau_{ay} - mg{\partial H_\circ\over\partial y} }_{\tt forcey}
      + {\tt vrel}\underbrace{\left(U_w\sin\theta+V_w\cos\theta\right)}_{\tt watery}  + {m\over\Delta t_e}v^k,
@@ -1502,8 +1505,8 @@ where :math:`{\bf F} = \nabla\cdot\sigma^{k+1}`. Then
 
 .. math::
    \begin{aligned}
-   \left({m\over\Delta t_e} +{\tt vrel}\cos\theta\right)u^{k+1} - \left(mf + {\tt vrel}\sin\theta\right) v^{k+1} &=& \hat{u}  \\
-   \left(mf + {\tt vrel}\sin\theta\right) u^{k+1} + \left({m\over\Delta t_e} +{\tt vrel}\cos\theta\right)v^{k+1} &=& \hat{v}.\end{aligned}
+   \left({m\over\Delta t_e} +{\tt vrel}\cos\theta\ + C_b \right)u^{k+1} - \left(mf + {\tt vrel}\sin\theta\right) v^{k+1} &=& \hat{u}  \\
+   \left(mf + {\tt vrel}\sin\theta\right) u^{k+1} + \left({m\over\Delta t_e} +{\tt vrel}\cos\theta + C_b \right)v^{k+1} &=& \hat{v}.\end{aligned}
 
 Solving simultaneously for :math:`u^{k+1}` and :math:`v^{k+1}`,
 
@@ -1515,7 +1518,7 @@ Solving simultaneously for :math:`u^{k+1}` and :math:`v^{k+1}`,
 where
 
 .. math::
-   a = {m\over\Delta t_e} + {\tt vrel}\cos\theta \\
+   a = {m\over\Delta t_e} + {\tt vrel}\cos\theta + C_b \\
    :label: cevpa
 
 .. math::
@@ -1530,6 +1533,46 @@ The Hibler-Bryan form for the ice-ocean stress :cite:`HB87`
 is included in **ice\_dyn\_shared.F90** but is currently commented out,
 pending further testing.
 
+.. _seabed-stress:
+
+***************
+Seabed stress
+***************
+
+The parameterization for the seabed stress is described in :cite:`Lemieux2016`. The components of the basal seabed stress are 
+:math:`\tau_{bx}=C_bu` and :math:`\tau_{by}=C_bv`, where :math:`C_b` is a coefficient expressed as
+
+.. math::
+   C_b= k_2 \max [0,(h_u - h_{cu})]  e^{-\alpha_b * (1 - a_u)} (\sqrt{u^2+v^2}+u_0)^{-1}, \\
+   :label: Cb 
+
+where :math:`k_2` determines the maximum seabed stress that can be sustained by the grounded parameterized ridge(s), :math:`u_0` 
+is a small residual velocity and :math:`\alpha_b=20` is a parameter to ensure that the seabed stress quickly drops when 
+the ice concentration is smaller than 1. In the code, :math:`k_2 \max [0,(h_u - h_{cu})]  e^{-\alpha_b * (1 - a_u)}` is defined as 
+:math:`T_b`. The quantities :math:`h_u`, :math:`a_{u}` and :math:`h_{cu}` are calculated at 
+the 'u' point based on local ice conditions (surrounding tracer points). They are respectively given by 
+
+.. math::
+   h_u=\max[v_i(i,j),v_i(i+1,j),v_i(i,j+1),v_i(i+1,j+1)], \\
+   :label: hu 
+   
+.. math::
+   a_u=\max[a_i(i,j),a_i(i+1,j),a_i(i,j+1),a_i(i+1,j+1)]. \\
+   :label: au      
+   
+.. math::
+   h_{cu}=a_u h_{wu} / k_1, \\
+   :label: hcu
+
+where the :math:`a_i` and :math:`v_i` are the total ice concentrations and ice volumes around the :math:`u` point :math:`i,j` and 
+:math:`k_1` is a parameter that defines the critical ice thickness :math:`h_{cu}` at which the parameterized 
+ridge(s) reaches the seafloor for a water depth :math:`h_{wu}=\min[h_w(i,j),h_w(i+1,j),h_w(i,j+1),h_w(i+1,j+1)]`.
+
+Given the formulation of :math:`C_b` in equation :eq:`Cb`, the seabed stress components are non-zero only when :math:`h_u > h_{cu}`, which means
+that the parameterized ridge is thick enough to reach the seafloor. The maximum seabed stress depends on the weigth of the ridge 
+above hydrostatic balance and the value of :math:`k_2`. Note that the user must provide a bathymetry field for using this grounding 
+scheme.
+   
 .. _internal-stress:
 
 ***************
@@ -1545,11 +1588,14 @@ strain rates, :math:`D_T` and :math:`D_S` respectively.
 *Elastic-Viscous-Plastic*
 
 In the EVP model the internal stress tensor is determined from a
-regularized version of the VP constitutive law,
+regularized version of the VP constitutive law. Following the approach of :cite:`KH2010` (see also :cite:`Lemieux2016`), the 
+elliptical yield curve can be modified such that the ice has isotropic tensile strength. 
+The tensile strength :math:`T` is expressed as a fraction of the ice strength :math:`P`, that is :math:`T=k_t P` 
+where :math:`k_t` should be set to a value between 0 and 1. The constitutive law is therefore 
 
 .. math::
    {1\over E}{\partial\sigma_1\over\partial t} + {\sigma_1\over 2\zeta} 
-     + {P\over 2\zeta} = D_D, \\
+     + {p(1-k_t)\over 2\zeta} = D_D, \\
    :label: sig1 
 
 .. math::
@@ -1576,19 +1622,20 @@ where
    \dot{\epsilon}_{ij} = {1\over 2}\left({{\partial u_i}\over{\partial x_j}} + {{\partial u_j}\over{\partial x_i}}\right), 
 
 .. math::
-   \zeta = {P\over 2\Delta}, 
+   \zeta = {P(1+k_t)\over 2\Delta}, 
 
 .. math::
-   \eta  = {P\over {2\Delta e^2}}, 
+   \eta  = {P(1+k_t)\over {2\Delta e^2}}, 
 
 .. math::
    \Delta = \left[D_D^2 + {1\over e^2}\left(D_T^2 + D_S^2\right)\right]^{1/2},
 
-and :math:`P` is a function of the ice thickness and concentration,
-described in Section :ref:`mech-red`. The dynamics component
-employs a “replacement pressure” (see :cite:`GHA98`, for
+and :math:`p` is a “replacement pressure” (see :cite:`GHA98`, for
 example), which serves to prevent residual ice motion due to spatial
-variations of :math:`P` when the rates of strain are exactly zero.
+variations of :math:`P` when the rates of strain are exactly zero. The ice strength :math:`P` 
+is a function of the ice thickness and concentration
+as it is described in Section :ref:`mech-red`. JFL CHECK HERE...only small p is modified by the 
+replacement pressure...not the P in the viscous coeff.
 
 Viscosities are updated during the subcycling, so that the entire
 dynamics component is subcycled within the time step, and the elastic
@@ -1605,14 +1652,15 @@ become
 .. math::
    \begin{aligned}
    {\partial\sigma_1\over\partial t} + {\sigma_1\over 2T} 
-     + {P\over 2T} &=& {P\over 2T\Delta} D_D, \\
-   {\partial\sigma_2\over\partial t} + {e^2\sigma_2\over 2T} &=& {P\over
+     + {p(1-k_t)\over 2T} &=& {P(1+k_t)\over 2T\Delta} D_D, \\
+   {\partial\sigma_2\over\partial t} + {e^2\sigma_2\over 2T} &=& {P(1+k_t)\over
      2T\Delta} D_T,\\
    {\partial\sigma_{12}\over\partial t} + {e^2\sigma_{12}\over  2T} &=&
-     {P\over 4T\Delta}D_S.\end{aligned}
+     {P(1+k_t)\over 4T\Delta}D_S.\end{aligned}
 
 All coefficients on the left-hand side are constant except for
-:math:`P`, which changes only on the longer time step :math:`\Delta t`.
+:math:`P`, JFL NOT TRUE FOR REP PRESSURE? IN FACT I WOULD REMOVE THE FIRST 
+2 sentences of this paragraph...which changes only on the longer time step :math:`\Delta t`.
 This modification compensates for the decreased efficiency of including
 the viscosity terms in the subcycling. (Note that the viscosities do not
 appear explicitly.) Choices of the parameters used to define :math:`E`,

--- a/doc/source/science_guide/sg_modelcomps.rst
+++ b/doc/source/science_guide/sg_modelcomps.rst
@@ -3,7 +3,7 @@
 .. _modelcomps:
 
 Model components
-================ jfl
+================ jfl1
 
 The Arctic and Antarctic sea ice packs are mixtures of open water, thin
 first-year ice, thicker multiyear ice, and thick pressure ridges. The


### PR DESCRIPTION
This is a follow up of my PR submitted yesterday for the documentation. This includes doc for the grounding scheme, for the tensile strength (with T_p instead of T...) and I also added a sentence for the internal ice pressure. Attached is a pdf that explain what I meant about the replacement pressure.

[rep_pressure.pdf](https://github.com/CICE-Consortium/CICE/files/2010350/rep_pressure.pdf)

Elizabeth, please cancel the previous PR and use this one instead.

- Developer(s): JF Lemieux

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? N.A.  only changes to the documentation.

- Is the documentation being updated with this PR? (Y/N) Y
If not, does the documentation need to be updated separately at a later time? (Y/N)
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
