### PR TITLE
fix decomp test failure by broadcasting calendar fields

### DIFF
--- a/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
@@ -36,7 +36,7 @@
 
       subroutine init_restart_read(ice_ic)
 
-      use ice_calendar, only: istep0, istep1, time, time_forc, npt
+      use ice_calendar, only: istep0, istep1, time, time_forc, npt, nyr
       use ice_communicate, only: my_task, master_task
       use ice_dyn_shared, only: kdyn
       use ice_read_write, only: ice_open, ice_open_ext
@@ -79,7 +79,7 @@
             call ice_open(nu_restart,trim(filename),0)
          endif
          if (use_restart_time) then
-            read (nu_restart) istep0,time,time_forc
+            read (nu_restart) istep0,time,time_forc,nyr
          else
             read (nu_restart) iignore,rignore,rignore ! use namelist values
          endif
@@ -89,6 +89,7 @@
       call broadcast_scalar(istep0,master_task)
       call broadcast_scalar(time,master_task)
       call broadcast_scalar(time_forc,master_task)
+      call broadcast_scalar(nyr,master_task)
       
       istep1 = istep0
 
@@ -347,7 +348,7 @@
          else
             call ice_open(nu_dump,filename,0)
          endif
-         write(nu_dump) istep1,time,time_forc
+         write(nu_dump) istep1,time,time_forc,nyr
          write(nu_diag,*) 'Writing ',filename(1:lenstr(filename))
       endif
 

--- a/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
@@ -90,6 +90,7 @@
       call broadcast_scalar(istep0,master_task)
       call broadcast_scalar(time,master_task)
       call broadcast_scalar(time_forc,master_task)
+      call broadcast_scalar(nyr,master_task)
       
       istep1 = istep0
 

--- a/cicecore/cicedynB/infrastructure/io/io_pio/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio/ice_restart.F90
@@ -101,6 +101,7 @@
       call broadcast_scalar(istep0,master_task)
       call broadcast_scalar(time,master_task)
       call broadcast_scalar(time_forc,master_task)
+      call broadcast_scalar(nyr,master_task)
       
       istep1 = istep0
 

--- a/cicecore/drivers/cice/CICE_RunMod.F90_debug
+++ b/cicecore/drivers/cice/CICE_RunMod.F90_debug
@@ -1,4 +1,4 @@
-!  SVN:$Id: CICE_RunMod.F90 746 2013-09-28 22:47:56Z eclare $
+!  SVN:$Id: CICE_RunMod.F90 1228 2017-05-23 21:33:34Z tcraig $
 !=======================================================================
 !
 !  Main driver for time stepping of CICE.
@@ -16,11 +16,19 @@
       module CICE_RunMod
 
       use ice_kinds_mod
+      use ice_fileunits, only: nu_diag
+      use ice_arrays_column, only: oceanmixed_ice
+      use ice_constants, only: c0, c1
+      use ice_constants, only: field_loc_center, field_type_scalar
+      use ice_exit, only: abort_ice
+      use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
+      use icepack_intfc, only: icepack_max_aero
+      use icepack_intfc, only: icepack_query_parameters
+      use icepack_intfc, only: icepack_query_tracer_flags, icepack_query_tracer_numbers
 
       implicit none
       private
       public :: CICE_Run, ice_step
-      save
 
 !=======================================================================
 
@@ -41,16 +49,22 @@
       use ice_forcing_bgc, only: get_forcing_bgc, get_atm_bgc, fzaero_data, & 
           faero_default
       use ice_flux, only: init_flux_atm, init_flux_ocn
-      use ice_colpkg_tracers, only: tr_aero, tr_zaero
       use ice_timers, only: ice_timer_start, ice_timer_stop, &
           timer_couple, timer_step
-      use ice_colpkg_shared, only: skl_bgc, z_tracers
+      logical (kind=log_kind) :: &
+          tr_aero, tr_zaero, skl_bgc, z_tracers
 
    !--------------------------------------------------------------------
    !  initialize error code and step timer
    !--------------------------------------------------------------------
 
       call ice_timer_start(timer_step)   ! start timing entire run
+
+      call icepack_query_parameters(skl_bgc_out=skl_bgc, z_tracers_out=z_tracers)
+      call icepack_query_tracer_flags(tr_aero_out=tr_aero, tr_zaero_out=tr_zaero)
+      call icepack_warnings_flush(nu_diag)
+      if (icepack_warnings_aborted()) call abort_ice(error_message="subname", &
+         file=__FILE__, line=__LINE__)
 
 #ifndef CICE_IN_NEMO
    !--------------------------------------------------------------------
