### PR TITLE
Alloc dyn

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
@@ -34,7 +34,8 @@
 
       implicit none
       private
-      public :: eap, init_eap, write_restart_eap, read_restart_eap
+      public :: eap, init_eap, write_restart_eap, read_restart_eap, &
+                alloc_dyn_eap
 
       ! Look-up table needed for calculating structure tensor
       integer (int_kind), parameter :: & 
@@ -45,12 +46,12 @@
       real (kind=dbl_kind), dimension (nx_yield,ny_yield,na_yield) :: & 
         s11r, s12r, s22r, s11s, s12s, s22s           
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable :: &
          a11_1, a11_2, a11_3, a11_4,                  & ! components of 
          a12_1, a12_2, a12_3, a12_4                     ! structure tensor
 
       ! history
-      real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension(:,:,:), allocatable, public :: &
          e11      , & ! components of strain rate tensor (1/s)
          e12      , & 
          e22      , &
@@ -66,6 +67,38 @@
 !=======================================================================
 
       contains
+
+!=======================================================================
+!
+! Allocate space for all variables 
+!
+      subroutine alloc_dyn_eap
+
+      integer (int_kind) :: ierr
+
+      allocate( a11_1        (nx_block,ny_block,max_blocks), &
+                a11_2        (nx_block,ny_block,max_blocks), &
+                a11_3        (nx_block,ny_block,max_blocks), &
+                a11_4        (nx_block,ny_block,max_blocks), &
+                a12_1        (nx_block,ny_block,max_blocks), &
+                a12_2        (nx_block,ny_block,max_blocks), &
+                a12_3        (nx_block,ny_block,max_blocks), &
+                a12_4        (nx_block,ny_block,max_blocks), &
+                e11          (nx_block,ny_block,max_blocks), &
+                e12          (nx_block,ny_block,max_blocks), &
+                e22          (nx_block,ny_block,max_blocks), &
+                yieldstress11(nx_block,ny_block,max_blocks), &
+                yieldstress12(nx_block,ny_block,max_blocks), &
+                yieldstress22(nx_block,ny_block,max_blocks), &
+                s11          (nx_block,ny_block,max_blocks), &
+                s12          (nx_block,ny_block,max_blocks), &
+                s22          (nx_block,ny_block,max_blocks), &
+                a11          (nx_block,ny_block,max_blocks), &
+                a12          (nx_block,ny_block,max_blocks), &
+                stat=ierr)
+      if (ierr/=0) call abort_ice('(alloc_dyn_eap): Out of memory')
+
+      end subroutine alloc_dyn_eap
 
 !=======================================================================
 !

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -22,7 +22,8 @@
       implicit none
       private
       public :: init_evp, set_evp_parameters, stepu, principal_stress, &
-                dyn_prep1, dyn_prep2, dyn_finish, basal_stress_coeff
+                dyn_prep1, dyn_prep2, dyn_finish, basal_stress_coeff,  &
+                alloc_dyn_shared
 
       ! namelist parameters
 
@@ -61,7 +62,7 @@
       real (kind=dbl_kind), allocatable, public :: & 
          fcor_blk(:,:,:)   ! Coriolis parameter (1/s)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: & 
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          uvel_init, & ! x-component of velocity (m/s), beginning of timestep
          vvel_init    ! y-component of velocity (m/s), beginning of timestep
          
@@ -75,6 +76,22 @@
 !=======================================================================
 
       contains
+
+!=======================================================================
+!
+! Allocate space for all variables 
+!
+      subroutine alloc_dyn_shared
+
+      integer (int_kind) :: ierr
+
+      allocate( &
+         uvel_init (nx_block,ny_block,max_blocks), & ! x-component of velocity (m/s), beginning of timestep
+         vvel_init (nx_block,ny_block,max_blocks), & ! y-component of velocity (m/s), beginning of timestep
+         stat=ierr)
+      if (ierr/=0) call abort_ice('(alloc_dyn_shared): Out of memory')
+
+      end subroutine alloc_dyn_shared
 
 !=======================================================================
 

--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -27,13 +27,13 @@
       implicit none
       private
       public :: init_coupler_flux, init_history_therm, init_history_dyn, &
-                init_flux_ocn, init_flux_atm, scale_fluxes
+                init_flux_ocn, init_flux_atm, scale_fluxes, alloc_flux
 
       !-----------------------------------------------------------------
       ! Dynamics component
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
 
        ! in from atmos (if .not.calc_strair)  
          strax   , & ! wind stress components (N/m^2)
@@ -57,7 +57,7 @@
 
        ! diagnostic
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          sig1    , & ! normalized principal stress component
          sig2    , & ! normalized principal stress component
          sigP    , & ! internal ice pressure (N/m)
@@ -80,7 +80,7 @@
          opening     ! rate of opening due to divergence/shear (1/s)
 
       real (kind=dbl_kind), & 
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
        ! ridging diagnostics in categories
          dardg1ndt, & ! rate of area loss by ridging ice (1/s)
          dardg2ndt, & ! rate of area gain by new ridges (1/s)
@@ -96,19 +96,19 @@
 
        ! restart
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
        ! ice stress tensor in each corner of T cell (kg/s^2)
          stressp_1, stressp_2, stressp_3, stressp_4 , & ! sigma11+sigma22
          stressm_1, stressm_2, stressm_3, stressm_4 , & ! sigma11-sigma22
          stress12_1,stress12_2,stress12_3,stress12_4    ! sigma12
 
       logical (kind=log_kind), &
-         dimension (nx_block,ny_block,max_blocks), public :: &
+         dimension (:,:,:), allocatable, public :: &
          iceumask   ! ice extent mask (U-cell)
 
        ! internal
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          fm       , & ! Coriolis param. * mass in U-cell (kg/s)
          Tbu          ! coefficient for basal stress (N/m^2)
 
@@ -118,7 +118,7 @@
 
        ! in from atmosphere (if calc_Tsfc)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          zlvl    , & ! atm level height (m)
          uatm    , & ! wind velocity components (m/s)
          vatm    , &
@@ -139,7 +139,7 @@
        ! not per ice area. When in standalone mode, these are per ice area.
 
       real (kind=dbl_kind), & 
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          fsurfn_f   , & ! net flux to top surface, excluding fcondtop
          fcondtopn_f, & ! downward cond flux at top surface (W m-2)
          fsensn_f   , & ! sensible heat flux (W m-2)
@@ -147,13 +147,13 @@
 
        ! in from atmosphere
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          frain   , & ! rainfall rate (kg/m^2 s)
          fsnow       ! snowfall rate (kg/m^2 s)
 
        ! in from ocean
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          sss     , & ! sea surface salinity (ppt)
          sst     , & ! sea surface temperature (C)
          frzmlt  , & ! freezing/melting potential (W/m^2)
@@ -167,7 +167,7 @@
        ! out to atmosphere (if calc_Tsfc)
        ! note Tsfc is in ice_state.F
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          fsens   , & ! sensible heat flux (W/m^2)
          flat    , & ! latent heat flux   (W/m^2)
          fswabs  , & ! shortwave flux absorbed in ice and ocean (W/m^2)
@@ -179,7 +179,7 @@
          evap        ! evaporative water flux (kg/m^2/s)
 
        ! albedos aggregated over categories (if calc_Tsfc)
-      real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          alvdr   , & ! visible, direct   (fraction)
          alidr   , & ! near-ir, direct   (fraction)
          alvdf   , & ! visible, diffuse  (fraction)
@@ -202,13 +202,13 @@
          alidf_init    ! near-ir, diffuse  (fraction)
 
       real (kind=dbl_kind), &
-         dimension(nx_block,ny_block,max_blocks,max_nstrm), public :: &
+         dimension(:,:,:,:), allocatable, public :: &
          albcnt       ! counter for zenith angle
 
        ! out to ocean 
        ! (Note CICE_IN_NEMO does not use these for coupling.  
        !  It uses fresh_ai,fsalt_ai,fhocn_ai and fswthru_ai)
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          fpond   , & ! fresh water flux to ponds (kg/m^2/s)
          fresh   , & ! fresh water flux to ocean (kg/m^2/s)
          fsalt   , & ! salt flux to ocean (kg/m^2/s)
@@ -218,7 +218,7 @@
        ! internal
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,max_blocks), public :: &
+         dimension (:,:,:), allocatable, public :: &
          fswfac  , & ! for history
          scale_factor! scaling factor for shortwave components
 
@@ -227,21 +227,21 @@
          l_mpond_fresh   ! if true, include freshwater feedback from meltponds
                          ! when running in ice-ocean or coupled configuration
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          meltsn      , & ! snow melt in category n (m)
          melttn      , & ! top melt in category n (m)
          meltbn      , & ! bottom melt in category n (m)
          congeln     , & ! congelation ice formation in category n (m)
          snoicen         ! snow-ice formation in category n (m)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          keffn_top       ! effective thermal conductivity of the top ice layer 
                          ! on categories (W/m^2/K)
 
       ! quantities passed from ocean mixed layer to atmosphere
       ! (for running with CAM)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          strairx_ocn , & ! stress on ocean by air, x-direction
          strairy_ocn , & ! stress on ocean by air, y-direction
          fsens_ocn   , & ! sensible heat flux (W/m^2)
@@ -257,7 +257,7 @@
 
       ! diagnostic
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          fsurf , & ! net surface heat flux (excluding fcondtop)(W/m^2)
          fcondtop,&! top surface conductive flux        (W/m^2)
          fbot,   & ! heat flux at bottom surface of ice (excluding excess) (W/m^2)
@@ -277,7 +277,7 @@
          frazil_diag ! frazil ice growth diagnostic (m/step-->cm/day)
          
       real (kind=dbl_kind), & 
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          fsurfn,   & ! category fsurf
          fcondtopn,& ! category fcondtop
          fsensn,   & ! category sensible heat flux
@@ -290,14 +290,14 @@
       ! (The others suffer from problem of incorrect values at grid boxes
       !  that change from an ice free state to an icy state.)
     
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          fresh_ai, & ! fresh water flux to ocean (kg/m^2/s)
          fsalt_ai, & ! salt flux to ocean (kg/m^2/s)
          fhocn_ai, & ! net heat flux to ocean (W/m^2)
          fswthru_ai  ! shortwave penetrating to ocean (W/m^2)
 
       ! Used with data assimilation in hadgem drivers
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          fresh_da, & ! fresh water flux to ocean due to data assim (kg/m^2/s)
          fsalt_da    ! salt flux to ocean due to data assimilation(kg/m^2/s)
 
