### PR TITLE
update pgi compiler optimization to address reproducibility problems

### DIFF
--- a/configuration/scripts/machines/Macros.conrad_pgi
+++ b/configuration/scripts/machines/Macros.conrad_pgi
@@ -14,7 +14,7 @@ FFLAGS_NOOPT:= -O0
 ifeq ($(ICE_BLDDEBUG), true)
   FFLAGS     += -O0 -g -Mbounds -Mchkptr
 else
-  FFLAGS     += -O2
+  FFLAGS     += -O -g
 endif
 
 ifeq ($(ICE_COMMDIR), mpi)

--- a/configuration/scripts/machines/Macros.gordon_pgi
+++ b/configuration/scripts/machines/Macros.gordon_pgi
@@ -14,7 +14,7 @@ FFLAGS_NOOPT:= -O0
 ifeq ($(ICE_BLDDEBUG), true)
   FFLAGS     += -O0 -g -Mbounds -Mchkptr
 else
-  FFLAGS     += -O2
+  FFLAGS     += -O -g
 endif
 
 ifeq ($(ICE_COMMDIR), mpi)


### PR DESCRIPTION
Update pgi compiler optimization, switch from O2 to O. 

- Developer(s): tcraig

- Are the code changes bit for bit, different at roundoff level, or more substantial? NOT bit-for-bit for pgi compiler, but this is good.

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N

- Other Relevant Details:

Confirmed that O0, O1, and O all generate results that are reproducible as expected (different block sizes, etc).  O2 does not.  O is between O1 and O2 and seems to actually perform better than O2 on conrad and gordon.
 