@@ -72,20 +86,27 @@
          if (stop_now >= 1) exit timeLoop
 #endif
 
-#ifndef coupled
          call ice_timer_start(timer_couple)  ! atm/ocn coupling
+
+#ifndef coupled
+#ifndef CESMCOUPLED
          call get_forcing_atmo     ! atmospheric forcing from data
          call get_forcing_ocn(dt)  ! ocean forcing from data
-         ! if (tr_aero) call faero_data       ! aerosols
-         if (tr_aero .or. tr_zaero)  call faero_default     ! aerosols
+
+         ! aerosols
+         ! if (tr_aero)  call faero_data                   ! data file
+         ! if (tr_zaero) call fzaero_data                  ! data file (gx1)
+         if (tr_aero .or. tr_zaero)  call faero_default    ! default values
+
          if (skl_bgc .or. z_tracers) call get_forcing_bgc  ! biogeochemistry
-         if (z_tracers) call get_atm_bgc      ! biogeochemistry
-         !if (tr_zaero)  call fzaero_data      ! zaerosols, gx1
-         call ice_timer_stop(timer_couple)    ! atm/ocn coupling
 #endif
+#endif
+         if (z_tracers) call get_atm_bgc                   ! biogeochemistry
 
          call init_flux_atm     ! initialize atmosphere fluxes sent to coupler
          call init_flux_ocn     ! initialize ocean fluxes sent to coupler
+
+         call ice_timer_stop(timer_couple)    ! atm/ocn coupling
 
 #ifndef CICE_IN_NEMO
       enddo timeLoop
@@ -110,7 +131,6 @@
 
       use ice_boundary, only: ice_HaloUpdate
       use ice_calendar, only: dt, dt_dyn, ndtd, diagfreq, write_restart, istep
-      use ice_constants, only: field_loc_center, field_type_scalar, c0
       use ice_diagnostics, only: init_mass_diags, runtime_diags
       use ice_diagnostics_bgc, only: hbrine_diags, zsal_diags, bgc_diags
       use ice_domain, only: halo_info, nblocks
@@ -129,12 +149,9 @@
       use ice_restart_driver, only: dumpfile
       use ice_restoring, only: restore_ice, ice_HaloRestore
       use ice_state, only: trcrn
-      use ice_colpkg_tracers, only: tr_iage, tr_FY, tr_lvl, &
-          tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_brine, tr_aero
       use ice_step_mod, only: prep_radiation, step_therm1, step_therm2, &
           update_state, step_dyn_horiz, step_dyn_ridge, step_radiation, &
           biogeochemistry
-      use ice_colpkg_shared, only: calc_Tsfc, skl_bgc, solve_zsal, z_tracers
       use ice_timers, only: ice_timer_start, ice_timer_stop, &
           timer_diags, timer_column, timer_thermo, timer_bound, &
           timer_hist, timer_readwrite
@@ -146,12 +163,26 @@
       real (kind=dbl_kind) :: &
          offset          ! d(age)/dt time offset
 
+      logical (kind=log_kind) :: &
+          tr_iage, tr_FY, tr_lvl, &
+          tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_brine, tr_aero, &
+          calc_Tsfc, skl_bgc, solve_zsal, z_tracers
+
       character (len=char_len) :: plabeld
 
       plabeld = 'beginning time step'
       do iblk = 1, nblocks
          call debug_ice (iblk, plabeld)
       enddo
+
+      call icepack_query_parameters(calc_Tsfc_out=calc_Tsfc, skl_bgc_out=skl_bgc, &
+           solve_zsal_out=solve_zsal, z_tracers_out=z_tracers)
+      call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+           tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+           tr_pond_topo_out=tr_pond_topo, tr_brine_out=tr_brine, tr_aero_out=tr_aero)
+      call icepack_warnings_flush(nu_diag)
+      if (icepack_warnings_aborted()) call abort_ice(error_message="subname", &
+         file=__FILE__, line=__LINE__)
 
       !-----------------------------------------------------------------
       ! restoring on grid boundaries
@@ -218,6 +249,7 @@
       !-----------------------------------------------------------------
 
          do k = 1, ndtd
+
             ! momentum, stress, transport
             call step_dyn_horiz (dt_dyn)
 
@@ -324,9 +356,6 @@
           albicen, albsnon, albpndn, apeffn, fzsal_g, fzsal, snowfracn
       use ice_blocks, only: block, nx_block, ny_block
       use ice_calendar, only: dt, nstreams
