### PR TITLE
Minor modifs to ice_dyn routines

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -22,7 +22,7 @@
       implicit none
       private
       public :: init_evp, set_evp_parameters, stepu, principal_stress, &
-                evp_prep1, evp_prep2, evp_finish, basal_stress_coeff
+                dyn_prep1, dyn_prep2, dyn_finish, basal_stress_coeff
 
       ! namelist parameters
 
@@ -250,7 +250,7 @@
 !
 ! author: Elizabeth C. Hunke, LANL
 
-      subroutine evp_prep1 (nx_block,  ny_block, & 
+      subroutine dyn_prep1 (nx_block,  ny_block, & 
                             ilo, ihi,  jlo, jhi, &
                             aice,      vice,     & 
                             vsno,      tmask,    & 
@@ -353,7 +353,7 @@
       enddo
       enddo
 
-      end subroutine evp_prep1
+      end subroutine dyn_prep1
 
 !=======================================================================
 ! Computes quantities needed in the stress tensor (sigma)
@@ -365,7 +365,7 @@
 !
 ! author: Elizabeth C. Hunke, LANL
 
-      subroutine evp_prep2 (nx_block,   ny_block,   & 
+      subroutine dyn_prep2 (nx_block,   ny_block,   & 
                             ilo, ihi,   jlo, jhi,   &
                             icellt,     icellu,     & 
                             indxti,     indxtj,     & 
@@ -604,7 +604,7 @@
          forcey(i,j) = strairy(i,j) + strtlty(i,j)
       enddo
 
-      end subroutine evp_prep2
+      end subroutine dyn_prep2
 
 !=======================================================================
 
@@ -765,7 +765,7 @@
 !
 ! author: Elizabeth C. Hunke, LANL
 
-      subroutine evp_finish (nx_block, ny_block, &
+      subroutine dyn_finish (nx_block, ny_block, &
                              icellu,   Cw,       &
                              indxui,   indxuj,   &
                              uvel,     vvel,     &
@@ -857,7 +857,7 @@
          strocnyT(i,j) = strocny(i,j) / aiu(i,j)
       enddo
 
-      end subroutine evp_finish
+      end subroutine dyn_finish
 
 !=======================================================================
 ! Computes basal stress Tbu coefficients (landfast ice)

--- a/configuration/scripts/machines/env.fram_intel
+++ b/configuration/scripts/machines/env.fram_intel
@@ -6,9 +6,9 @@
 setenv ICE_MACHINE_ENVNAME fram
 setenv ICE_MACHINE_COMPILER intel
 setenv ICE_MACHINE_MAKE make
-setenv ICE_MACHINE_WKDIR /users/dor/armn/jfl/local1/CICE6dev/CICE/tests/CICE_RUNS
+setenv ICE_MACHINE_WKDIR /home/dormrb01/zephyr4/armn/jfl/local1/Minor_modif4july2018/CICE/tests/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /users/dor/armn/jfl/local1/CICE6/CICE/configuration/data/gx3Ncar
-setenv ICE_MACHINE_BASELINE /users/dor/armn/jfl/local1/CICE6dev/CICE/tests/CICE_BASELINE
+setenv ICE_MACHINE_BASELINE /home/dormrb01/zephyr4/armn/jfl/local1/Minor_modif4july2018/CICE/tests/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub"
 setenv ICE_MACHINE_QUEUE "default"
 setenv ICE_MACHINE_TPNODE 36
@@ -19,5 +19,3 @@ if (-e ~/.cice_proj) then
    set account_name = `head -1 ~/.cice_proj`
    setenv CICE_ACCT ${account_name}
 endif
-
-echo "je suis dans env"

--- a/doc/source/science_guide/sg_coupling.rst
+++ b/doc/source/science_guide/sg_coupling.rst
@@ -393,7 +393,7 @@ source. In our case, the sea surface height :math:`H_\circ` is a
 prognostic variable in POP—the flux coupler can provide the surface
 slope directly, rather than inferring it from the currents. (The option
 of computing it from the currents is provided in subroutine
-*evp\_prep*.) The sea ice model uses the surface layer currents
+*dyn\_prep2*.) The sea ice model uses the surface layer currents
 :math:`\vec{U}_w` to determine the stress between the ocean and the ice,
 and subsequently the ice velocity :math:`\vec{u}`. This stress, relative
 to the ice,

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -343,7 +343,7 @@ The logical masks `tmask` and `umask` (which correspond to the real masks
 `hm` and `uvm`, respectively) are useful in conditional statements.
 
 In addition to the land masks, two other masks are implemented in
-*evp\_prep* in order to reduce the dynamics component’s work on a global
+*dyn\_prep* in order to reduce the dynamics component’s work on a global
 grid. At each time step the logical masks `ice\_tmask` and `ice\_umask` are
 determined from the current ice extent, such that they have the value
 “true” wherever ice exists. They also include a border of cells around


### PR DESCRIPTION
-Renamed evp_prep1 and 2 to dyn_prep1 and 2.

-Renamed evp_finish to dyn_finish

-Added OMP instruction for basal_stress calculation

-Changed the order of Deltasw and Deltase so that these deformations are calculated in the same order as the other ones (i.e., ne-nw-sw-se).

- Developer(s): JF Lemieux

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Is the documentation being updated with this PR? (Y/N) Y
If not, does the documentation need to be updated separately at a later time? (Y/N)
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
