### PR TITLE
Modif to basal stress calculation for computational efficiency (NEW one)

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -82,9 +82,9 @@
       use ice_domain_size, only: max_blocks, ncat
       use ice_flux, only: rdg_conv, rdg_shear, strairxT, strairyT, &
           strairx, strairy, uocn, vocn, ss_tltx, ss_tlty, iceumask, fm, &
-          strtltx, strtlty, strocnx, strocny, strintx, strinty, &
+          strtltx, strtlty, strocnx, strocny, strintx, strinty, taubx, tauby, &
           strocnxT, strocnyT, strax, stray, &
-          Cbu, taubx, tauby, hwater, &
+          Tbu, hwater, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
@@ -260,6 +260,7 @@
                          strtltx   (:,:,iblk), strtlty   (:,:,iblk), & 
                          strocnx   (:,:,iblk), strocny   (:,:,iblk), & 
                          strintx   (:,:,iblk), strinty   (:,:,iblk), & 
+                         taubx     (:,:,iblk), tauby     (:,:,iblk), & 
                          waterx    (:,:,iblk), watery    (:,:,iblk), & 
                          forcex    (:,:,iblk), forcey    (:,:,iblk), & 
                          stressp_1 (:,:,iblk), stressp_2 (:,:,iblk), & 
@@ -270,7 +271,7 @@
                          stress12_3(:,:,iblk), stress12_4(:,:,iblk), & 
                          uvel_init (:,:,iblk), vvel_init (:,:,iblk), &
                          uvel      (:,:,iblk), vvel      (:,:,iblk), &
-                         Cbu       (:,:,iblk))
+                         Tbu       (:,:,iblk))
 
       !-----------------------------------------------------------------
       ! ice strength
@@ -326,6 +327,20 @@
          call ice_HaloMask(halo_info_mask, halo_info, halomask)
       endif
 
+      !-----------------------------------------------------------------
+      ! basal stress coefficients (landfast ice)
+      !-----------------------------------------------------------------
+      
+      if (basalstress) then
+       do iblk = 1, nblocks
+         call basal_stress_coeff (nx_block,         ny_block,       &
+                                  icellu  (iblk),                   &
+                                  indxui(:,iblk),   indxuj(:,iblk), &
+                                  vice(:,:,iblk),   aice(:,:,iblk), &
+                                  hwater(:,:,iblk), Tbu(:,:,iblk))
+       enddo                           
+      endif
+      
       do ksub = 1,ndte        ! subcycling
 
       !-----------------------------------------------------------------
@@ -358,26 +373,13 @@
 !            endif               ! yield_curve
 
       !-----------------------------------------------------------------
-      ! basal stress calculation (landfast ice)
-      !-----------------------------------------------------------------
-      
-            if (basalstress) then        
-               call basal_stress_coeff (nx_block,       ny_block,       &
-                                        icellu  (iblk),                 &
-                                        indxui(:,iblk), indxuj(:,iblk), &
-                                        vice(:,:,iblk), aice(:,:,iblk), &
-                                        hwater(:,:,iblk),               &
-                                        uvel(:,:,iblk), vvel(:,:,iblk), &
-                                        Cbu(:,:,iblk)) 
-            endif
-
-      !-----------------------------------------------------------------
       ! momentum equation
       !-----------------------------------------------------------------
 
             call stepu (nx_block,            ny_block,           &
                         icellu       (iblk), Cdn_ocn (:,:,iblk), & 
-                        indxui     (:,iblk), indxuj    (:,iblk), & 
+                        indxui     (:,iblk), indxuj    (:,iblk), &
+                        ksub,                                    &
                         aiu      (:,:,iblk), strtmp  (:,:,:),    & 
                         uocn     (:,:,iblk), vocn    (:,:,iblk), &     
                         waterx   (:,:,iblk), watery  (:,:,iblk), & 
@@ -385,10 +387,11 @@
                         umassdti (:,:,iblk), fm      (:,:,iblk), & 
                         uarear   (:,:,iblk),                     & 
                         strocnx  (:,:,iblk), strocny (:,:,iblk), & 
-                        strintx  (:,:,iblk), strinty (:,:,iblk), & 
+                        strintx  (:,:,iblk), strinty (:,:,iblk), &
+                        taubx    (:,:,iblk), tauby   (:,:,iblk), & 
                         uvel_init(:,:,iblk), vvel_init(:,:,iblk),&
                         uvel     (:,:,iblk), vvel    (:,:,iblk), &
-                        Cbu      (:,:,iblk))
+                        Tbu      (:,:,iblk))
 
             ! load velocity into array for boundary updates
             fld2(:,:,1,iblk) = uvel(:,:,iblk)