-      use ice_colpkg_shared, only: calc_Tsfc, oceanmixed_ice, max_aero
-      use ice_colpkg_tracers, only: nbtrcr
-      use ice_constants, only: c0, c1, puny, rhofresh
       use ice_domain_size, only: ncat
       use ice_flux, only: alvdf, alidf, alvdr, alidr, albice, albsno, &
           albpnd, albcnt, apeff_ai, coszen, fpond, fresh, l_mpond_fresh, &
@@ -350,11 +379,24 @@
       integer (kind=int_kind) :: & 
          n           , & ! thickness category index
          i,j         , & ! horizontal indices
-         k               ! tracer index
+         k           , & ! tracer index
+         nbtrcr          !
+
+      logical (kind=log_kind) :: &
+         calc_Tsfc       !
 
       real (kind=dbl_kind) :: &
          cszn        , & ! counter for history averaging
+         puny        , & !
+         rhofresh    , & !
          netsw           ! flag for shortwave radiation presence
+
+         call icepack_query_parameters(puny_out=puny, rhofresh_out=rhofresh)
+         call icepack_query_tracer_numbers(nbtrcr_out=nbtrcr)
+         call icepack_query_parameters(calc_Tsfc_out=calc_Tsfc)
+         call icepack_warnings_flush(nu_diag)
+         if (icepack_warnings_aborted()) call abort_ice(error_message="subname", &
+            file=__FILE__, line=__LINE__)
 
       !-----------------------------------------------------------------
       ! Save current value of frzmlt for diagnostics.
@@ -401,6 +443,8 @@
          do n = 1, ncat
          do j = 1, ny_block
          do i = 1, nx_block
+            if (aicen(i,j,n,iblk) > puny) then
+
             alvdf(i,j,iblk) = alvdf(i,j,iblk) &
                + alvdfn(i,j,n,iblk)*aicen(i,j,n,iblk)
             alidf(i,j,iblk) = alidf(i,j,iblk) &
@@ -425,6 +469,8 @@
                + apeffn(i,j,n,iblk)*aicen(i,j,n,iblk)
             snowfrac(i,j,iblk) = snowfrac(i,j,iblk) &       ! for history
                + snowfracn(i,j,n,iblk)*aicen(i,j,n,iblk)
+
+            endif ! aicen > puny
          enddo
          enddo
          enddo
@@ -481,7 +527,7 @@
       !-----------------------------------------------------------------
 
          call scale_fluxes (nx_block,            ny_block,           &
-                            tmask    (:,:,iblk), nbtrcr, max_aero,   &
+                            tmask    (:,:,iblk), nbtrcr, icepack_max_aero,   &
                             aice     (:,:,iblk), Tf      (:,:,iblk), &
                             Tair     (:,:,iblk), Qa      (:,:,iblk), &
                             strairxT (:,:,iblk), strairyT(:,:,iblk), &
@@ -563,8 +609,13 @@
           i, j, n    ! horizontal indices
       
       real (kind=dbl_kind)    :: &
+          puny, &          !
           rLsub            ! 1/Lsub
 
+      call icepack_query_parameters(puny_out=puny)
+      call icepack_warnings_flush(nu_diag)
+      if (icepack_warnings_aborted()) call abort_ice(error_message="subname", &
+         file=__FILE__, line=__LINE__)
       rLsub = c1 / Lsub
 
       do n = 1, ncat


### PR DESCRIPTION
Fix nonBFB decomposition test comparisons.

- Developer(s):  E. Hunke

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial?

BFB except for the tests that were failing.

- Is the documentation being updated with this PR? (Y/N)  N
If not, does the documentation need to be updated separately at a later time? (Y/N)  N
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:

This PR addresses issue #137.   All of the ranks/tasks need calendar information for the frz_onset and mlt_onset variables, but nyr was not broadcast when using restart calendar information.  This broadcast has been added for all three I/O types (only netcdf is tested here).  We might also need to broadcast month, mday and sec too, but I’ve elected to wait on those until we actually see a problem with them.

I also updated drivers/cice/CICE_RunMod.F90_debug to match the current module.  This allows helpful printing of many pertinent fields throughout the timestepping for a grid point specified in ice_diagnostics.F90 (I added frz_onset to the printing routine temporarily but am not committing that change here).  

I have tested base_suite and decomp_suite, but using pes=1x8x5x29x80 in decomp_suite instead of 1x20x5x29x80 (see issue #137).  The boxrestart test fails (known issue, #138) in base_suite, otherwise everything passes.