@@ -305,20 +305,204 @@
       ! internal
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          rside   , & ! fraction of ice that melts laterally
          fsw     , & ! incoming shortwave radiation (W/m^2)
          coszen  , & ! cosine solar zenith angle, < 0 for sun below horizon 
          rdg_conv, & ! convergence term for ridging (1/s)
          rdg_shear   ! shear term for ridging (1/s)
  
-      real (kind=dbl_kind), dimension(nx_block,ny_block,nilyr+1,max_blocks), public :: &
+      real (kind=dbl_kind), dimension(:,:,:,:), allocatable, public :: &
          salinz    ,&   ! initial salinity  profile (ppt)   
          Tmltz          ! initial melting temperature (^oC)
 
 !=======================================================================
 
       contains
+
+!=======================================================================
+!
+! Allocate space for all variables 
+!
+      subroutine alloc_flux
+
+      integer (int_kind) :: ierr
+
+      allocate( &
+         strax      (nx_block,ny_block,max_blocks), & ! wind stress components (N/m^2)
+         stray      (nx_block,ny_block,max_blocks), & ! 
+         uocn       (nx_block,ny_block,max_blocks), & ! ocean current, x-direction (m/s)
+         vocn       (nx_block,ny_block,max_blocks), & ! ocean current, y-direction (m/s)
+         ss_tltx    (nx_block,ny_block,max_blocks), & ! sea surface slope, x-direction (m/m)
+         ss_tlty    (nx_block,ny_block,max_blocks), & ! sea surface slope, y-direction
+         hwater     (nx_block,ny_block,max_blocks), & ! water depth for basal stress calc (landfast ice) 
+         strairxT   (nx_block,ny_block,max_blocks), & ! stress on ice by air, x-direction
+         strairyT   (nx_block,ny_block,max_blocks), & ! stress on ice by air, y-direction
+         strocnxT   (nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction
+         strocnyT   (nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction
+         sig1       (nx_block,ny_block,max_blocks), & ! normalized principal stress component
+         sig2       (nx_block,ny_block,max_blocks), & ! normalized principal stress component
+         sigP       (nx_block,ny_block,max_blocks), & ! internal ice pressure (N/m)
+         taubx      (nx_block,ny_block,max_blocks), & ! basal stress (x) (N/m^2)
+         tauby      (nx_block,ny_block,max_blocks), & ! basal stress (y) (N/m^2)
+         strairx    (nx_block,ny_block,max_blocks), & ! stress on ice by air, x-direction
+         strairy    (nx_block,ny_block,max_blocks), & ! stress on ice by air, y-direction
+         strocnx    (nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction
+         strocny    (nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction
+         strtltx    (nx_block,ny_block,max_blocks), & ! stress due to sea surface slope, x-direction
+         strtlty    (nx_block,ny_block,max_blocks), & ! stress due to sea surface slope, y-direction
+         strintx    (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, x (N/m^2)
+         strinty    (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, y (N/m^2)
+         daidtd     (nx_block,ny_block,max_blocks), & ! ice area tendency due to transport   (1/s)
+         dvidtd     (nx_block,ny_block,max_blocks), & ! ice volume tendency due to transport (m/s)
+         dagedtd    (nx_block,ny_block,max_blocks), & ! ice age tendency due to transport (s/s)
+         dardg1dt   (nx_block,ny_block,max_blocks), & ! rate of area loss by ridging ice (1/s)
+         dardg2dt   (nx_block,ny_block,max_blocks), & ! rate of area gain by new ridges (1/s)
+         dvirdgdt   (nx_block,ny_block,max_blocks), & ! rate of ice volume ridged (m/s)
+         opening    (nx_block,ny_block,max_blocks), & ! rate of opening due to divergence/shear (1/s)
+         stressp_1  (nx_block,ny_block,max_blocks), & ! sigma11+sigma22
+         stressp_2  (nx_block,ny_block,max_blocks), & ! sigma11+sigma22
+         stressp_3  (nx_block,ny_block,max_blocks), & ! sigma11+sigma22
+         stressp_4  (nx_block,ny_block,max_blocks), & ! sigma11+sigma22
+         stressm_1  (nx_block,ny_block,max_blocks), & ! sigma11-sigma22
+         stressm_2  (nx_block,ny_block,max_blocks), & ! sigma11-sigma22
+         stressm_3  (nx_block,ny_block,max_blocks), & ! sigma11-sigma22
+         stressm_4  (nx_block,ny_block,max_blocks), & ! sigma11-sigma22
+         stress12_1 (nx_block,ny_block,max_blocks), & ! sigma12
+         stress12_2 (nx_block,ny_block,max_blocks), & ! sigma12
+         stress12_3 (nx_block,ny_block,max_blocks), & ! sigma12
+         stress12_4 (nx_block,ny_block,max_blocks), & ! sigma12
+         iceumask   (nx_block,ny_block,max_blocks), & ! ice extent mask (U-cell)
+         fm         (nx_block,ny_block,max_blocks), & ! Coriolis param. * mass in U-cell (kg/s)
+         Tbu        (nx_block,ny_block,max_blocks), & ! coefficient for basal stress (landfast ice)
+         zlvl       (nx_block,ny_block,max_blocks), & ! atm level height (m)
+         uatm       (nx_block,ny_block,max_blocks), & ! wind velocity components (m/s)
+         vatm       (nx_block,ny_block,max_blocks), &
+         wind       (nx_block,ny_block,max_blocks), & ! wind speed (m/s)
+         potT       (nx_block,ny_block,max_blocks), & ! air potential temperature  (K)
+         Tair       (nx_block,ny_block,max_blocks), & ! air temperature  (K)
+         Qa         (nx_block,ny_block,max_blocks), & ! specific humidity (kg/kg)
+         rhoa       (nx_block,ny_block,max_blocks), & ! air density (kg/m^3)
+         swvdr      (nx_block,ny_block,max_blocks), & ! sw down, visible, direct  (W/m^2)
+         swvdf      (nx_block,ny_block,max_blocks), & ! sw down, visible, diffuse (W/m^2)
+         swidr      (nx_block,ny_block,max_blocks), & ! sw down, near IR, direct  (W/m^2)
+         swidf      (nx_block,ny_block,max_blocks), & ! sw down, near IR, diffuse (W/m^2)
+         flw        (nx_block,ny_block,max_blocks), & ! incoming longwave radiation (W/m^2)
+         frain      (nx_block,ny_block,max_blocks), & ! rainfall rate (kg/m^2 s)
+         fsnow      (nx_block,ny_block,max_blocks), & ! snowfall rate (kg/m^2 s)
+         sss        (nx_block,ny_block,max_blocks), & ! sea surface salinity (ppt)
+         sst        (nx_block,ny_block,max_blocks), & ! sea surface temperature (C)
+         frzmlt     (nx_block,ny_block,max_blocks), & ! freezing/melting potential (W/m^2)
+         frzmlt_init(nx_block,ny_block,max_blocks), & ! frzmlt used in current time step (W/m^2)
+         Tf         (nx_block,ny_block,max_blocks), & ! freezing temperature (C)
+         qdp        (nx_block,ny_block,max_blocks), & ! deep ocean heat flux (W/m^2), negative upward
+         hmix       (nx_block,ny_block,max_blocks), & ! mixed layer depth (m)
+         daice_da   (nx_block,ny_block,max_blocks), & ! data assimilation concentration increment rate (concentration s-1)(only used in hadgem drivers)
+         fsens      (nx_block,ny_block,max_blocks), & ! sensible heat flux (W/m^2)
+         flat       (nx_block,ny_block,max_blocks), & ! latent heat flux   (W/m^2)
+         fswabs     (nx_block,ny_block,max_blocks), & ! shortwave flux absorbed in ice and ocean (W/m^2)
+         fswint_ai  (nx_block,ny_block,max_blocks), & ! SW absorbed in ice interior below surface (W/m^2)
+         flwout     (nx_block,ny_block,max_blocks), & ! outgoing longwave radiation (W/m^2)
+         Tref       (nx_block,ny_block,max_blocks), & ! 2m atm reference temperature (K)
+         Qref       (nx_block,ny_block,max_blocks), & ! 2m atm reference spec humidity (kg/kg)
+         Uref       (nx_block,ny_block,max_blocks), & ! 10m atm reference wind speed (m/s)
+         evap       (nx_block,ny_block,max_blocks), & ! evaporative water flux (kg/m^2/s)
+         alvdr      (nx_block,ny_block,max_blocks), & ! visible, direct   (fraction)
+         alidr      (nx_block,ny_block,max_blocks), & ! near-ir, direct   (fraction)
+         alvdf      (nx_block,ny_block,max_blocks), & ! visible, diffuse  (fraction)
+         alidf      (nx_block,ny_block,max_blocks), & ! near-ir, diffuse  (fraction)
+         alvdr_ai   (nx_block,ny_block,max_blocks), & ! visible, direct   (fraction)
+         alidr_ai   (nx_block,ny_block,max_blocks), & ! near-ir, direct   (fraction)
+         alvdf_ai   (nx_block,ny_block,max_blocks), & ! visible, diffuse  (fraction)
+         alidf_ai   (nx_block,ny_block,max_blocks), & ! near-ir, diffuse  (fraction)
+         albice     (nx_block,ny_block,max_blocks), & ! bare ice albedo
+         albsno     (nx_block,ny_block,max_blocks), & ! snow albedo
+         albpnd     (nx_block,ny_block,max_blocks), & ! melt pond albedo
+         apeff_ai   (nx_block,ny_block,max_blocks), & ! effective pond area used for radiation calculation
+         snowfrac   (nx_block,ny_block,max_blocks), & ! snow fraction used in radiation
+         alvdr_init (nx_block,ny_block,max_blocks), & ! visible, direct   (fraction)
+         alidr_init (nx_block,ny_block,max_blocks), & ! near-ir, direct   (fraction)
+         alvdf_init (nx_block,ny_block,max_blocks), & ! visible, diffuse  (fraction)
+         alidf_init (nx_block,ny_block,max_blocks), & ! near-ir, diffuse  (fraction)
+         fpond      (nx_block,ny_block,max_blocks), & ! fresh water flux to ponds (kg/m^2/s)
+         fresh      (nx_block,ny_block,max_blocks), & ! fresh water flux to ocean (kg/m^2/s)
+         fsalt      (nx_block,ny_block,max_blocks), & ! salt flux to ocean (kg/m^2/s)
+         fhocn      (nx_block,ny_block,max_blocks), & ! net heat flux to ocean (W/m^2)
+         fswthru    (nx_block,ny_block,max_blocks), & ! shortwave penetrating to ocean (W/m^2)
+         fswfac     (nx_block,ny_block,max_blocks), & ! for history
+         scale_factor (nx_block,ny_block,max_blocks), & ! scaling factor for shortwave components
+         strairx_ocn(nx_block,ny_block,max_blocks), & ! stress on ocean by air, x-direction
+         strairy_ocn(nx_block,ny_block,max_blocks), & ! stress on ocean by air, y-direction
+         fsens_ocn  (nx_block,ny_block,max_blocks), & ! sensible heat flux (W/m^2)
+         flat_ocn   (nx_block,ny_block,max_blocks), & ! latent heat flux   (W/m^2)
+         flwout_ocn (nx_block,ny_block,max_blocks), & ! outgoing longwave radiation (W/m^2)
+         evap_ocn   (nx_block,ny_block,max_blocks), & ! evaporative water flux (kg/m^2/s)
+         alvdr_ocn  (nx_block,ny_block,max_blocks), & ! visible, direct   (fraction)
+         alidr_ocn  (nx_block,ny_block,max_blocks), & ! near-ir, direct   (fraction)
+         alvdf_ocn  (nx_block,ny_block,max_blocks), & ! visible, diffuse  (fraction)
+         alidf_ocn  (nx_block,ny_block,max_blocks), & ! near-ir, diffuse  (fraction)
+         Tref_ocn   (nx_block,ny_block,max_blocks), & ! 2m atm reference temperature (K)
+         Qref_ocn   (nx_block,ny_block,max_blocks), & ! 2m atm reference spec humidity (kg/kg)
+         fsurf      (nx_block,ny_block,max_blocks), & ! net surface heat flux (excluding fcondtop)(W/m^2)
+         fcondtop   (nx_block,ny_block,max_blocks), & ! top surface conductive flux        (W/m^2)
+         fbot       (nx_block,ny_block,max_blocks), & ! heat flux at bottom surface of ice (excluding excess) (W/m^2)
+         congel     (nx_block,ny_block,max_blocks), & ! basal ice growth         (m/step-->cm/day)
+         frazil     (nx_block,ny_block,max_blocks), & ! frazil ice growth        (m/step-->cm/day)
+         snoice     (nx_block,ny_block,max_blocks), & ! snow-ice formation       (m/step-->cm/day)
+         meltt      (nx_block,ny_block,max_blocks), & ! top ice melt             (m/step-->cm/day)
+         melts      (nx_block,ny_block,max_blocks), & ! snow melt                (m/step-->cm/day)
+         meltb      (nx_block,ny_block,max_blocks), & ! basal ice melt           (m/step-->cm/day)
+         meltl      (nx_block,ny_block,max_blocks), & ! lateral ice melt         (m/step-->cm/day)
+         dsnow      (nx_block,ny_block,max_blocks), & ! change in snow thickness (m/step-->cm/day)
+         daidtt     (nx_block,ny_block,max_blocks), & ! ice area tendency thermo.   (s^-1)
+         dvidtt     (nx_block,ny_block,max_blocks), & ! ice volume tendency thermo. (m/s)
+         dagedtt    (nx_block,ny_block,max_blocks), & ! ice age tendency thermo.    (s/s)
+         mlt_onset  (nx_block,ny_block,max_blocks), & ! day of year that sfc melting begins
+         frz_onset  (nx_block,ny_block,max_blocks), & ! day of year that freezing begins (congel or frazil)
+         frazil_diag(nx_block,ny_block,max_blocks), & ! frazil ice growth diagnostic (m/step-->cm/day)
+         fresh_ai   (nx_block,ny_block,max_blocks), & ! fresh water flux to ocean (kg/m^2/s)
+         fsalt_ai   (nx_block,ny_block,max_blocks), & ! salt flux to ocean (kg/m^2/s)
+         fhocn_ai   (nx_block,ny_block,max_blocks), & ! net heat flux to ocean (W/m^2)
+         fswthru_ai (nx_block,ny_block,max_blocks), &  ! shortwave penetrating to ocean (W/m^2)
+         fresh_da   (nx_block,ny_block,max_blocks), & ! fresh water flux to ocean due to data assim (kg/m^2/s)
+         fsalt_da   (nx_block,ny_block,max_blocks), & ! salt flux to ocean due to data assimilation(kg/m^2/s)
+         rside      (nx_block,ny_block,max_blocks), & ! fraction of ice that melts laterally
+         fsw        (nx_block,ny_block,max_blocks), & ! incoming shortwave radiation (W/m^2)
+         coszen     (nx_block,ny_block,max_blocks), & ! cosine solar zenith angle, < 0 for sun below horizon 
+         rdg_conv   (nx_block,ny_block,max_blocks), & ! convergence term for ridging (1/s)
+         rdg_shear  (nx_block,ny_block,max_blocks), & ! shear term for ridging (1/s)
+         dardg1ndt  (nx_block,ny_block,ncat,max_blocks), & ! rate of area loss by ridging ice (1/s)
+         dardg2ndt  (nx_block,ny_block,ncat,max_blocks), & ! rate of area gain by new ridges (1/s)
+         dvirdgndt  (nx_block,ny_block,ncat,max_blocks), & ! rate of ice volume ridged (m/s)
+         aparticn   (nx_block,ny_block,ncat,max_blocks), & ! participation function
+         krdgn      (nx_block,ny_block,ncat,max_blocks), & ! mean ridge thickness/thickness of ridging ice
+         ardgn      (nx_block,ny_block,ncat,max_blocks), & ! fractional area of ridged ice
+         vrdgn      (nx_block,ny_block,ncat,max_blocks), & ! volume of ridged ice
+         araftn     (nx_block,ny_block,ncat,max_blocks), & ! rafting ice area
+         vraftn     (nx_block,ny_block,ncat,max_blocks), & ! rafting ice volume 
+         aredistn   (nx_block,ny_block,ncat,max_blocks), & ! redistribution function: fraction of new ridge area
+         vredistn   (nx_block,ny_block,ncat,max_blocks), & ! redistribution function: fraction of new ridge volume
+         fsurfn_f   (nx_block,ny_block,ncat,max_blocks), & ! net flux to top surface, excluding fcondtop
+         fcondtopn_f(nx_block,ny_block,ncat,max_blocks), & ! downward cond flux at top surface (W m-2)
+         fsensn_f   (nx_block,ny_block,ncat,max_blocks), & ! sensible heat flux (W m-2)
+         flatn_f    (nx_block,ny_block,ncat,max_blocks), & ! latent heat flux (W m-2)
+         meltsn     (nx_block,ny_block,ncat,max_blocks), & ! snow melt in category n (m)
+         melttn     (nx_block,ny_block,ncat,max_blocks), & ! top melt in category n (m)
+         meltbn     (nx_block,ny_block,ncat,max_blocks), & ! bottom melt in category n (m)
+         congeln    (nx_block,ny_block,ncat,max_blocks), & ! congelation ice formation in category n (m)
+         snoicen    (nx_block,ny_block,ncat,max_blocks), & ! snow-ice formation in category n (m)
+         keffn_top  (nx_block,ny_block,ncat,max_blocks), & ! effective thermal conductivity of the top ice layer
+         fsurfn     (nx_block,ny_block,ncat,max_blocks), & ! category fsurf
+         fcondtopn  (nx_block,ny_block,ncat,max_blocks), & ! category fcondtop
+         fsensn     (nx_block,ny_block,ncat,max_blocks), & ! category sensible heat flux
+         flatn      (nx_block,ny_block,ncat,max_blocks), & ! category latent heat flux
+         albcnt     (nx_block,ny_block,max_blocks,max_nstrm), & ! counter for zenith angle
+         salinz     (nx_block,ny_block,nilyr+1,max_blocks), & ! initial salinity  profile (ppt)   
+         Tmltz      (nx_block,ny_block,nilyr+1,max_blocks), & ! initial melting temperature (^oC)
+         stat=ierr)
+      if (ierr/=0) call abort_ice('(alloc_flux): Out of memory')
+
+      end subroutine alloc_flux
 
 !=======================================================================
 

--- a/cicecore/cicedynB/general/ice_flux_bgc.F90
+++ b/cicecore/cicedynB/general/ice_flux_bgc.F90
@@ -20,32 +20,32 @@
       implicit none
       private
 
-      public :: bgcflux_ice_to_ocn 
+      public :: bgcflux_ice_to_ocn, alloc_flux_bgc
 
       ! in from atmosphere
 
       real (kind=dbl_kind), &   !coupling variable for both tr_aero and tr_zaero
-         dimension (nx_block,ny_block,icepack_max_aero,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          faero_atm   ! aerosol deposition rate (kg/m^2 s)   
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          flux_bio_atm  ! all bio fluxes to ice from atmosphere
 
       ! in from ocean
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,icepack_max_aero,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          faero_ocn   ! aerosol flux to ocean  (kg/m^2/s)
 
       ! out to ocean 
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          flux_bio   , & ! all bio fluxes to ocean
          flux_bio_ai    ! all bio fluxes to ocean, averaged over grid cell
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          fzsal_ai, & ! salt flux to ocean from zsalinity (kg/m^2/s) 
          fzsal_g_ai  ! gravity drainage salt flux to ocean (kg/m^2/s) 
 
@@ -54,11 +54,11 @@
       logical (kind=log_kind), public :: &
          cpl_bgc         ! switch to couple BGC via drivers
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          hin_old     , & ! old ice thickness
          dsnown          ! change in snow thickness in category n (m)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          nit        , & ! ocean nitrate (mmol/m^3)          
          amm        , & ! ammonia/um (mmol/m^3)
          sil        , & ! silicate (mmol/m^3)
@@ -73,32 +73,81 @@
          fhum       , & ! ice-ocean humic material carbon (mmol/m^2/s), positive to ocean
          fdust          ! ice-ocean dust flux (kg/m^2/s), positive to ocean
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,icepack_max_algae, max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          algalN     , & ! ocean algal nitrogen (mmol/m^3) (diatoms, pico, phaeo)
          falgalN        ! ice-ocean algal nitrogen flux (mmol/m^2/s) (diatoms, pico, phaeo)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,icepack_max_doc, max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          doc         , & ! ocean doc (mmol/m^3)  (saccharids, lipids, tbd )
          fdoc            ! ice-ocean doc flux (mmol/m^2/s)  (saccharids, lipids, tbd)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,icepack_max_don, max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          don         , & ! ocean don (mmol/m^3) (proteins and amino acids)
          fdon            ! ice-ocean don flux (mmol/m^2/s) (proteins and amino acids)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,icepack_max_dic, max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          dic         , & ! ocean dic (mmol/m^3) 
          fdic            ! ice-ocean dic flux (mmol/m^2/s) 
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,icepack_max_fe, max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          fed, fep    , & ! ocean dissolved and particulate fe (nM) 
          ffed, ffep      ! ice-ocean dissolved and particulate fe flux (umol/m^2/s) 
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,icepack_max_aero, max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          zaeros          ! ocean aerosols (mmol/m^3) 
 
 !=======================================================================
 
       contains
+
+!=======================================================================
+!
+! Allocate space for all variables 
+!
+      subroutine alloc_flux_bgc
+
+      integer (int_kind) :: ierr
+
+      allocate( &
+         fzsal_ai    (nx_block,ny_block,max_blocks), & ! salt flux to ocean from zsalinity (kg/m^2/s) 
+         fzsal_g_ai  (nx_block,ny_block,max_blocks), & ! gravity drainage salt flux to ocean (kg/m^2/s) 
+         nit         (nx_block,ny_block,max_blocks), & ! ocean nitrate (mmol/m^3)          
+         amm         (nx_block,ny_block,max_blocks), & ! ammonia/um (mmol/m^3)
+         sil         (nx_block,ny_block,max_blocks), & ! silicate (mmol/m^3)
+         dmsp        (nx_block,ny_block,max_blocks), & ! dmsp (mmol/m^3)
+         dms         (nx_block,ny_block,max_blocks), & ! dms (mmol/m^3)
+         hum         (nx_block,ny_block,max_blocks), & ! humic material carbon (mmol/m^3)
+         fnit        (nx_block,ny_block,max_blocks), & ! ice-ocean nitrate flux (mmol/m^2/s), positive to ocean
+         famm        (nx_block,ny_block,max_blocks), & ! ice-ocean ammonia/um flux (mmol/m^2/s), positive to ocean
+         fsil        (nx_block,ny_block,max_blocks), & ! ice-ocean silicate flux (mmol/m^2/s), positive to ocean
+         fdmsp       (nx_block,ny_block,max_blocks), & ! ice-ocean dmsp (mmol/m^2/s), positive to ocean
+         fdms        (nx_block,ny_block,max_blocks), & ! ice-ocean dms (mmol/m^2/s), positive to ocean
+         fhum        (nx_block,ny_block,max_blocks), & ! ice-ocean humic material carbon (mmol/m^2/s), positive to ocean
+         fdust       (nx_block,ny_block,max_blocks), & ! ice-ocean dust flux (kg/m^2/s), positive to ocean
+         hin_old     (nx_block,ny_block,ncat,max_blocks), & ! old ice thickness
+         dsnown      (nx_block,ny_block,ncat,max_blocks), & ! change in snow thickness in category n (m)
+         faero_atm   (nx_block,ny_block,icepack_max_aero,max_blocks), & ! aerosol deposition rate (kg/m^2 s)   
+         faero_ocn   (nx_block,ny_block,icepack_max_aero,max_blocks), & ! aerosol flux to ocean  (kg/m^2/s)
+         zaeros      (nx_block,ny_block,icepack_max_aero,max_blocks), & ! ocean aerosols (mmol/m^3) 
+         flux_bio_atm(nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! all bio fluxes to ice from atmosphere
+         flux_bio    (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! all bio fluxes to ocean
+         flux_bio_ai (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! all bio fluxes to ocean, averaged over grid cell
+         algalN      (nx_block,ny_block,icepack_max_algae,max_blocks), & ! ocean algal nitrogen (mmol/m^3) (diatoms, pico, phaeo)
+         falgalN     (nx_block,ny_block,icepack_max_algae,max_blocks), & ! ice-ocean algal nitrogen flux (mmol/m^2/s) (diatoms, pico, phaeo)
+         doc         (nx_block,ny_block,icepack_max_doc,max_blocks), & ! ocean doc (mmol/m^3)  (saccharids, lipids, tbd )
+         fdoc        (nx_block,ny_block,icepack_max_doc,max_blocks), & ! ice-ocean doc flux (mmol/m^2/s)  (saccharids, lipids, tbd)
+         don         (nx_block,ny_block,icepack_max_don,max_blocks), & ! ocean don (mmol/m^3) (proteins and amino acids)
+         fdon        (nx_block,ny_block,icepack_max_don,max_blocks), & ! ice-ocean don flux (mmol/m^2/s) (proteins and amino acids)
+         dic         (nx_block,ny_block,icepack_max_dic,max_blocks), & ! ocean dic (mmol/m^3) 
+         fdic        (nx_block,ny_block,icepack_max_dic,max_blocks), & ! ice-ocean dic flux (mmol/m^2/s) 
+         fed         (nx_block,ny_block,icepack_max_fe, max_blocks), & ! ocean dissolved fe (nM) 
+         fep         (nx_block,ny_block,icepack_max_fe, max_blocks), & ! ocean particulate fe (nM) 
+         ffed        (nx_block,ny_block,icepack_max_fe, max_blocks), & ! ice-ocean dissolved fe flux (umol/m^2/s) 
+         ffep        (nx_block,ny_block,icepack_max_fe, max_blocks), & ! ice-ocean particulate fe flux (umol/m^2/s) 
+         stat=ierr)
+      if (ierr/=0) call abort_ice('(alloc_flux_bgc): Out of memory')
+
+      end subroutine alloc_flux_bgc
 
 !=======================================================================
 

--- a/cicecore/cicedynB/general/ice_state.F90
+++ b/cicecore/cicedynB/general/ice_state.F90
@@ -45,20 +45,20 @@
 
       implicit none
       private
-      public :: bound_state
+      public :: bound_state, alloc_state
 
       !-----------------------------------------------------------------
       ! state of the ice aggregated over all categories
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks), &
+      real (kind=dbl_kind), dimension(:,:,:), allocatable, &
          public :: &
          aice  , & ! concentration of ice
          vice  , & ! volume per unit area of ice          (m)
          vsno      ! volume per unit area of snow         (m)
 
       real (kind=dbl_kind), &
-         dimension(nx_block,ny_block,max_ntrcr,max_blocks), public :: &
+         dimension(:,:,:,:), allocatable, public :: &
          trcr      ! ice tracers
                    ! 1: surface temperature of ice/snow (C)
 
@@ -66,18 +66,18 @@
       ! state of the ice for each category
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, &
          public:: &
          aice0     ! concentration of open water
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          aicen , & ! concentration of ice
          vicen , & ! volume per unit area of ice          (m)
          vsnon     ! volume per unit area of snow         (m)
 
       real (kind=dbl_kind), public, &
-         dimension (nx_block,ny_block,max_ntrcr,ncat,max_blocks) :: &
+         dimension (:,:,:,:,:), allocatable :: &
          trcrn     ! tracers
                    ! 1: surface temperature of ice/snow (C)
 
@@ -104,7 +104,7 @@
       ! dynamic variables closely related to the state of the ice
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks), &
+      real (kind=dbl_kind), dimension(:,:,:), allocatable, &
          public :: &
          uvel     , & ! x-component of velocity (m/s)
          vvel     , & ! y-component of velocity (m/s)
@@ -116,12 +116,12 @@
       ! ice state at start of time step, saved for later in the step 
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks), &
+      real (kind=dbl_kind), dimension(:,:,:), allocatable, &
          public :: &
          aice_init       ! initial concentration of ice, for diagnostics
 
       real (kind=dbl_kind), &
-         dimension(nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension(:,:,:,:), allocatable, public :: &
          aicen_init  , & ! initial ice concentration, for linear ITD
          vicen_init  , & ! initial ice volume (m), for linear ITD
          vsnon_init      ! initial snow volume (m), for aerosol 
@@ -129,6 +129,37 @@
 !=======================================================================
 
       contains
+
+!=======================================================================
+!
+! Allocate space for all state variables 
+!
+      subroutine alloc_state
+      integer (int_kind) :: ierr
+
+      allocate ( &
+         aice      (nx_block,ny_block,max_blocks) , & ! concentration of ice
+         vice      (nx_block,ny_block,max_blocks) , & ! volume per unit area of ice (m)
+         vsno      (nx_block,ny_block,max_blocks) , & ! volume per unit area of snow (m)
+         aice0     (nx_block,ny_block,max_blocks) , & ! concentration of open water
+         uvel      (nx_block,ny_block,max_blocks) , & ! x-component of velocity (m/s)
+         vvel      (nx_block,ny_block,max_blocks) , & ! y-component of velocity (m/s)
+         divu      (nx_block,ny_block,max_blocks) , & ! strain rate I component, velocity divergence (1/s)
+         shear     (nx_block,ny_block,max_blocks) , & ! strain rate II component (1/s)
+         strength  (nx_block,ny_block,max_blocks) , & ! ice strength (N/m)
+         aice_init (nx_block,ny_block,max_blocks) , & ! initial concentration of ice, for diagnostics
+         aicen     (nx_block,ny_block,ncat,max_blocks) , & ! concentration of ice
+         vicen     (nx_block,ny_block,ncat,max_blocks) , & ! volume per unit area of ice (m)
+         vsnon     (nx_block,ny_block,ncat,max_blocks) , & ! volume per unit area of snow (m)
+         aicen_init(nx_block,ny_block,ncat,max_blocks) , & ! initial ice concentration, for linear ITD
+         vicen_init(nx_block,ny_block,ncat,max_blocks) , & ! initial ice volume (m), for linear ITD
+         vsnon_init(nx_block,ny_block,ncat,max_blocks) , & ! initial snow volume (m), for aerosol 
+         trcr      (nx_block,ny_block,max_ntrcr,max_blocks) , & ! ice tracers: 1: surface temperature of ice/snow (C)
+         trcrn     (nx_block,ny_block,max_ntrcr,ncat,max_blocks) , & ! tracers: 1: surface temperature of ice/snow (C)
+         stat=ierr)
+      if (ierr/=0) call abort_ice('(alloc_state): Out of memory')
+
+      end subroutine alloc_state
 
 !=======================================================================
 !

--- a/cicecore/cicedynB/infrastructure/ice_blocks.F90
+++ b/cicecore/cicedynB/infrastructure/ice_blocks.F90
@@ -43,9 +43,8 @@
    integer (int_kind), parameter, public :: &
       nghost = 1       ! number of ghost cells around each block
 
-   integer (int_kind), parameter, public :: &! size of block domain in
-      nx_block = block_size_x + 2*nghost,   &!  x,y dir including ghost
-      ny_block = block_size_y + 2*nghost     !  cells 
+   integer (int_kind), public :: &! size of block domain in
+      nx_block, ny_block          !  x,y dir including ghost
 
    ! predefined directions for neighbor id routine
    ! Note: the directions that are commented out are implemented in 
@@ -147,6 +146,8 @@ contains
 !
 !----------------------------------------------------------------------
 
+   nx_block    = block_size_x + 2*nghost ! size of block domain in x,y dir
+   ny_block    = block_size_y + 2*nghost !  including ghost cells
    nblocks_x   = (nx_global-1)/block_size_x + 1
    nblocks_y   = (ny_global-1)/block_size_y + 1
    nblocks_tot = nblocks_x*nblocks_y

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -35,7 +35,7 @@
       private
       public :: init_grid1, init_grid2, &
                 t2ugrid_vector, u2tgrid_vector, &
-                to_ugrid, to_tgrid
+                to_ugrid, to_tgrid, alloc_grid
 
       character (len=char_len_long), public :: &
          grid_format  , & ! file format ('bin'=binary or 'nc'=netcdf)
@@ -45,7 +45,7 @@
          grid_type        !  current options are rectangular (default),
                           !  displaced_pole, tripole, regional
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          dxt    , & ! width of T-cell through the middle (m)
          dyt    , & ! height of T-cell through the middle (m)
          dxu    , & ! width of U-cell through the middle (m)
@@ -69,7 +69,7 @@
          ocn_gridcell_frac   ! only relevant for lat-lon grids
                              ! gridcell value of [1 - (land fraction)] (T-cell)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          cyp    , & ! 1.5*HTE - 0.5*HTE
          cxp    , & ! 1.5*HTN - 0.5*HTN
          cym    , & ! 0.5*HTE - 1.5*HTE
@@ -78,14 +78,14 @@
          dyhx       ! 0.5*(HTN - HTN)
 
       ! Corners of grid boxes for history output
-      real (kind=dbl_kind), dimension (4,nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          lont_bounds, & ! longitude of gridbox corners for T point
          latt_bounds, & ! latitude of gridbox corners for T point
          lonu_bounds, & ! longitude of gridbox corners for U point
          latu_bounds    ! latitude of gridbox corners for U point       
 
       ! geometric quantities used for remapping transport
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          xav  , & ! mean T-cell value of x
          yav  , & ! mean T-cell value of y
          xxav , & ! mean T-cell value of xx
@@ -98,21 +98,21 @@
 !         yyyav    ! mean T-cell value of yyy
 
       real (kind=dbl_kind), &
-         dimension (2,2,nx_block,ny_block,max_blocks), public :: &
+         dimension (:,:,:,:,:), allocatable, public :: &
          mne, & ! matrices used for coordinate transformations in remapping
          mnw, & ! ne = northeast corner, nw = northwest, etc.
          mse, & 
          msw
 
       ! masks
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          hm     , & ! land/boundary mask, thickness (T-cell)
          bm     , & ! task/block id
          uvm    , & ! land/boundary mask, velocity (U-cell)
          kmt        ! ocean topography mask for bathymetry (T-cell)
 
       logical (kind=log_kind), &
-         dimension (nx_block,ny_block,max_blocks), public :: &
+         dimension (:,:,:), allocatable, public :: &
          tmask  , & ! land/boundary mask, thickness (T-cell)
          umask  , & ! land/boundary mask, velocity (U-cell)
          lmask_n, & ! northern hemisphere mask
@@ -123,12 +123,74 @@
          dxrect = 30.e5_dbl_kind   ,&! uniform HTN (cm)
          dyrect = 30.e5_dbl_kind     ! uniform HTE (cm)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          rndex_global       ! global index for local subdomain (dbl)
 
 !=======================================================================
 
       contains
+
+!=======================================================================
+!
+! Allocate space for all variables 
+!
+      subroutine alloc_grid
+
+      integer (int_kind) :: ierr
+
+      allocate( &
+         dxt      (nx_block,ny_block,max_blocks), & ! width of T-cell through the middle (m)
+         dyt      (nx_block,ny_block,max_blocks), & ! height of T-cell through the middle (m)
+         dxu      (nx_block,ny_block,max_blocks), & ! width of U-cell through the middle (m)
+         dyu      (nx_block,ny_block,max_blocks), & ! height of U-cell through the middle (m)
+         HTE      (nx_block,ny_block,max_blocks), & ! length of eastern edge of T-cell (m)
+         HTN      (nx_block,ny_block,max_blocks), & ! length of northern edge of T-cell (m)
+         tarea    (nx_block,ny_block,max_blocks), & ! area of T-cell (m^2)
+         uarea    (nx_block,ny_block,max_blocks), & ! area of U-cell (m^2)
+         tarear   (nx_block,ny_block,max_blocks), & ! 1/tarea
+         uarear   (nx_block,ny_block,max_blocks), & ! 1/uarea
+         tinyarea (nx_block,ny_block,max_blocks), & ! puny*tarea
+         tarean   (nx_block,ny_block,max_blocks), & ! area of NH T-cells
+         tareas   (nx_block,ny_block,max_blocks), & ! area of SH T-cells
+         ULON     (nx_block,ny_block,max_blocks), & ! longitude of velocity pts (radians)
+         ULAT     (nx_block,ny_block,max_blocks), & ! latitude of velocity pts (radians)
+         TLON     (nx_block,ny_block,max_blocks), & ! longitude of temp pts (radians)
+         TLAT     (nx_block,ny_block,max_blocks), & ! latitude of temp pts (radians)
+         ANGLE    (nx_block,ny_block,max_blocks), & ! for conversions between POP grid and lat/lon
+         ANGLET   (nx_block,ny_block,max_blocks), & ! ANGLE converted to T-cells
+         bathymetry(nx_block,ny_block,max_blocks),& ! ocean depth, for grounding keels and bergs (m)
+         ocn_gridcell_frac(nx_block,ny_block,max_blocks),& ! only relevant for lat-lon grids
+         cyp      (nx_block,ny_block,max_blocks), & ! 1.5*HTE - 0.5*HTE
+         cxp      (nx_block,ny_block,max_blocks), & ! 1.5*HTN - 0.5*HTN
+         cym      (nx_block,ny_block,max_blocks), & ! 0.5*HTE - 1.5*HTE
+         cxm      (nx_block,ny_block,max_blocks), & ! 0.5*HTN - 1.5*HTN
+         dxhy     (nx_block,ny_block,max_blocks), & ! 0.5*(HTE - HTE)
+         dyhx     (nx_block,ny_block,max_blocks), & ! 0.5*(HTN - HTN)
+         xav      (nx_block,ny_block,max_blocks), & ! mean T-cell value of x
+         yav      (nx_block,ny_block,max_blocks), & ! mean T-cell value of y
+         xxav     (nx_block,ny_block,max_blocks), & ! mean T-cell value of xx
+         yyav     (nx_block,ny_block,max_blocks), & ! mean T-cell value of yy
+         hm       (nx_block,ny_block,max_blocks), & ! land/boundary mask, thickness (T-cell)
+         bm       (nx_block,ny_block,max_blocks), & ! task/block id
+         uvm      (nx_block,ny_block,max_blocks), & ! land/boundary mask, velocity (U-cell)
+         kmt      (nx_block,ny_block,max_blocks), & ! ocean topography mask for bathymetry (T-cell)
+         tmask    (nx_block,ny_block,max_blocks), & ! land/boundary mask, thickness (T-cell)
+         umask    (nx_block,ny_block,max_blocks), & ! land/boundary mask, velocity (U-cell)
+         lmask_n  (nx_block,ny_block,max_blocks), & ! northern hemisphere mask
+         lmask_s  (nx_block,ny_block,max_blocks), & ! southern hemisphere mask
+         rndex_global(nx_block,ny_block,max_blocks), & ! global index for local subdomain (dbl)
+         lont_bounds(4,nx_block,ny_block,max_blocks), & ! longitude of gridbox corners for T point
+         latt_bounds(4,nx_block,ny_block,max_blocks), & ! latitude of gridbox corners for T point
+         lonu_bounds(4,nx_block,ny_block,max_blocks), & ! longitude of gridbox corners for U point
+         latu_bounds(4,nx_block,ny_block,max_blocks), & ! latitude of gridbox corners for U point       
+         mne  (2,2,nx_block,ny_block,max_blocks), & ! matrices used for coordinate transformations in remapping
+         mnw  (2,2,nx_block,ny_block,max_blocks), & ! ne = northeast corner, nw = northwest, etc.
+         mse  (2,2,nx_block,ny_block,max_blocks), &
+         msw  (2,2,nx_block,ny_block,max_blocks), &
+         stat=ierr)
+      if (ierr/=0) call abort_ice('(alloc_grid): Out of memory')
+
+      end subroutine alloc_grid
 
 !=======================================================================
 

--- a/cicecore/drivers/cesm/CICE_InitMod.F90
+++ b/cicecore/drivers/cesm/CICE_InitMod.F90
@@ -58,22 +58,22 @@
       subroutine cice_init(mpicom_ice)
 
       use ice_arrays_column, only: hin_max, c_hi_range, zfswin, trcrn_sw, &
-          ocean_bio_all, ice_bio_net, snow_bio_net
+          ocean_bio_all, ice_bio_net, snow_bio_net, alloc_arrays_column
       use ice_calendar, only: dt, dt_dyn, write_ic, &
           init_calendar, calendar, time
       use ice_communicate, only: init_communicate, my_task, master_task
       use ice_diagnostics, only: init_diags
       use ice_domain, only: init_domain_blocks
       use ice_domain_size, only: ncat
-      use ice_dyn_eap, only: init_eap
-      use ice_dyn_shared, only: kdyn, init_evp
+      use ice_dyn_eap, only: init_eap, alloc_dyn_eap
+      use ice_dyn_shared, only: kdyn, init_evp, alloc_dyn_shared
       use ice_flux, only: init_coupler_flux, init_history_therm, &
-          init_history_dyn, init_flux_atm, init_flux_ocn
+          init_history_dyn, init_flux_atm, init_flux_ocn, alloc_flux
       use ice_forcing, only: init_forcing_ocn, init_forcing_atmo, &
-          get_forcing_atmo, get_forcing_ocn
+          get_forcing_atmo, get_forcing_ocn, alloc_forcing
       use ice_forcing_bgc, only: get_forcing_bgc, get_atm_bgc, &
-          faero_data, faero_default, faero_optics
-      use ice_grid, only: init_grid1, init_grid2
+          faero_data, faero_default, faero_optics, alloc_forcing_bgc
+      use ice_grid, only: init_grid1, init_grid2, alloc_grid
       use ice_history, only: init_hist, accum_hist
       use ice_restart_shared, only: restart, runid, runtype
       use ice_init, only: input_data, init_state
@@ -110,6 +110,12 @@
 
       call init_domain_blocks   ! set up block decomposition
       call init_grid1           ! domain distribution
+      call alloc_grid           ! allocate grid
+      call alloc_arrays_column  ! allocate column arrays
+      call alloc_state          ! allocate state
+      call alloc_dyn_shared     ! allocate dyn shared (init_uvel,init_vvel)
+      call alloc_flux_bgc       ! allocate flux_bgc
+      call alloc_flux           ! allocate flux
       call init_ice_timers      ! initialize all timers
       call ice_timer_start(timer_total)   ! start timing entire run
       call init_grid2           ! grid variables
@@ -118,6 +124,7 @@
       call init_hist (dt)       ! initialize output history file
 
       if (kdyn == 2) then
+         call alloc_dyn_eap     ! allocate dyn_eap arrays
          call init_eap (dt_dyn) ! define eap dynamics parameters, variables
       else                      ! for both kdyn = 0 or 1
          call init_evp (dt_dyn) ! define evp dynamics parameters, variables
@@ -181,6 +188,7 @@
       ! if (tr_zaero) call fzaero_data                  ! data file (gx1)
       if (tr_aero .or. tr_zaero)  call faero_default    ! default values
 
+      if (skl_bgc .or. z_tracers) call alloc_forcing_bgc ! allocate biogeochemistry arrays
       if (skl_bgc .or. z_tracers) call get_forcing_bgc  ! biogeochemistry
 #endif
 #endif

--- a/cicecore/drivers/cice/CICE_InitMod.F90
+++ b/cicecore/drivers/cice/CICE_InitMod.F90
@@ -59,23 +59,25 @@
 
       subroutine cice_init
 
+      use ice_state, only: alloc_state
+      use ice_flux_bgc, only: alloc_flux_bgc
       use ice_arrays_column, only: hin_max, c_hi_range, zfswin, trcrn_sw, &
-          ocean_bio_all, ice_bio_net, snow_bio_net
+          ocean_bio_all, ice_bio_net, snow_bio_net, alloc_arrays_column
       use ice_calendar, only: dt, dt_dyn, time, istep, istep1, write_ic, &
           init_calendar, calendar
       use ice_communicate, only: init_communicate, my_task, master_task
       use ice_diagnostics, only: init_diags
       use ice_domain, only: init_domain_blocks
       use ice_domain_size, only: ncat
-      use ice_dyn_eap, only: init_eap
-      use ice_dyn_shared, only: kdyn, init_evp, basalstress
+      use ice_dyn_eap, only: init_eap, alloc_dyn_eap
+      use ice_dyn_shared, only: kdyn, init_evp, basalstress, alloc_dyn_shared
       use ice_flux, only: init_coupler_flux, init_history_therm, &
-          init_history_dyn, init_flux_atm, init_flux_ocn
+          init_history_dyn, init_flux_atm, init_flux_ocn, alloc_flux
       use ice_forcing, only: init_forcing_ocn, init_forcing_atmo, &
-          get_forcing_atmo, get_forcing_ocn
+          get_forcing_atmo, get_forcing_ocn, alloc_forcing
       use ice_forcing_bgc, only: get_forcing_bgc, get_atm_bgc, &
-          faero_data, faero_default, faero_optics
-      use ice_grid, only: init_grid1, init_grid2
+          faero_data, faero_default, faero_optics, alloc_forcing_bgc
+      use ice_grid, only: init_grid1, init_grid2, alloc_grid
       use ice_history, only: init_hist, accum_hist
       use ice_restart_shared, only: restart, runid, runtype
       use ice_init, only: input_data, init_state
@@ -106,6 +108,12 @@
 
       call init_domain_blocks   ! set up block decomposition
       call init_grid1           ! domain distribution
+      call alloc_grid           ! allocate grid arrays
+      call alloc_arrays_column  ! allocate column arrays
+      call alloc_state          ! allocate state arrays
+      call alloc_dyn_shared     ! allocate dyn shared arrays
+      call alloc_flux_bgc       ! allocate flux_bgc arrays
+      call alloc_flux           ! allocate flux arrays
       call init_ice_timers      ! initialize all timers
       call ice_timer_start(timer_total)   ! start timing entire run
       call init_grid2           ! grid variables
@@ -114,6 +122,7 @@
       call init_hist (dt)       ! initialize output history file
 
       if (kdyn == 2) then
+         call alloc_dyn_eap     ! allocate dyn_eap arrays
          call init_eap (dt_dyn) ! define eap dynamics parameters, variables
       else                      ! for both kdyn = 0 or 1
          call init_evp (dt_dyn) ! define evp dynamics parameters, variables
@@ -182,6 +191,7 @@
       ! if (tr_zaero) call fzaero_data                  ! data file (gx1)
       if (tr_aero .or. tr_zaero)  call faero_default    ! default values
 
+      if (skl_bgc .or. z_tracers) call alloc_forcing_bgc ! allocate biogeochemistry arrays
       if (skl_bgc .or. z_tracers) call get_forcing_bgc  ! biogeochemistry
 #endif
 #endif

--- a/cicecore/drivers/hadgem3/CICE_InitMod.F90
+++ b/cicecore/drivers/hadgem3/CICE_InitMod.F90
@@ -58,23 +58,25 @@
 
       subroutine cice_init
 
+      use ice_state, only: alloc_state
+      use ice_flux_bgc, only: alloc_flux_bgc
       use ice_arrays_column, only: hin_max, c_hi_range, zfswin, trcrn_sw, &
-          ocean_bio_all, ice_bio_net, snow_bio_net
+          ocean_bio_all, ice_bio_net, snow_bio_net, alloc_arrays_column
       use ice_calendar, only: dt, dt_dyn, time, istep, istep1, write_ic, &
           init_calendar, calendar
       use ice_communicate, only: init_communicate, my_task, master_task
       use ice_diagnostics, only: init_diags
       use ice_domain, only: init_domain_blocks
       use ice_domain_size, only: ncat
-      use ice_dyn_eap, only: init_eap
-      use ice_dyn_shared, only: kdyn, init_evp, basalstress
+      use ice_dyn_eap, only: init_eap, alloc_dyn_eap
+      use ice_dyn_shared, only: kdyn, init_evp, basalstress, alloc_dyn_shared
       use ice_flux, only: init_coupler_flux, init_history_therm, &
-          init_history_dyn, init_flux_atm, init_flux_ocn
+          init_history_dyn, init_flux_atm, init_flux_ocn, alloc_flux
       use ice_forcing, only: init_forcing_ocn, init_forcing_atmo, &
-          get_forcing_atmo, get_forcing_ocn
+          get_forcing_atmo, get_forcing_ocn, alloc_forcing
       use ice_forcing_bgc, only: get_forcing_bgc, get_atm_bgc, &
-          faero_data, faero_default, faero_optics
-      use ice_grid, only: init_grid1, init_grid2
+          faero_data, faero_default, faero_optics, alloc_forcing_bgc
+      use ice_grid, only: init_grid1, init_grid2, alloc_grid
       use ice_history, only: init_hist, accum_hist
       use ice_restart_shared, only: restart, runid, runtype
       use ice_init, only: input_data, init_state
@@ -105,6 +107,12 @@
 
       call init_domain_blocks   ! set up block decomposition
       call init_grid1           ! domain distribution
+      call alloc_grid           ! allocate grid
+      call alloc_arrays_column  ! allocate column arrays
+      call alloc_state          ! allocate state
+      call alloc_dyn_shared     ! allocate dyn shared (init_uvel,init_vvel)
+      call alloc_flux_bgc       ! allocate flux_bgc
+      call alloc_flux           ! allocate flux
       call init_ice_timers      ! initialize all timers
       call ice_timer_start(timer_total)   ! start timing entire run
       call init_grid2           ! grid variables
@@ -113,6 +121,7 @@
       call init_hist (dt)       ! initialize output history file
 
       if (kdyn == 2) then
+         call alloc_dyn_eap     ! allocate dyn_eap arrays
          call init_eap (dt_dyn) ! define eap dynamics parameters, variables
       else                      ! for both kdyn = 0 or 1
          call init_evp (dt_dyn) ! define evp dynamics parameters, variables
@@ -185,6 +194,7 @@
       ! if (tr_zaero) call fzaero_data                  ! data file (gx1)
       if (tr_aero .or. tr_zaero)  call faero_default    ! default values
 
+      if (skl_bgc .or. z_tracers) call alloc_forcing_bgc ! Allocate biogeochemistry arrays
       if (skl_bgc .or. z_tracers) call get_forcing_bgc  ! biogeochemistry
 #endif
 #endif

--- a/cicecore/shared/ice_arrays_column.F90
+++ b/cicecore/shared/ice_arrays_column.F90
@@ -18,10 +18,11 @@
            icepack_nmodal1, icepack_nmodal2
 
       implicit none
+      public :: alloc_arrays_column
 
       ! icepack_atmo.F90
       real (kind=dbl_kind), public, &
-         dimension (nx_block,ny_block,max_blocks) :: &
+         dimension (:,:,:), allocatable :: &
          Cdn_atm     , & ! atm drag coefficient
          Cdn_ocn     , & ! ocn drag coefficient
                          ! form drag
@@ -65,14 +66,14 @@
 
       ! icepack_meltpond_lvl.F90
       real (kind=dbl_kind), public, &
-         dimension (nx_block,ny_block,ncat,max_blocks) :: &
+         dimension (:,:,:,:), allocatable :: &
          dhsn, &      ! depth difference for snow on sea ice and pond ice
          ffracn       ! fraction of fsurfn used to melt ipond
 
       ! icepack_shortwave.F90
       ! category albedos
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          alvdrn      , & ! visible direct albedo           (fraction)
          alidrn      , & ! near-ir direct albedo           (fraction)
          alvdfn      , & ! visible diffuse albedo          (fraction)
@@ -80,32 +81,32 @@
 
       ! albedo components for history
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          albicen, &   ! bare ice 
          albsnon, &   ! snow 
          albpndn, &   ! pond 
          apeffn       ! effective pond area used for radiation calculation
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,ncat,max_blocks), &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, &
          public :: &
          snowfracn    ! Category snow fraction used in radiation
 
       ! shortwave components
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,nilyr,ncat,max_blocks), public :: &
+         dimension (:,:,:,:,:), allocatable, public :: &
          Iswabsn         ! SW radiation absorbed in ice layers (W m-2)
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,nslyr,ncat,max_blocks), public :: &
+         dimension (:,:,:,:,:), allocatable, public :: &
          Sswabsn         ! SW radiation absorbed in snow layers (W m-2)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,ncat,max_blocks), &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, &
          public :: &
          fswsfcn     , & ! SW absorbed at ice/snow surface (W m-2)
          fswthrun    , & ! SW through ice to ocean            (W/m^2)
          fswintn         ! SW absorbed in ice interior, below surface (W m-2)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,nilyr+1,ncat,max_blocks), &
+      real (kind=dbl_kind), dimension (:,:,:,:,:), allocatable, &
          public :: &
          fswpenln        ! visible SW entering ice layers (W m-2)
 
@@ -138,27 +139,27 @@
          icgrid           , &  ! interface grid for CICE (shortwave variable)
          swgrid                ! grid for ice tracers used in dEdd scheme
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          first_ice_real     ! .true. = c1, .false. = c0
 
       logical (kind=log_kind), &
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          first_ice      ! distinguishes ice that disappears (e.g. melts)
                         ! and reappears (e.g. transport) in a grid cell
                         ! during a single time step from ice that was
                         ! there the entire time step (true until ice forms)
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          ocean_bio      ! contains all the ocean bgc tracer concentrations
 
       ! diagnostic fluxes
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          fbio_snoice, & ! fluxes from snow to ice
          fbio_atmice    ! fluxes from atm to ice
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,icepack_max_nbtrcr, max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
          ocean_bio_all      ! fixed order, all values even for tracers false
                             ! N(1:icepack_max_algae) = 1:icepack_max_algae
                             ! Nit = icepack_max_algae + 1
@@ -184,76 +185,76 @@
                             ! humic ==  2*icepack_max_algae + icepack_max_doc + 8 + icepack_max_dic + icepack_max_don + 2*icepack_max_fe
                             !                     + icepack_max_aero 
 
-      integer (kind=int_kind), dimension(nx_block, ny_block,icepack_max_algae, max_blocks), public :: &
+      integer (kind=int_kind), dimension(:,:,:,:), allocatable, public :: &
         algal_peak          ! vertical location of algal maximum, 0 if no maximum 
 
       real (kind=dbl_kind), & 
-         dimension (nx_block,ny_block,nblyr+1,ncat,max_blocks), public :: &
+         dimension (:,:,:,:,:), allocatable, public :: &
          Zoo        ! N losses accumulated in timestep (ie. zooplankton/bacteria)
                     ! mmol/m^3
 
       real (kind=dbl_kind), &  
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          dhbr_top     , & ! brine top change
          dhbr_bot         ! brine bottom change
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,max_blocks), public :: &
+         dimension (:,:,:), allocatable, public :: &
          grow_net       , & ! Specific growth rate (/s) per grid cell
          PP_net         , & ! Total production (mg C/m^2/s) per grid cell
          hbri               ! brine height, area-averaged for comparison with hi (m)
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,nblyr+2,ncat,max_blocks), public :: &
+         dimension (:,:,:,:,:), allocatable, public :: &
          bphi           , & ! porosity of layers    
          bTiz               ! layer temperatures interpolated on bio grid (C)
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          darcy_V            ! darcy velocity positive up (m/s)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          zsal_tot    , & ! Total ice salinity in per grid cell (g/m^2) 
          chl_net     , & ! Total chla (mg chla/m^2) per grid cell      
          NO_net          ! Total nitrate per grid cell  
 
-      logical (kind=log_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      logical (kind=log_kind), dimension (:,:,:), allocatable, public :: &
          Rayleigh_criteria    ! .true. means Ra_c was reached   
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          Rayleigh_real        ! .true. = c1, .false. = c0
 
       real (kind=dbl_kind), & 
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          sice_rho     ! avg sea ice density  (kg/m^3)  ! ech: diagnostic only?
 
       real (kind=dbl_kind), & 
-         dimension (nx_block,ny_block,ncat,max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          fzsaln, &    ! category fzsal(kg/m^2/s) 
          fzsaln_g     ! salt flux from gravity drainage only
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          fzsal    , & ! Total flux  of salt to ocean at time step for conservation
          fzsal_g      ! Total gravity drainage flux
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,nblyr+1,ncat,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:,:), allocatable, public :: &
          zfswin       ! Shortwave flux into layers interpolated on bio grid  (W/m^2)
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,nblyr+1,ncat,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:,:,:), allocatable, public :: &
          iDi      , & ! igrid Diffusivity (m^2/s)    
          iki          ! Ice permeability (m^2)     
 
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), public :: &
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          upNO     , & ! nitrate uptake rate (mmol/m^2/d) times aice
          upNH         ! ammonium uptake rate (mmol/m^2/d) times aice
         
       real (kind=dbl_kind), &
-         dimension(nx_block,ny_block,max_ntrcr, ncat, max_blocks), public :: &
+         dimension(:,:,:,:,:), allocatable, public :: &
          trcrn_sw        ! bgc tracers active in the delta-Eddington shortwave 
                          ! calculation on the shortwave grid (swgrid)
 
       real (kind=dbl_kind), &
-         dimension (nx_block,ny_block,icepack_max_nbtrcr, max_blocks), public :: &
+         dimension (:,:,:,:), allocatable, public :: &
          ice_bio_net  , &   ! depth integrated tracer (mmol/m^2) 
          snow_bio_net       ! depth integrated snow tracer (mmol/m^2)
 
@@ -270,6 +271,94 @@
       real (kind=dbl_kind), dimension(icepack_max_algae) :: &
          R_C2N     ,      & ! algal C to N (mole/mole)
          R_chl2N            ! 3 algal chlorophyll to N (mg/mmol)
+
+!=======================================================================
+
+      contains
+
+!=======================================================================
+
+      subroutine alloc_arrays_column
+        ! Allocate column arrays
+        use ice_exit, only: abort_ice
+        integer (int_kind) :: ierr
+
+      allocate(                                       &
+         Cdn_atm      (nx_block,ny_block,max_blocks), & ! atm drag coefficient
+         Cdn_ocn      (nx_block,ny_block,max_blocks), & ! ocn drag coefficient
+         hfreebd      (nx_block,ny_block,max_blocks), & ! freeboard (m)
+         hdraft       (nx_block,ny_block,max_blocks), & ! draft of ice + snow column (Stoessel1993)
+         hridge       (nx_block,ny_block,max_blocks), & ! ridge height
+         distrdg      (nx_block,ny_block,max_blocks), & ! distance between ridges
+         hkeel        (nx_block,ny_block,max_blocks), & ! keel depth
+         dkeel        (nx_block,ny_block,max_blocks), & ! distance between keels
+         lfloe        (nx_block,ny_block,max_blocks), & ! floe length
+         dfloe        (nx_block,ny_block,max_blocks), & ! distance between floes
+         Cdn_atm_skin (nx_block,ny_block,max_blocks), & ! neutral skin drag coefficient
+         Cdn_atm_floe (nx_block,ny_block,max_blocks), & ! neutral floe edge drag coefficient
+         Cdn_atm_pond (nx_block,ny_block,max_blocks), & ! neutral pond edge drag coefficient
+         Cdn_atm_rdg  (nx_block,ny_block,max_blocks), & ! neutral ridge drag coefficient
+         Cdn_ocn_skin (nx_block,ny_block,max_blocks), & ! skin drag coefficient
+         Cdn_ocn_floe (nx_block,ny_block,max_blocks), & ! floe edge drag coefficient
+         Cdn_ocn_keel (nx_block,ny_block,max_blocks), & ! keel drag coefficient
+         Cdn_atm_ratio(nx_block,ny_block,max_blocks), & ! ratio drag atm / neutral drag atm
+         grow_net     (nx_block,ny_block,max_blocks), & ! Specific growth rate (/s) per grid cell
+         PP_net       (nx_block,ny_block,max_blocks), & ! Total production (mg C/m^2/s) per grid cell
+         hbri         (nx_block,ny_block,max_blocks), & ! brine height, area-averaged for comparison with hi (m)
+         zsal_tot     (nx_block,ny_block,max_blocks), & ! Total ice salinity in per grid cell (g/m^2) 
+         chl_net      (nx_block,ny_block,max_blocks), & ! Total chla (mg chla/m^2) per grid cell      
+         NO_net       (nx_block,ny_block,max_blocks), & ! Total nitrate per grid cell  
+         Rayleigh_criteria                            &
+                      (nx_block,ny_block,max_blocks), & ! .true. means Ra_c was reached   
+         Rayleigh_real(nx_block,ny_block,max_blocks), & ! .true. = c1, .false. = c0
+         fzsal        (nx_block,ny_block,max_blocks), & ! Total flux  of salt to ocean at time step for conservation
+         fzsal_g      (nx_block,ny_block,max_blocks), & ! Total gravity drainage flux
+         upNO         (nx_block,ny_block,max_blocks), & ! nitrate uptake rate (mmol/m^2/d) times aice
+         upNH         (nx_block,ny_block,max_blocks), & ! ammonium uptake rate (mmol/m^2/d) times aice
+         dhsn         (nx_block,ny_block,ncat,max_blocks), & ! depth difference for snow on sea ice and pond ice
+         ffracn       (nx_block,ny_block,ncat,max_blocks), & ! fraction of fsurfn used to melt ipond
+         alvdrn       (nx_block,ny_block,ncat,max_blocks), & ! visible direct albedo           (fraction)
+         alidrn       (nx_block,ny_block,ncat,max_blocks), & ! near-ir direct albedo           (fraction)
+         alvdfn       (nx_block,ny_block,ncat,max_blocks), & ! visible diffuse albedo          (fraction)
+         alidfn       (nx_block,ny_block,ncat,max_blocks), & ! near-ir diffuse albedo          (fraction)
+         albicen      (nx_block,ny_block,ncat,max_blocks), & ! bare ice 
+         albsnon      (nx_block,ny_block,ncat,max_blocks), & ! snow 
+         albpndn      (nx_block,ny_block,ncat,max_blocks), & ! pond 
+         apeffn       (nx_block,ny_block,ncat,max_blocks), & ! effective pond area used for radiation calculation
+         snowfracn    (nx_block,ny_block,ncat,max_blocks), & ! Category snow fraction used in radiation
+         fswsfcn      (nx_block,ny_block,ncat,max_blocks), & ! SW absorbed at ice/snow surface (W m-2)
+         fswthrun     (nx_block,ny_block,ncat,max_blocks), & ! SW through ice to ocean            (W/m^2)
+         fswintn      (nx_block,ny_block,ncat,max_blocks), & ! SW absorbed in ice interior, below surface (W m-2)
+         first_ice_real                                    &
+                      (nx_block,ny_block,ncat,max_blocks), & ! .true. = c1, .false. = c0
+         first_ice    (nx_block,ny_block,ncat,max_blocks), & ! distinguishes ice that disappears (e.g. melts) and reappears (e.g. transport)
+         dhbr_top     (nx_block,ny_block,ncat,max_blocks), & ! brine top change
+         dhbr_bot     (nx_block,ny_block,ncat,max_blocks), & ! brine bottom change
+         darcy_V      (nx_block,ny_block,ncat,max_blocks), & ! darcy velocity positive up (m/s)
+         sice_rho     (nx_block,ny_block,ncat,max_blocks), & ! avg sea ice density  (kg/m^3)  ! ech: diagnostic only?
+         fzsaln       (nx_block,ny_block,ncat,max_blocks), & ! category fzsal(kg/m^2/s) 
+         fzsaln_g     (nx_block,ny_block,ncat,max_blocks), & ! salt flux from gravity drainage only
+         ocean_bio    (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! contains all the ocean bgc tracer concentrations
+         fbio_snoice  (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! fluxes from snow to ice
+         fbio_atmice  (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! fluxes from atm to ice
+         ocean_bio_all(nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! fixed order, all values even for tracers false
+         ice_bio_net  (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! depth integrated tracer (mmol/m^2) 
+         snow_bio_net (nx_block,ny_block,icepack_max_nbtrcr,max_blocks), & ! depth integrated snow tracer (mmol/m^2)
+         trcrn_sw     (nx_block,ny_block,max_ntrcr,ncat,max_blocks), & ! bgc tracers active in the delta-Eddington shortwave 
+         Iswabsn      (nx_block,ny_block,nilyr,ncat,max_blocks), & ! SW radiation absorbed in ice layers (W m-2)
+         Sswabsn      (nx_block,ny_block,nslyr,ncat,max_blocks), & ! SW radiation absorbed in snow layers (W m-2)
+         fswpenln     (nx_block,ny_block,nilyr+1,ncat,max_blocks), & ! visible SW entering ice layers (W m-2)
+         Zoo          (nx_block,ny_block,nblyr+1,ncat,max_blocks), & ! N losses accumulated in timestep (ie. zooplankton/bacteria)
+         zfswin       (nx_block,ny_block,nblyr+1,ncat,max_blocks), & ! Shortwave flux into layers interpolated on bio grid  (W/m^2)
+         iDi          (nx_block,ny_block,nblyr+1,ncat,max_blocks), & ! igrid Diffusivity (m^2/s)    
+         iki          (nx_block,ny_block,nblyr+1,ncat,max_blocks), & ! Ice permeability (m^2)     
+         bphi         (nx_block,ny_block,nblyr+2,ncat,max_blocks), & ! porosity of layers    
+         bTiz         (nx_block,ny_block,nblyr+2,ncat,max_blocks), &    ! layer temperatures interpolated on bio grid (C)
+         algal_peak   (nx_block,ny_block,icepack_max_algae,max_blocks), & ! vertical location of algal maximum, 0 if no maximum 
+         stat=ierr)
+      if (ierr/=0) call abort_ice('(alloc_arrays_column): Out of Memory')
+
+      end subroutine alloc_arrays_column
 
 !=======================================================================
 

--- a/cicecore/shared/ice_domain_size.F90
+++ b/cicecore/shared/ice_domain_size.F90
@@ -19,9 +19,14 @@
       implicit none
       private
 
+      integer (kind=int_kind), public :: &
+        max_blocks  , & ! max number of blocks per processor
+        block_size_x, & ! size of block in first horiz dimension
+        block_size_y, & ! size of block in second horiz dimension
+        nx_global   , & ! i-axis size
+        ny_global       ! j-axis size
+
       integer (kind=int_kind), parameter, public :: &
-        nx_global = NXGLOB    , & ! i-axis size
-        ny_global = NYGLOB    , & ! j-axis size
         ncat      = NICECAT   , & ! number of categories
         nilyr     = NICELYR   , & ! number of ice layers per category
         nslyr     = NSNWLYR   , & ! number of snow layers per category
@@ -60,10 +65,6 @@
                   + 1         , & ! for unused tracer flags
         max_nstrm =   5           ! max number of history output streams
 
-      integer (kind=int_kind), parameter, public :: &
-        block_size_x = BLCKX  , & ! size of block in first horiz dimension
-        block_size_y = BLCKY      ! size of block in second horiz dimension
-
    !*** The model will inform the user of the correct
    !*** values for the parameter below.  A value higher than
    !*** necessary will not cause the code to fail, but will
@@ -73,9 +74,6 @@
    !*** max_blocks = (nx_global/block_size_x)*(ny_global/block_size_y)/
    !***               num_procs
  
-      integer (kind=int_kind), parameter, public :: &
-        max_blocks = MXBLCKS      ! max number of blocks per processor
-
 !=======================================================================
 
       end module ice_domain_size

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -153,6 +153,11 @@
 
 &domain_nml
     nprocs = 4
+    max_blocks        = -1
+    block_size_x      = 25
+    block_size_y      = 29
+    nx_global         = 100
+    ny_global         = 116
     processor_shape   = 'slenderX2'
     distribution_type = 'cartesian'
     distribution_wght = 'latitude'


### PR DESCRIPTION
CICE with dynamics allocatable through namelist

- Developer(s): Mads Hvid Ribergaard, DMI

- Please suggest code Pull Request reviewers in the column at right.
Tony?

- Are the code changes bit for bit, different at roundoff level, or more substantial?
Yes: BIT for BIT identical

- Is the documentation being updated with this PR? (Y/N): NO
If not, does the documentation need to be updated separately at a later time? (Y/N): ?
Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
--------------------------------------

One of my test using GX3 (24 iterations):
CICE_v6/GX3> md5sum history.*/iced*nc
1b47affe3502c4e9354691c22785c916  history.AllocDyn/iced.1998-01-02-00000.nc
1b47affe3502c4e9354691c22785c916  history.master/iced.1998-01-02-00000.nc

--o--

INFO:

New namelist info (and default values):
&domain_nml
nprocs = -1
max_blocks = -1 ! MXBLCK
block_size_x = -1 ! BLCKX
block_size_y = -1 ! BLCKY
nx_global = -1 ! NXGLOB
ny_global = -1 ! NYGLOB
...

CICE stops with ERROR if the namelist settings are <1 - except for max_blocks. If max_blocks is <1 it is automatically calculated/estimated as:
max_blocks=( ((nx_global-1)/block_size_x + 1) * ((ny_global-1)/block_size_y + 1) ) / nprocs

--o--

affected files:
cicecore/shared/ice_domain_size.F90
cicecore/shared/ice_arrays_column.F90
cicecore/drivers/cice/CICE_InitMod.F90
cicecore/drivers/hadgem3/CICE_InitMod.F90
cicecore/drivers/cesm/CICE_InitMod.F90
cicecore/cicedynB/infrastructure/ice_grid.F90
cicecore/cicedynB/infrastructure/ice_restoring.F90
cicecore/cicedynB/general/ice_flux.F90
cicecore/cicedynB/general/ice_state.F90
cicecore/cicedynB/general/ice_forcing.F90
cicecore/cicedynB/general/ice_forcing_bgc.F90
cicecore/cicedynB/general/ice_flux_bgc.F90
configuration/scripts/ice_in   (setup to GX3)

--o--

TIP: If you want to keep the CPPDEFS to specify blocks, grid size etc., You can add a "sed" command similar to this:

cat ice_in_tmp | sed s/'^.*nprocs.*$'/"    nprocs            = ${nprocs}"/g \
                      | sed s/'^.*max_blocks.*$'/"  , max_blocks        = ${MXBLCK}"/g \
                      | sed s/'^.*block_size_x.*$'/"  , block_size_x      = ${BLCKX}"/g \
                      | sed s/'^.*block_size_y.*$'/"  , block_size_y      = ${BLCKY}"/g \
                      | sed s/'^.*nx_global.*$'/"  , nx_global      = ${NXGLOB}"/g \
                      | sed s/'^.*ny_global.*$'/"  , ny_global      = ${NYGLOB}"/g > ice_in

MXBLCK can be set to 0. The it is calculated as:
max_blocks = (nx_global/block_size_x)*(ny_global/block_size_y) / nprocs
(as suggested within ice_domain_size.F90)