@@ -415,16 +418,6 @@
          !$OMP END PARALLEL DO
          
       enddo                     ! subcycling
-      
-      ! calculate basal stress component for outputs
-      if ( basalstress ) then
-         !$OMP PARALLEL DO PRIVATE(iblk)
-         do iblk = 1, nblocks
-            taubx(:,:,iblk) = -Cbu(:,:,iblk)*uvel(:,:,iblk)
-            tauby(:,:,iblk) = -Cbu(:,:,iblk)*vvel(:,:,iblk)
-         enddo
-         !$OMP END PARALLEL DO
-      endif
 
       deallocate(fld2)
       if (maskhalo_dyn) call ice_HaloDestroy(halo_info_mask)

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -381,6 +381,7 @@
                             strtltx,    strtlty,    & 
                             strocnx,    strocny,    &
                             strintx,    strinty,    &
+                            taubx,      tauby,      &
                             waterx,     watery,     & 
                             forcex,     forcey,     &     
                             stressp_1,  stressp_2,  &   
@@ -391,7 +392,7 @@
                             stress12_3, stress12_4, & 
                             uvel_init,  vvel_init,  &
                             uvel,       vvel,       &
-                            Cbu)
+                            Tbu)
 
       use ice_constants, only: c0, c1
 
@@ -438,7 +439,7 @@
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), & 
          intent(out) :: &
-         Cbu,      & ! coefficient for basal stress
+         Tbu,      & ! coefficient for basal stress (N/m^2)
          uvel_init,& ! x-component of velocity (m/s), beginning of time step
          vvel_init,& ! y-component of velocity (m/s), beginning of time step
          umassdti, & ! mass of U-cell/dt (kg/m^2 s)
@@ -460,7 +461,9 @@
          strocnx , & ! ice-ocean stress, x-direction
          strocny , & ! ice-ocean stress, y-direction
          strintx , & ! divergence of internal ice stress, x (N/m^2)
-         strinty     ! divergence of internal ice stress, y (N/m^2)
+         strinty , & ! divergence of internal ice stress, y (N/m^2)
+         taubx   , & ! basal stress, x-direction (N/m^2)
+         tauby       ! basal stress, y-direction (N/m^2)
 
       ! local variables
 
@@ -481,7 +484,9 @@
          forcex   (i,j) = c0
          forcey   (i,j) = c0
          umassdti (i,j) = c0
-         Cbu      (i,j) = c0
+         Tbu      (i,j) = c0
+         taubx    (i,j) = c0
+         tauby    (i,j) = c0
 
          if (revp==1) then               ! revised evp
             stressp_1 (i,j) = c0
@@ -611,6 +616,7 @@
       subroutine stepu (nx_block,   ny_block, &
                         icellu,     Cw,       &
                         indxui,     indxuj,   &
+                        ksub,                 &
                         aiu,        str,      &
                         uocn,       vocn,     &
                         waterx,     watery,   &
@@ -619,13 +625,15 @@
                         uarear,               &
                         strocnx,    strocny,  &
                         strintx,    strinty,  &
+                        taubx,      tauby,    &
                         uvel_init,  vvel_init,&
                         uvel,       vvel,     &
-                        Cbu)
+                        Tbu)
 
       integer (kind=int_kind), intent(in) :: &
          nx_block, ny_block, & ! block dimensions
-         icellu                ! total count when iceumask is true
+         icellu,             & ! total count when iceumask is true
+         ksub                  ! subcycling iteration
 
       integer (kind=int_kind), dimension (nx_block*ny_block), &
          intent(in) :: &
@@ -633,7 +641,7 @@
          indxuj      ! compressed index in j-direction
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
-         Cbu,      & ! coefficient for basal stress
+         Tbu,      & ! coefficient for basal stress (N/m^2)
          uvel_init,& ! x-component of velocity (m/s), beginning of timestep
          vvel_init,& ! y-component of velocity (m/s), beginning of timestep
          aiu     , & ! ice fraction on u-grid
