### PR TITLE
update icepack and fix 2 failing tests

### DIFF
--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -610,7 +610,6 @@
          if (my_task == master_task) &
             write(nu_diag,*) 'WARNING: ice_ic = none or default, setting restart flags to .false.'
          restart = .false.
-         restart_ext =  .false. 
          restart_aero =  .false. 
          restart_age =  .false. 
          restart_fy =  .false. 
@@ -622,6 +621,8 @@
 !         restart_bgc =  .false. 
 !         restart_hbrine =  .false. 
 !         restart_zsal =  .false. 
+! tcraig, OK to leave as true, needed for boxrestore case
+!         restart_ext =  .false. 
       endif
 
       if (trim(runtype) == 'initial' .and. .not.(restart) .and. &

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -47,7 +47,7 @@ EOF0
 if (${ICE_MACHINE} =~ cheyenne*) then
 cat >> ${jobfile} << EOFB
 #PBS -j oe 
-#PBS -m ae 
+###PBS -m ae 
 #PBS -V
 #PBS -q ${queue}
 #PBS -N ${ICE_CASENAME}
@@ -59,7 +59,7 @@ EOFB
 else if (${ICE_MACHINE} =~ hobart*) then
 cat >> ${jobfile} << EOFB
 #PBS -j oe 
-#PBS -m ae 
+###PBS -m ae 
 #PBS -V
 #PBS -q short
 #PBS -N ${ICE_CASENAME}

--- a/configuration/scripts/machines/env.gordon_intel
+++ b/configuration/scripts/machines/env.gordon_intel
@@ -9,11 +9,11 @@ module unload PrgEnv-pgi
 module load PrgEnv-intel/5.2.40
 
 module unload intel
-module load intel/14.0.2.144
+module load intel/17.0.2.174
 
 module unload cray-mpich
 module unload cray-mpich2
-module load cray-mpich/7.2.4
+module load cray-mpich/7.3.2
 
 module unload netcdf
 module unload cray-netcdf

--- a/configuration/scripts/options/set_env.iobinary
+++ b/configuration/scripts/options/set_env.iobinary
@@ -1,0 +1,1 @@
+setenv ICE_IOTYPE  binary

--- a/configuration/scripts/options/set_nml.iobinary
+++ b/configuration/scripts/options/set_nml.iobinary
@@ -1,0 +1,1 @@
+ice_ic = 'default'

--- a/configuration/scripts/tests/base_suite.ts
+++ b/configuration/scripts/tests/base_suite.ts
@@ -8,7 +8,7 @@ smoke          gx3     8x2        diag24,run1year,medium
 smoke          gx3     4x2        diag1,run5day          smoke_gx3_8x2_diag1_run5day
 smoke          gx3     4x1        diag1,run5day,thread   smoke_gx3_8x2_diag1_run5day
 decomp         gx3     4x2x25x29x5
-restart        gx1    40x4        debug,droundrobin
+restart        gx1     40x4       droundrobin,short
 restart        gx3     4x4        none
 restart        gx3     6x2        alt01
 restart        gx3     8x2        alt02

--- a/configuration/scripts/tests/base_suite.ts
+++ b/configuration/scripts/tests/base_suite.ts
@@ -10,6 +10,7 @@ smoke          gx3     4x1        diag1,run5day,thread   smoke_gx3_8x2_diag1_run
 decomp         gx3     4x2x25x29x5
 restart        gx1     40x4       droundrobin,short
 restart        gx3     4x4        none
+restart        gx3     4x4        iobinary
 restart        gx3     6x2        alt01
 restart        gx3     8x2        alt02
 restart        gx3     4x2        alt03

--- a/configuration/scripts/tests/baseline.script
+++ b/configuration/scripts/tests/baseline.script
@@ -47,6 +47,7 @@ if (${ICE_BASECOM} != ${ICE_SPVAL}) then
   if (-e ${baseline_data} ) then
     if ( { cmp -s ${test_data} ${baseline_data} } ) then
       echo "PASS ${ICE_TESTNAME} compare ${ICE_BASECOM} ${btimeloop} ${bdynamics} ${bcolumn}" >> ${ICE_CASEDIR}/test_output
+      echo "Regression baseline and test dataset are identical"
     else
       echo "FAIL ${ICE_TESTNAME} compare ${ICE_BASECOM} ${btimeloop} ${bdynamics} ${bcolumn} different-data" >> ${ICE_CASEDIR}/test_output
       echo "Regression baseline and test dataset are different"
@@ -84,6 +85,7 @@ if (${ICE_BFBCOMP} != ${ICE_SPVAL}) then
   if (-e ${comp_data} && -e ${test_data}) then
     if ( { cmp -s ${test_data} ${comp_data} } ) then
       echo "PASS ${ICE_TESTNAME} bfbcomp ${ICE_BFBCOMP}" >> ${ICE_CASEDIR}/test_output
+      echo "bfbcomp and test dataset are identical"
     else
       echo "FAIL ${ICE_TESTNAME} bfbcomp ${ICE_BFBCOMP} different-data" >> ${ICE_CASEDIR}/test_output
       echo "bfbcomp and test dataset are different"


### PR DESCRIPTION
Update icepack version to current master, fix 2 failing tests, add binary restart test, update gordon intel compiler version

- Developer(s): tcraig

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? bit-for-bit

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N

- Other Relevant Details:

This change is bit-for-bit, see full test results here for conrad, hash 8b44ba1050ae6636, 

https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks

There are still failing tests, but the boxrestore and medium test now run and validate.   The gx1 needs a mod in icepack which will be coming soon.  Add binary restart test, need to update the validation process of multiple binary restart files.  Update the gordon intel compiler version to be consistent with conrad, was causing some test failures.