### PR TITLE
Icepack interface for binary restarts

### DIFF
--- a/cicecore/cicedynB/general/ice_forcing_bgc.F90
+++ b/cicecore/cicedynB/general/ice_forcing_bgc.F90
@@ -848,6 +848,7 @@
     if (icepack_warnings_aborted()) call abort_ice(error_message="subname", &
        file=__FILE__, line=__LINE__)
 
+#ifdef ncdf
     if (modal_aero) then
        diag = .true.   ! write diagnostic information 
        optics_file =  &
@@ -886,6 +887,11 @@
             enddo
          enddo          
       endif      ! modal_aero
+#else
+    if (modal_aero) then
+      call abort_ice('faero_optics: netcdf required for modal_aero')
+    endif
+#endif
 
       end subroutine faero_optics
 

--- a/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
@@ -1,4 +1,3 @@
-!  SVN:$Id: ice_restart.F90 806 2014-07-31 19:00:00Z tcraig $
 !=======================================================================
 
 ! Read and write ice model restart files using netCDF or binary
@@ -13,9 +12,6 @@
       use ice_restart_shared, only: &
           restart, restart_ext, restart_dir, restart_file, pointer_file, &
           runid, runtype, use_restart_time, restart_format, lenstr
-!      use icepack_intfc, only: tr_iage, tr_FY, tr_lvl, tr_aero, tr_pond_cesm, &
-!                             tr_pond_topo, tr_pond_lvl, tr_brine, nbtrcr
-!      use icepack_intfc, only: solve_zsal
       use ice_fileunits, only: nu_diag, nu_rst_pointer
       use ice_fileunits, only: nu_dump, nu_dump_eap, nu_dump_FY, nu_dump_age
       use ice_fileunits, only: nu_dump_lvl, nu_dump_pond, nu_dump_hbrine

--- a/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
@@ -9,15 +9,24 @@
       module ice_restart
 
       use ice_broadcast
-      use ice_exit, only: abort_ice
-      use ice_fileunits
       use ice_kinds_mod
       use ice_restart_shared, only: &
           restart, restart_ext, restart_dir, restart_file, pointer_file, &
           runid, runtype, use_restart_time, restart_format, lenstr
-      use icepack_intfc, only: tr_iage, tr_FY, tr_lvl, tr_aero, tr_pond_cesm, &
-                             tr_pond_topo, tr_pond_lvl, tr_brine, nbtrcr
-      use icepack_intfc, only: solve_zsal
+!      use icepack_intfc, only: tr_iage, tr_FY, tr_lvl, tr_aero, tr_pond_cesm, &
+!                             tr_pond_topo, tr_pond_lvl, tr_brine, nbtrcr
+!      use icepack_intfc, only: solve_zsal
+      use ice_fileunits, only: nu_diag, nu_rst_pointer
+      use ice_fileunits, only: nu_dump, nu_dump_eap, nu_dump_FY, nu_dump_age
+      use ice_fileunits, only: nu_dump_lvl, nu_dump_pond, nu_dump_hbrine
+      use ice_fileunits, only: nu_dump_bgc, nu_dump_aero, nu_dump_age
+      use ice_fileunits, only: nu_restart, nu_restart_eap, nu_restart_FY, nu_restart_age 
+      use ice_fileunits, only: nu_restart_lvl, nu_restart_pond, nu_restart_hbrine
+      use ice_fileunits, only: nu_restart_bgc, nu_restart_aero, nu_restart_age
+      use ice_exit, only: abort_ice
+      use icepack_intfc, only: icepack_query_parameters
+      use icepack_intfc, only: icepack_query_tracer_numbers
+      use icepack_intfc, only: icepack_query_tracer_flags
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
 
       implicit none
@@ -45,11 +54,17 @@
 
       ! local variables
 
+      logical (kind=log_kind) :: &
+         solve_zsal, &
+         tr_iage, tr_FY, tr_lvl, tr_aero, tr_pond_cesm, &
+         tr_pond_topo, tr_pond_lvl, tr_brine
+
       character(len=char_len_long) :: &
          filename, filename0
 
       integer (kind=int_kind) :: &
          n, &                    ! loop indices
+         nbtrcr, &               ! number of bgc tracers
          iignore                 ! dummy variable
 
       real (kind=real_kind) :: &
@@ -57,6 +72,18 @@
 
       character(len=char_len_long) :: &
          string1, string2