@@ -661,7 +669,9 @@
          strocnx , & ! ice-ocean stress, x-direction
          strocny , & ! ice-ocean stress, y-direction
          strintx , & ! divergence of internal ice stress, x (N/m^2)
-         strinty     ! divergence of internal ice stress, y (N/m^2)
+         strinty , & ! divergence of internal ice stress, y (N/m^2)
+         taubx   , & ! basal stress, x-direction (N/m^2)
+         tauby       ! basal stress, y-direction (N/m^2)
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), &
          intent(inout) :: &
@@ -676,9 +686,13 @@
          uold, vold        , & ! old-time uvel, vvel
          vrel              , & ! relative ice-ocean velocity
          cca,ccb,ab2,cc1,cc2,& ! intermediate variables
-         taux, tauy        , & ! part of ocean stress term          
+         taux, tauy        , & ! part of ocean stress term
+         Cb                , & ! complete basal stress coeff
          rhow                  !
 
+      real (kind=dbl_kind) :: &
+         u0 = 5e-5_dbl_kind    ! residual velocity for basal stress (m/s)
+         
       !-----------------------------------------------------------------
       ! integrate the momentum equation
       !-----------------------------------------------------------------
@@ -701,9 +715,11 @@
          ! ice/ocean stress
          taux = vrel*waterx(i,j) ! NOTE this is not the entire
          tauy = vrel*watery(i,j) ! ocn stress term
-
+      
+         Cb  = Tbu(i,j) / (sqrt(uold**2 + vold**2) + u0) ! for basal stress
          ! revp = 0 for classic evp, 1 for revised evp
-         cca = (brlx + revp)*umassdti(i,j) + vrel * cosw + Cbu(i,j) ! kg/m^2 s
+         cca = (brlx + revp)*umassdti(i,j) + vrel * cosw + Cb ! kg/m^2 s
+               
          ccb = fm(i,j) + sign(c1,fm(i,j)) * vrel * sinw ! kg/m^2 s
 
          ab2 = cca**2 + ccb**2
@@ -729,6 +745,14 @@
       !-----------------------------------------------------------------
          strocnx(i,j) = taux
          strocny(i,j) = tauy
+         
+      ! calculate basal stress component for outputs
+         if (ksub == ndte) then ! on last subcycling iteration
+          if ( basalstress ) then
+           taubx(i,j) = -uvel(i,j)*Tbu(i,j) / (sqrt(uold**2 + vold**2) + u0)
+           tauby(i,j) = -vvel(i,j)*Tbu(i,j) / (sqrt(uold**2 + vold**2) + u0)
+          endif
+         endif
 
       enddo                     ! ij
 
@@ -836,20 +860,25 @@
       end subroutine evp_finish
 
 !=======================================================================
-! Computes basal stress Cb coefficients (landfast ice)
+! Computes basal stress Tbu coefficients (landfast ice)
 !
-! Lemieux, J. F., B. Tremblay, F. Dupont, M. Plante, G. Smith, D. Dumont (2015). 
-! A basal stress parameterization form modeling landfast ice. J. Geophys. Res. 
+! Lemieux, J. F., B. Tremblay, F. Dupont, M. Plante, G.C. Smith, D. Dumont (2015). 
+! A basal stress parameterization form modeling landfast ice, J. Geophys. Res. 
 ! Oceans, 120, 3157-3173.
 !
-! author: Philippe Blain, CMC (coop summer 2015)
+! Lemieux, J. F., F. Dupont, P. Blain, F. Roy, G.C. Smith, G.M. Flato (2016). 
+! Improving the simulation of landfast ice by combining tensile strength and a
+! parameterization for grounded ridges, J. Geophys. Res. Oceans, 121.
 !
-      subroutine basal_stress_coeff (nx_block, ny_block, icellu, &
+! author: JF Lemieux, Philippe Blain (ECCC)
+!
+! note: Tbu is a part of the Cb as defined in Lemieux et al. 2015 and 2016.
+!
+      subroutine basal_stress_coeff (nx_block, ny_block,         &
+                                     icellu,                     &
                                      indxui,   indxuj,           &
                                      vice,     aice,             &
-                                     hwater,                     &
-                                     uold,     vold,             &
-                                     Cbu)
+                                     hwater,   Tbu)
 
       use ice_constants, only: c0, c1                                     
                                      
@@ -865,25 +894,19 @@
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
          aice    , & ! concentration of ice at tracer location
          vice    , & ! volume per unit area of ice at tracer location
-         hwater  , & ! water depth at tracer location
-         uold    , & ! u component of ice speed at previous iteration
-         vold        ! v component of ice speed at previous iteration
+         hwater      ! water depth at tracer location
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(inout) :: &
-         Cbu         ! coefficient for basal stress
-
-!
-!EOP
+         Tbu         ! coefficient for basal stress (N/m^2)
 
       real (kind=dbl_kind) :: &
          au,  & ! concentration of ice at u location
          hu,  & ! volume per unit area of ice at u location (mean thickness)
          hwu, & ! water depth at u location
          hcu, & ! critical thickness at u location
-         k1 = 8.0_dbl_kind , &  ! first free parameter for landfast parametrization 
-         k2 = 15.0_dbl_kind, &  ! second free parameter (Nm^-3) for landfast parametrization 
-         u0 = 5e-5_dbl_kind, &  ! residual velocity (m/s)
-         CC = 20.0_dbl_kind     ! CC=Cb factor in Lemieux et al 2015
+         k1 = 20.0_dbl_kind , &  ! first free parameter for landfast parametrization 
+         k2 = 15.0_dbl_kind , &  ! second free parameter (N/m^3) for landfast parametrization 
+         alphab = 20.0_dbl_kind  ! alphab=Cb factor in Lemieux et al 2015
 
       integer (kind=int_kind) :: &
          i, j, ij
@@ -897,14 +920,11 @@
          hwu = min(hwater(i,j),hwater(i+1,j),hwater(i,j+1),hwater(i+1,j+1))
          hu  = max(vice(i,j),vice(i+1,j),vice(i,j+1),vice(i+1,j+1))
 
-         ! calculate basal stress factor
          ! 1- calculate critical thickness
          hcu = au * hwu / k1
 
-         ! 2- calculate stress factor
-                      
-         Cbu(i,j) = ( k2 / (sqrt(uold(i,j)**2 + vold(i,j)**2) + u0) ) &
-                    * max(c0,(hu - hcu)) * exp(-CC * (c1 - au))
+         ! 2- calculate basal stress factor                    
+         Tbu(i,j) = k2 * max(c0,(hu - hcu)) * exp(-alphab * (c1 - au))
 
       enddo                     ! ij
 

--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -110,7 +110,7 @@
 
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
          fm       , & ! Coriolis param. * mass in U-cell (kg/s)
-         Cbu          ! coefficient for basal stress (landfast ice)
+         Tbu          ! coefficient for basal stress (N/m^2)
 
       !-----------------------------------------------------------------
       ! Thermodynamic component
@@ -273,7 +273,7 @@
          dvidtt, & ! ice volume tendency thermo. (m/s)
          dagedtt,& ! ice age tendency thermo.    (s/s)
          mlt_onset, &! day of year that sfc melting begins
-         frz_onset = c0, &! day of year that freezing begins (congel or frazil)
+         frz_onset, &! day of year that freezing begins (congel or frazil)
          frazil_diag ! frazil ice growth diagnostic (m/step-->cm/day)
          
       real (kind=dbl_kind), & 


### PR DESCRIPTION
[Remove this and add a short summary line]:

- Developer(s): JF Lemieux

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? 

It is BFB for the standard code (i.e. basal_stress = 'false').

It is not BFB when basal_stress = 'true' in the Northwern Hemipshere (it is .BFB in the Southern Hemisphere because there is no grounding with the bathymetry I used). I ran the gx3 config for one year for the latest code and this new code. The max. difference in thickness one year later (monthly mean) is 3 cm.

The new code for the basal stress is more computationally efficient (based on a suggestion from David Hebert, NRL). It is not BFB because I have changed the order of the operations.

I had a careful look at this and the differences are really due to small nonBFB differences.

I ran the testing script cice.t-test.py 

INFO:__main__:Number of files: 1833
INFO:__main__:Two-Stage Test Passed
INFO:__main__:Quadratic Skill Test Passed for Northern Hemisphere
INFO:__main__:Quadratic Skill Test Failed for Southern Hemisphere
INFO:__main__:
INFO:__main__:Quality Control Test PASSED

It passes except in the Southerne Hemisphere...It is weird as it is BFB there. 

- Is the documentation being updated with this PR? (Y/N) Y (done in previous PR)
If not, does the documentation need to be updated separately at a later time? (Y/N)
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