+
+      call icepack_query_parameters( &
+         solve_zsal_out=solve_zsal)
+      call icepack_query_tracer_numbers( &
+         nbtrcr_out=nbtrcr)
+      call icepack_query_tracer_flags( &
+         tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, &
+         tr_aero_out=tr_aero, tr_pond_cesm_out=tr_pond_cesm, &
+         tr_pond_topo_out=tr_pond_topo, tr_pond_lvl_out=tr_pond_lvl, tr_brine_out=tr_brine)
+      call icepack_warnings_flush(nu_diag)
+      if (icepack_warnings_aborted()) call abort_ice(error_message="subname", &
+         file=__FILE__, line=__LINE__)
 
       if (present(ice_ic)) then 
          filename = trim(ice_ic)
@@ -319,10 +346,28 @@
 
       ! local variables
 
+      logical (kind=log_kind) :: &
+         solve_zsal, &
+         tr_iage, tr_FY, tr_lvl, tr_aero, tr_pond_cesm, &
+         tr_pond_topo, tr_pond_lvl, tr_brine
+
       integer (kind=int_kind) :: &
-          iyear, imonth, iday     ! year, month, day
+         nbtrcr, &               ! number of bgc tracers
+         iyear, imonth, iday     ! year, month, day
 
       character(len=char_len_long) :: filename
+
+      call icepack_query_parameters( &
+         solve_zsal_out=solve_zsal)
+      call icepack_query_tracer_numbers( &
+         nbtrcr_out=nbtrcr)
+      call icepack_query_tracer_flags( &
+         tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, &
+         tr_aero_out=tr_aero, tr_pond_cesm_out=tr_pond_cesm, &
+         tr_pond_topo_out=tr_pond_topo, tr_pond_lvl_out=tr_pond_lvl, tr_brine_out=tr_brine)
+      call icepack_warnings_flush(nu_diag)
+      if (icepack_warnings_aborted()) call abort_ice(error_message="subname", &
+         file=__FILE__, line=__LINE__)
 
       ! construct path/file
       if (present(filename_spec)) then
@@ -682,7 +727,26 @@
       use ice_calendar, only: istep1, time, time_forc
       use ice_communicate, only: my_task, master_task
 
-      integer (kind=int_kind) :: status
+      logical (kind=log_kind) :: &
+         solve_zsal, &
+         tr_iage, tr_FY, tr_lvl, tr_aero, tr_pond_cesm, &
+         tr_pond_topo, tr_pond_lvl, tr_brine
+
+      integer (kind=int_kind) :: &
+         nbtrcr, &               ! number of bgc tracers
+         status
+
+      call icepack_query_parameters( &
+         solve_zsal_out=solve_zsal)
+      call icepack_query_tracer_numbers( &
+         nbtrcr_out=nbtrcr)
+      call icepack_query_tracer_flags( &
+         tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, &
+         tr_aero_out=tr_aero, tr_pond_cesm_out=tr_pond_cesm, &
+         tr_pond_topo_out=tr_pond_topo, tr_pond_lvl_out=tr_pond_lvl, tr_brine_out=tr_brine)
+      call icepack_warnings_flush(nu_diag)
+      if (icepack_warnings_aborted()) call abort_ice(error_message="subname", &
+         file=__FILE__, line=__LINE__)
 
       if (my_task == master_task) then
          close(nu_dump)

--- a/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
@@ -134,10 +134,10 @@
          tr_bgc_hum
 
       integer (kind=int_kind) :: &
-          k,  n,                & ! index
-          nx, ny,               & ! global array size
-          iyear, imonth, iday,  & ! year, month, day
-          nbtrcr
+         k,  n,                & ! index
+         nx, ny,               & ! global array size
+         iyear, imonth, iday,  & ! year, month, day
+         nbtrcr                  ! number of bgc tracers
 
       character(len=char_len_long) :: filename
 

--- a/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
@@ -1,4 +1,3 @@
-!  SVN:$Id: ice_restart.F90 607 2013-03-29 15:49:42Z eclare $
 !=======================================================================
 
 ! Read and write ice model restart files using netCDF or binary


### PR DESCRIPTION
Added Icepack interface calls to binary restart module and isolated netcdf bgc code.

- Developer(s):  E. Hunke

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial?  BFB

- Is the documentation being updated with this PR? (Y/N)  N
If not, does the documentation need to be updated separately at a later time? (Y/N)  N
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:

The modal_aero option requires netcdf input, so I added an abort if modal_aero=T and netcdf is not available.  @njeffery is it possible to include this data directly in the code or provide binary for it?

The change to io/netcdf/ice_restart.F90 is cosmetic.

This PR is not yet fully tested, just trying to keep Rob going...



