### PR TITLE
adding CMIP variable documentation

### DIFF
--- a/doc/source/developer_guide/dg_documentation.rst
+++ b/doc/source/developer_guide/dg_documentation.rst
@@ -142,7 +142,7 @@ Here are some resources for using RST files:
 Building documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Once you've committed and pushed changes to the documentation *.rst files on your personal development fork. 
+Once you've committed and pushed changes to the documentation `*.rst` files on your personal development fork. 
 Go to your readthedocs.org site and then select your project "Overview". Whenever you commit to your fork
 the documents will automatically build. There is also an option to "Build a Version". Choose "latest" 
 and then click the green "Build version" button. 

--- a/doc/source/developer_guide/dg_driver.rst
+++ b/doc/source/developer_guide/dg_driver.rst
@@ -14,7 +14,7 @@ coupled.  Within the **cicecore/drivers/cice/** directory, the following files a
 **CICE.F90** is the top level program file and that calls CICE_Initialize, CICE_Run, and CICE_Finalize methods.
 **CICE_InitMod.F90** contains the CICE_Initialize method and other next level source code.
 **CICE_RunMod.F90** contains the CICE_Run method and other next level source code.
-**CICE_FinalMod.F90 ** contains the CICE_Finalize method and other next level source code.
+**CICE_FinalMod.F90** contains the CICE_Finalize method and other next level source code.
 
 Other **cicecore/drivers/** directories are similarly implemented with a top level coupling layer,
 that is largely specified by an external coupled system and then some version of the **CICE_InitMod.F90**,

--- a/doc/source/developer_guide/dg_dynamics.rst
+++ b/doc/source/developer_guide/dg_dynamics.rst
@@ -70,7 +70,10 @@ block size and tracer count.  Those block sizes and tracer counts are defined in
 **cice.settings** file, are passed to the build script as CPPs, like
 ::
 
-ftn -c ... -DNXGLOB=100 -DNYGLOB=116 -DBLCKX=25 -DBLCKY=29 -DMXBLCKS=4 -DNICELYR=7 -DNSNWLYR=1 -DNICECAT=5 -DTRAGE=1 -DTRFY=1 -DTRLVL=1 -DTRPND=1 -DTRBRI=0 -DNTRAERO=1  -DTRZS=0 -DNBGCLYR=7 -DTRALG=0 -DTRBGCZ=0 -DTRDOC=0 -DTRDOC=0 -DTRDIC=0 -DTRDON=0 -DTRFED=0 -DTRFEP=0 -DTRZAERO=0 -DTRBGCS=0 -DNUMIN=11 -DNUMAX=99 ...
+       ftn -c ... -DNXGLOB=100 -DNYGLOB=116 -DBLCKX=25 -DBLCKY=29 -DMXBLCKS=4 -DNICELYR=7
+       -DNSNWLYR=1 -DNICECAT=5 -DTRAGE=1 -DTRFY=1 -DTRLVL=1 -DTRPND=1 -DTRBRI=0 -DNTRAERO=1
+       -DTRZS=0 -DNBGCLYR=7 -DTRALG=0 -DTRBGCZ=0 -DTRDOC=0 -DTRDOC=0 -DTRDIC=0 -DTRDON=0
+       -DTRFED=0 -DTRFEP=0 -DTRZAERO=0 -DTRBGCS=0 -DNUMIN=11 -DNUMAX=99 ...
 
 and then those CPPs replace variable strings in the file **cicecore/shared/ice_domain_size.F90**.
 Data in **ice_domain_size.F90** provides parameters for static array allocations throughout CICE.

--- a/doc/source/developer_guide/dg_scripts.rst
+++ b/doc/source/developer_guide/dg_scripts.rst
@@ -29,7 +29,7 @@ The directory structure under configure/scripts is as follows.
 |        **parse_namelist.sh**     replaces namelist with command-line configuration
 |        **parse_namelist_from_settings.sh**   replaces namelist with values from cice.settings
 |        **parse_settings.sh**     replaces settings with command-line configuration
-|        **setup_run_dirs.csh      creates the case run directories
+|        **setup_run_dirs.csh**    creates the case run directories
 |        **set_version_number.csh** updates the model version number from the **cice.setup** command line
 |        **tests/**                scripts for configuring and running basic tests
 
@@ -51,7 +51,7 @@ The file **cice.settings** specifies a set of env defaults for the case.  The fi
 **ice_in** defines the namelist input for the cice driver.
 
 
-.. _dev_options:
+.. _dev_preset_options:
 
 Preset Case Options
 ---------------------
@@ -89,7 +89,7 @@ One other files will need to be
 changed to support a port, that is **configuration/scripts/cice.batch.csh**.
 To port to a new machine, see :ref:`porting`.  
 
-.. _dev_options:
+.. _dev_test_options:
 
 Test Options
 ---------------

--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -45,12 +45,14 @@
 @string{NTN = {NCAR Tech. Note}}
 @string{BGC = {Biogeochemistry}}
 @string{EFM = {Eng. Fract. Mech.}}
+@string{GMD = {Geosci. Model Dev.}}
+@string{CRST = {Cold Reg. Sci. Technol.}}
 
-% Individual entries (roughly sequential, then alphabetical but first-authorâ€™s last name)
+% Individual entries (roughly sequential, then alphabetical but first-author last name)
 @incollection{Assur58,
   author =  "A. Assur",
   title  = "Composition of sea ice and its tensile strength",
-  booktitle = "Arctic sea ice; conference held at Easton, Maryland, February 24â€“27, 1958",
+  booktitle = "Arctic sea ice; conference held at Easton, Maryland, February 24-€“27, 1958",
   publisher = "Publs. Natl. Res. Coun. Wash.",
   address = "Washington, D.C.",
   year =  "1958",
@@ -178,7 +180,7 @@
 @incollection{SP86
   author = "G. Siedler and H. Peters",
   title  = "Physical properties (general) of sea water",
-  booktitle = "Landolt-BÃ¶rnstein: Numerical data and functional relationships in science and technology,  New Series V/3a",
+  booktitle = "Landolt-Barnstein: Numerical data and functional relationships in science and technology,  New Series V/3a",
   publisher = "Springer",
   year =  "1986",
   pages = {233-264},
@@ -292,6 +294,16 @@
   year = "1995",
   url = {https://github.com/CICE-Consortium/CICE/blob/master/doc/PDF/LAUR-95-1146.pdf}
 }
+@article{ZvS95,
+  author = "F.W. Zwiers and H. von Storch",
+  title = {Taking serial correlation into account in tests of the mean},  
+  journal = JC,
+  year = {1995},
+  volume = {8},  
+  number = {2},
+  pages = {336-351},
+  url = {https://doi.org/10.1175/1520-0442(1995)008<0336:TSCIAI>2.0.CO;2}
+}
 @Article{Murray96
   author = "R.J. Murray",
   title = "{Explicit generation of orthogonal grids for ocean models}",
@@ -373,7 +385,7 @@
   publisher = "Cambridge University Press",
   note = "Cambridge, UK",
   year = "1999",
-  pages = {484 pp},
+  pages = {484 pp}
 }
 @Article{DB00
   author = "J.K. Dukowicz and J.R. Baumgardner",
@@ -420,6 +432,16 @@
   pages = {1839-1887},
   url = {http://dx.doi.org/10.1016/S0013-7944(01)00037-6}
 }
+@article{Taylor01,
+  author = "K.E. Taylor",
+  title = {Summarizing multiple aspects of model performance in a single diagram},
+  journal = JGRA,
+  year = "2001",
+  volume = {106},
+  number = {D7},
+  pages = {7183-7192},
+  url = {https://doi.org/10.1029/2000JD900719}
+}
 @Article{TWMH01
   author = "H.J. Trodahl and S.O.F. Wilkinson and M.J. McGuinness and T.G. Haskeel",
   title = "{Thermal conductivity of sea ice: dependence on temperature and depth}",
@@ -431,7 +453,7 @@
 }
 @Article{HD02
   author = "E.C. Hunke and J.K. Dukowicz",
-  title = "{The Elastic-Viscous-Plastic sea ice dynamics model in general orthogonal curvilinear coordinates on a sphereâ€”Effect of metric terms}",
+  title = "{The Elastic-Viscous-Plastic sea ice dynamics model in general orthogonal curvilinear coordinates on a sphere - Incorporation of metric terms}",
   journal = MWR,
   year = "2002",
   volume = {130},
@@ -517,7 +539,7 @@
 }
 @Book{Notz05
   author = "D. Notz",
-  title = "Thermodynamic and Fluid-Dynamical Processes in Sea Ice",
+  title = "{Thermodynamic and Fluid-Dynamical Processes in Sea Ice}",
   publisher = "University of Cambridge, UK",
   note = "PhD thesis",
   year = "2005",
@@ -550,6 +572,14 @@
   year =  "2006",
   volume = {4},
 }
+@article{HRHPSL06,
+  author = "W.D. Hibler and A. Roberts and P. Heil and A.Y. Proshutinsky and H.L. Simmons and J. Lovick",
+  title = "{Modeling M2 tidal variability in Arctic sea-ice drift and deformation}",
+  journal = AG,
+  volume = {44},
+  year = {2006},
+  url = {https://doi.org/10.3189/172756406781811178}
+}
 @Article{WF06
   author = "A.V. Wilchinsky and D.L. Feltham",
   title = "{Modelling the rheology of sea ice as a collection of diamond-shaped floes}",
@@ -565,7 +595,7 @@
   publisher = "Academic Press",
   note = "2nd ed.",
   year = "2006",
-  pages = {627 pp},
+  pages = {627 pp}
 }
 @Manual{BL07
   author = "B.P. Briegleb and B. Light",
@@ -646,6 +676,15 @@
   number = {C8},
   url = {http://dx.doi.org/10.1029/2009JC005568}
 }
+@Article{KH2010
+  author = "C. Konig Beatty and D.M. Holland",
+  title = "{Modeling landfast ice by adding tensile strength}",
+  journal = JPO,
+  year = "2010",
+  volume = {40},
+  pages = {185-198},
+  url = {https://doi.org/10.1175/2009JPO4105.1}
+}
 @Article{ABTH11
   author = "K.C. Armour and C.M. Bitz and L. Thompson and E.C. Hunke",
   title = "{Controls on Arctic sea ice from first-year and multi-year ice survivability}",
@@ -700,8 +739,17 @@
   pages = {1413-1430},
   url = {http://dx.doi.org/10.1175/JCLI-D-11-00078.1}
 }
+@article{LOSF12,
+  author = "M. Lepparanta and A. Oikkonen and K. Shirasawa and Y. Fukamachi",
+  title = "{A treatise on frequency spectrum of drift ice velocity}",
+  journal = CRST,
+  year = {2012},
+  volume = {76-77},
+  pages = {83-91},
+  url= {https://doi.org/10.1016/j.coldregions.2011.12.005}
+}
 @Article{LGHA12
-  author = "C. LÃ¼pkes and V.M. Gryanik and  J. Hartmann and E.L. Andreas",
+  author = "C. Lupkes and V.M. Gryanik and  J. Hartmann and E.L. Andreas",
   title = "{A parametrization, based on sea ice morphology, of the neutral atmospheric drag coefficients for weather prediction and climate models}",
   journal = JGRA,
   year = "2012",
@@ -726,6 +774,15 @@
   volume = {71},
   pages = {26-42},
   url = {http://dx.doi.org/10.1016/j.ocemod.2012.11.008}
+}
+@article{Irving2015,
+  author = "D. Irving",
+  title = {A minimum standard for publishing computational results in the weather and climate sciences},
+  journal = BAMS,
+  number = {97},
+  pages = {1149-1158},
+  year = {2015},
+  url = {https://doi.org/10.1175/BAMS-D-15-00010.1}
 }
 @Article{TFW13
   author = "M. Tsamados and D.L. Feltham and A.V. Wilchinsky",
@@ -754,128 +811,45 @@
   pages = {1329-1353},
   url = {https://doi.org/10.1175/JPO-D-13-0215.1}
 }
-
-@Article{KH2010
-  author = "C. Konig Beatty and D.M. Holland",
-  title = "{Modeling landfast ice by adding tensile strength}",
-  journal = JPO,
-  year = "2010",
-  volume = {40},
-  pages = {185-198},
-  url = {https://doi.org/10.1175/2009JPO4105.1}
+@article{RCWODHNCB15,
+  author = "A.F. Roberts and A.P. Craig and W. Maslowski and R. Osinski and A.K. DuVivier and M. Hughes and B. Nijssen and J.J. Cassano and M. Brunke",
+  title = "{Simulating transient ice -€“ ocean Ekman transport in the Regional Arctic System Model and Community Earth System Model}",  
+  journal = AG,
+  year = "2015",  
+  volume = {56},
+  number = {69},
+  pages = {211-228},
+  url = {https://doi.org/10.3189/2015AoG69A760}
 }
-
-@Article{Lemieux2016
-  author = "J.F. Lemieux and F.Dupont and P. Blain and F. Roy and G.C. Smith and G.M. Flato",
-  title = "{Improving the simulation of landfast ice by combining tensile strength and a parameterization for
-grounded ridges,}",
+@Article{LDBRSF16
+  author = "J.F. Lemieux and F. Dupont and P. Blain and F. Roy and G.C. Smith and G.M. Flato",
+  title = "{Improving the simulation of landfast ice by combining tensile strength and a parameterization for grounded ridges}",
   journal = JGRO,
   year = "2016",
   volume = {121},
-  pages = {},
+  pages = {7354-7368},
   url = {https://doi.org/10.1002/2016JC012006}
 }
-
-@article{Hunke2018,
-  author = {Hunke, Elizabeth and Roberts, Andrew and Allard, Richard and Lemieux, Jean-Fran{\c{c}}ois and Turner, Matthew and Craig, Tony and DuVivier, Alice and Bailey, David and Holland, Marika and Winton, Michael and Dupont, Frederic and Grumbine, Robert},
-  title = {{The CICE Consortium Sea Ice Modeling Suite}},
-  journal = {},
-  year = {In Prep.}
+@Article{NJHHMSTV16
+  author = "D. Notz and A. Jahn and E. Hunke and F. Massonnet and J. Stroeve and B. Tremblay and M. Vancoppenolle",
+  title = "{The CMIP6 Sea-Ice Model Intercomparison Project (SIMIP): understanding sea ice through climate-model simulations}",
+  journal = GMD,
+  year = "2016",
+  volume = {9},
+  pages = {3427-3446},
+  url = {https://doi.org/10.5194/gmd-9-3427-2016}
 }
-
-@article{Roberts2015,
-  author = {Roberts, Andrew F. and Craig, Anthony and Maslowski, Wieslaw and Osinski, Robert and Duvivier, Alice and Hughes, Mimi and Nijssen, Bart and Cassano, John J. and Brunke, Michael},
-  doi = {10.3189/2015AoG69A760},
-  journal = {Ann. Glaciol.},
-  number = {69},
-  pages = {211--228},
-  title = {{Simulating transient ice â€“ ocean Ekman transport in the Regional Arctic System Model and Community Earth System Model}},
-  volume = {56},
-  year = {2015}
+@article{HRALTCDBHWDG18,
+  author = {E.C. Hunke and A. Roberts and R. Allard and J.F. Lemieux and M. Turner, and A.P. Craig and A.K. DuVivier and D. Bailey and M.M. Holland and M. Winton and F. Dupont and R. Grumbine},
+  title = "{The CICE Consortium Sea Ice Modeling Suite}",
+  journal = {In Prep.},
+  year = {2018 - In Prep.},
+  url = {https://doi.org}
 }
-
-@article{Taylor2001,
-  author = {Taylor, Karl E},
-  journal = {J. Geophys. Res.},
-  number = {D7},
-  pages = {7183--7192},
-  title = {{Summarizing multiple aspects of model performance}},
-  volume = {106},
-  year = {2001}
-}
-
-@article{HiblerIII2006,
-  author = {Hibler, III, W. D. and Roberts, Andrew F. and Heil, Petra and Proshutinsky, A Y and Simmons, H L and Lovick, J},
-  doi = {10.3189/172756406781811178},
-  journal = {Ann. Glaciol.},
-  pages = {418--428},
-  title = {{Modeling M2 tidal variability in Arctic sea-ice drift and deformation}},
-  volume = {44},
-  year = {2006}
-}
-
-@article{Hibler2006,
-  author = {Hibler, W.D. and Roberts, A. and Heil, P. and Proshutinsky, A.Y. and Simmons, H.L. and Lovick, J.},
-  doi = {10.3189/172756406781811178},
-  journal = {Ann. Glaciol.},
-  title = {{Modeling M2 tidal variability in Arctic sea-ice drift and deformation}},
-  volume = {44},
-  year = {2006}
-}
-
-@article{Zwiers1995,
-  author = {Zwiers, Francis W. and von Storch, Hans},
-  doi = {10.1175/1520-0442(1995)008<0336:TSCIAI>2.0.CO;2},
-  journal = {J. Clim.},
-  number = {2},
-  pages = {336--351},
-  title = {{Taking serial correlation into account in tests of the mean}},
-  volume = {8},
-  year = {1995}
-}
-
-@book{VonStorch1999,
-  author = {von Storch, Hans and Zwiers, Francis W},
-  pages = {484},
-  publisher = {Cambridge University Press},
-  title = {{Statistical Analysis in Climate Research}},
-  year = {1999}
-}
-
 @article{Roberts2018,
-  author = {Roberts, A. and Maslowski, W. and Hunke, E. and Osinski, R. and Cassano, J. and DuVivier, A. and Hughes, M. and Seefeldt, M. and Nijssen, B. and Hamman, J. and Hutchings, J. and Tsamados, M. and Feltham, D.},
-  journal = {Prep.},
-  title = {{Inter-comparison of isotropic and anisotropic sea-ice mechanics in a high-resolution fully coupled climate model}},
-  year = {2018}
+  author = {A. Roberts and W. Maslowski and E.C. Hunke and R. Osinski and J.J. Cassano and A.K. DuVivier and M. Hughes and M. Seefeldt and B. Nijssen and J. Hamman and J. Hutchings and M. Tsamados and D. Feltham},
+  title = "{Inter-comparison of isotropic and anisotropic sea-ice mechanics in a high-resolution fully coupled climate model}",
+  journal = {In Prep.},
+  year = {2018 - In Prep.},
+  url = {https://doi.org}
 }
-
-@article{Irving2015,
-  author = {Irving, Damien},
-  doi = {10.1175/BAMS-D-15-00010.1},
-  journal = {Bull. Am. Meteorol. Soc.},
-  number = {July},
-  pages = {151007152952002},
-  title = {{A minimum standard for publishing computational results in the weather and climate sciences}},
-  year = {2015}
-}
-
-@article{Lepparanta2012,
-  author = {Lepp{\"{a}}ranta, Matti and Oikkonen, Annu and Shirasawa, Kunio and Fukamachi, Yasushi},
-  doi = {10.1016/j.coldregions.2011.12.005},
-  journal = {Cold Reg. Sci. Technol.},
-  month = {jun},
-  pages = {83--91},
-  title = {{A treatise on frequency spectrum of drift ice velocity}},
-  volume = {76-77},
-  year = {2012}
-}
-
-@book{Wilks2006,
-  author = {Wilks, Daniel S},
-  edition = {2nd},
-  pages = {627},
-  publisher = {Academic Press},
-  title = {{Statistical methods in the atmospheric sciences}},
-  year = {2006}
-}
-

--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -296,9 +296,9 @@
 }
 @article{ZvS95,
   author = "F.W. Zwiers and H. von Storch",
-  title = {Taking serial correlation into account in tests of the mean},  
+  title = "{Taking serial correlation into account in tests of the mean}",  
   journal = JC,
-  year = {1995},
+  year = "1995",
   volume = {8},  
   number = {2},
   pages = {336-351},

--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -48,11 +48,11 @@
 @string{GMD = {Geosci. Model Dev.}}
 @string{CRST = {Cold Reg. Sci. Technol.}}
 
-% Individual entries (roughly sequential, then alphabetical but first-author last name)
+% Individual entries (roughly sequential, then alphabetical by first-author's last name)
 @incollection{Assur58,
   author =  "A. Assur",
   title  = "Composition of sea ice and its tensile strength",
-  booktitle = "Arctic sea ice; conference held at Easton, Maryland, February 24-€“27, 1958",
+  booktitle = "Arctic sea ice; conference held at Easton, Maryland, February 24-27, 1958",
   publisher = "Publs. Natl. Res. Coun. Wash.",
   address = "Washington, D.C.",
   year =  "1958",
@@ -180,7 +180,7 @@
 @incollection{SP86
   author = "G. Siedler and H. Peters",
   title  = "Physical properties (general) of sea water",
-  booktitle = "Landolt-Barnstein: Numerical data and functional relationships in science and technology,  New Series V/3a",
+  booktitle = "Landolt-BÃ¶rnstein: Numerical data and functional relationships in science and technology,  New Series V/3a",
   publisher = "Springer",
   year =  "1986",
   pages = {233-264},
@@ -385,7 +385,7 @@
   publisher = "Cambridge University Press",
   note = "Cambridge, UK",
   year = "1999",
-  pages = {484 pp}
+  pages = {484 pp},
 }
 @Article{DB00
   author = "J.K. Dukowicz and J.R. Baumgardner",
@@ -453,7 +453,7 @@
 }
 @Article{HD02
   author = "E.C. Hunke and J.K. Dukowicz",
-  title = "{The Elastic-Viscous-Plastic sea ice dynamics model in general orthogonal curvilinear coordinates on a sphere - Incorporation of metric terms}",
+  title = "{The Elastic-Viscous-Plastic sea ice dynamics model in general orthogonal curvilinear coordinates on a sphereâ€”Effect of metric terms}",
   journal = MWR,
   year = "2002",
   volume = {130},
@@ -539,7 +539,7 @@
 }
 @Book{Notz05
   author = "D. Notz",
-  title = "{Thermodynamic and Fluid-Dynamical Processes in Sea Ice}",
+  title = "Thermodynamic and Fluid-Dynamical Processes in Sea Ice",
   publisher = "University of Cambridge, UK",
   note = "PhD thesis",
   year = "2005",
@@ -595,7 +595,7 @@
   publisher = "Academic Press",
   note = "2nd ed.",
   year = "2006",
-  pages = {627 pp}
+  pages = {627 pp},
 }
 @Manual{BL07
   author = "B.P. Briegleb and B. Light",
@@ -676,7 +676,7 @@
   number = {C8},
   url = {http://dx.doi.org/10.1029/2009JC005568}
 }
-@Article{KH2010
+@Article{KH10
   author = "C. Konig Beatty and D.M. Holland",
   title = "{Modeling landfast ice by adding tensile strength}",
   journal = JPO,
@@ -704,7 +704,7 @@
   url = {http://dx.doi.org/10.1029/2010JC006409}
 }
 @Article{LLCL11
-  author = "P. Lu and Z. Li and B. Cheng and M. Lepparanta",
+  author = "P. Lu and Z. Li and B. Cheng and M. Lepp{\"{a}}ranta",
   title = "{A parametrization fo the ice-ocean drag coefficient}",
   journal = JGRO,
   year = "2011",
@@ -740,16 +740,16 @@
   url = {http://dx.doi.org/10.1175/JCLI-D-11-00078.1}
 }
 @article{LOSF12,
-  author = "M. Lepparanta and A. Oikkonen and K. Shirasawa and Y. Fukamachi",
+  author = "M. Lepp{\"{a}}ranta and A. Oikkonen and K. Shirasawa and Y. Fukamachi",
   title = "{A treatise on frequency spectrum of drift ice velocity}",
+  year = "2012",
   journal = CRST,
-  year = {2012},
   volume = {76-77},
   pages = {83-91},
-  url= {https://doi.org/10.1016/j.coldregions.2011.12.005}
+  doi = {https://doi.org/10.1016/j.coldregions.2011.12.005}
 }
 @Article{LGHA12
-  author = "C. Lupkes and V.M. Gryanik and  J. Hartmann and E.L. Andreas",
+  author = "C. LÃ¼pkes and V.M. Gryanik and  J. Hartmann and E.L. Andreas",
   title = "{A parametrization, based on sea ice morphology, of the neutral atmospheric drag coefficients for weather prediction and climate models}",
   journal = JGRA,
   year = "2012",
@@ -774,15 +774,6 @@
   volume = {71},
   pages = {26-42},
   url = {http://dx.doi.org/10.1016/j.ocemod.2012.11.008}
-}
-@article{Irving2015,
-  author = "D. Irving",
-  title = {A minimum standard for publishing computational results in the weather and climate sciences},
-  journal = BAMS,
-  number = {97},
-  pages = {1149-1158},
-  year = {2015},
-  url = {https://doi.org/10.1175/BAMS-D-15-00010.1}
 }
 @Article{TFW13
   author = "M. Tsamados and D.L. Feltham and A.V. Wilchinsky",
@@ -813,9 +804,9 @@
 }
 @article{RCWODHNCB15,
   author = "A.F. Roberts and A.P. Craig and W. Maslowski and R. Osinski and A.K. DuVivier and M. Hughes and B. Nijssen and J.J. Cassano and M. Brunke",
-  title = "{Simulating transient ice -€“ ocean Ekman transport in the Regional Arctic System Model and Community Earth System Model}",  
+  title = "{Simulating transient ice-ocean Ekman transport in the Regional Arctic System Model and Community Earth System Model}",
+  year = "2015",
   journal = AG,
-  year = "2015",  
   volume = {56},
   number = {69},
   pages = {211-228},
@@ -846,10 +837,20 @@
   year = {2018 - In Prep.},
   url = {https://doi.org}
 }
+
 @article{Roberts2018,
-  author = {A. Roberts and W. Maslowski and E.C. Hunke and R. Osinski and J.J. Cassano and A.K. DuVivier and M. Hughes and M. Seefeldt and B. Nijssen and J. Hamman and J. Hutchings and M. Tsamados and D. Feltham},
+  author = "A. Roberts and W. Maslowski and E.C. Hunke and R. Osinski and J.J. Cassano and A.K. DuVivier and M. Hughes and M. Seefeldt and B. Nijssen and J. Hamman and J. Hutchings and M. Tsamados and D. Feltham",
   title = "{Inter-comparison of isotropic and anisotropic sea-ice mechanics in a high-resolution fully coupled climate model}",
   journal = {In Prep.},
   year = {2018 - In Prep.},
   url = {https://doi.org}
+}
+@article{Irving2015,
+  author = "D. Irving",
+  title = "{A minimum standard for publishing computational results in the weather and climate sciences}",
+  year = "2015",
+  journal = BAMS,
+  number = {97},
+  pages = {1149-1158},
+  url = {https://doi.org/10.1175/BAMS-D-15-00010.1}
 }

--- a/doc/source/science_guide/sg_modelcomps.rst
+++ b/doc/source/science_guide/sg_modelcomps.rst
@@ -1439,7 +1439,7 @@ where :math:`m` is the combined mass of ice and snow per unit area and
 :math:`\vec{\tau}_a` and :math:`\vec{\tau}_w` are wind and ocean
 stresses, respectively. The term :math:`\vec{\tau}_b` is a 
 seabed stress (also referred to as basal stress) that represents the grounding of pressure
-ridges in shallow water :cite:`Lemieux2016`. The strength of the ice is represented by the
+ridges in shallow water :cite:`LDBRSF16`. The strength of the ice is represented by the
 internal stress tensor :math:`\sigma_{ij}`, and the other two terms on
 the right hand side are stresses due to Coriolis effects and the sea
 surface slope. The parameterization for the wind and ice–ocean stress
@@ -1537,7 +1537,7 @@ pending further testing.
 Seabed stress
 ***************
 
-The parameterization for the seabed stress is described in :cite:`Lemieux2016`. The components of the basal seabed stress are 
+The parameterization for the seabed stress is described in :cite:`LDBRSF16`. The components of the basal seabed stress are 
 :math:`\tau_{bx}=C_bu` and :math:`\tau_{by}=C_bv`, where :math:`C_b` is a coefficient expressed as
 
 .. math::
@@ -1590,7 +1590,7 @@ is therefore simply equal to :math:`-\sigma_1/2`.
 *Elastic-Viscous-Plastic*
 
 In the EVP model the internal stress tensor is determined from a
-regularized version of the VP constitutive law. Following the approach of :cite:`KH2010` (see also :cite:`Lemieux2016`), the 
+regularized version of the VP constitutive law. Following the approach of :cite:`KH2010` (see also :cite:`LDBRSF16`), the 
 elliptical yield curve can be modified such that the ice has isotropic tensile strength. 
 The tensile strength :math:`T_p` is expressed as a fraction of the ice strength :math:`P`, that is :math:`T_p=k_t P` 
 where :math:`k_t` should be set to a value between 0 and 1. The constitutive law is therefore 

--- a/doc/source/science_guide/sg_modelcomps.rst
+++ b/doc/source/science_guide/sg_modelcomps.rst
@@ -1590,7 +1590,7 @@ is therefore simply equal to :math:`-\sigma_1/2`.
 *Elastic-Viscous-Plastic*
 
 In the EVP model the internal stress tensor is determined from a
-regularized version of the VP constitutive law. Following the approach of :cite:`KH2010` (see also :cite:`LDBRSF16`), the 
+regularized version of the VP constitutive law. Following the approach of :cite:`KH10` (see also :cite:`LDBRSF16`), the 
 elliptical yield curve can be modified such that the ice has isotropic tensile strength. 
 The tensile strength :math:`T_p` is expressed as a fraction of the ice strength :math:`P`, that is :math:`T_p=k_t P` 
 where :math:`k_t` should be set to a value between 0 and 1. The constitutive law is therefore 

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -354,7 +354,7 @@ Table of namelist options
    "``trestore``", "integer", "sst restoring time scale (days)", ""
    "``restore_ice``", "true/false", "restore ice state along lateral boundaries", ""
    "", "", "", ""
-   "*icefields_tracer_nml*", "", "", ""
+   "*icefields_nml*", "", "", ""
    "", "", "*History Fields*", ""
    "``f_<var>``", "string", "frequency units for writing ``<var>`` to history", ""
    "", "``y``", "write history every ``histfreq_n`` years", ""

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -94,6 +94,7 @@ Table of namelist options
    :header: "variable", "options/format", "description", "recommended value"
    :widths: 15, 15, 30, 15 
 
+   "", "", "", ""
    "*setup_nml*", "", "", ""
    "", "", "*Time, Diagnostics*", ""
    "``days_per_year``", "``360`` or ``365``", "number of days in a model year", "365"

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -836,10 +836,13 @@ the grid cell area. Our naming convention attaches the suffix “\_ai" to
 the grid-cell-mean variable names.
 
 In this version of CICE, history variables requested by the Sea Ice Model Intercomparison 
-Project (SIMIP) have been added as possible history output variables (e.g. 
-`f_sithick`, `f_sidmassgrowthbottom`, etc.). A full list of SIMIP variables is 
-available at the following site
-<https://earthsystemcog.org/projects/wip/CMIP6DataRequest>. 
+Project (SIMIP) :cite:`NJHHMSTV16` have been added as possible history output variables (e.g. 
+`f_sithick`, `f_sidmassgrowthbottom`, etc.). The lists of
+`monthly <http://clipc-services.ceda.ac.uk/dreq/u/MIPtable::SImon.html>`_ and 
+`daily <http://clipc-services.ceda.ac.uk/dreq/u/MIPtable::SIday.html>`_ 
+requested  SIMIP variables provide the names of possible history fields in CICE. 
+However, each of the additional variables can be output at any temporal frequency 
+specified in the **icefields\_nml** section of **ice\_in** as detailed above.
 Additionally, a new history output variable, `f_CMIP`, has been added. When `f_CMIP`
 is added to the **icefields\_nml** section of **ice\_in** then all SIMIP variables
 will be turned on for output at the frequency specified by `f_CMIP`. 

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -743,8 +743,10 @@ History files
 
 Model output data is averaged over the period(s) given by `histfreq` and
 `histfreq\_n`, and written to binary or  files prepended by `history\_file`
-in **ice\_in**. That is, if `history\_file` = ‘iceh’ then the filenames
-will have the form **iceh.[timeID].nc** or **iceh.[timeID].da**,
+in **ice\_in**. These settings for history files are set in the 
+**setup\_nml** section of **ice\_in** (see :ref:`tabnamelist`). 
+If `history\_file` = ‘iceh’ then the 
+filenames will have the form **iceh.[timeID].nc** or **iceh.[timeID].da**,
 depending on the output file format chosen in **comp\_ice** (set
 `IO\_TYPE`). The  history files are CF-compliant; header information for
 data contained in the  files is displayed with the command `ncdump -h
@@ -752,9 +754,10 @@ filename.nc`. Parallel  output is available using the PIO library; the
 attribute `io\_flavor` distinguishes output files written with PIO from
 those written with standard netCDF. With binary files, a separate header
 file is written with equivalent information. Standard fields are output
-according to settings in the **icefields\_nml** namelist in **ice\_in**.
+according to settings in the **icefields\_nml** section of **ice\_in** 
+(see :ref:`tabnamelist`).
 The user may add (or subtract) variables not already available in the
-namelist by following the instructions in section :ref:`addhist`.
+namelist by following the instructions in section :ref:`addhist`. 
 
 With this release, the history module has been divided into several
 modules based on the desired formatting and on the variables
@@ -779,7 +782,7 @@ with a given `histfreq` value, or if an element of `histfreq\_n` is 0, then
 no file will be written at that frequency. The output period can be
 discerned from the filenames.
 
-For example, in namelist:
+For example, in the namelist:
 
 ::
 
@@ -831,6 +834,16 @@ representing an average over the sea ice fraction of the grid cell, and
 another that is multiplied by :math:`a_i`, representing an average over
 the grid cell area. Our naming convention attaches the suffix “\_ai" to
 the grid-cell-mean variable names.
+
+In this version of CICE, history variables requested by the Sea Ice Model Intercomparison 
+Project (SIMIP) have been added as possible history output variables (e.g. 
+`f_sithick`, `f_sidmassgrowthbottom`, etc.). A full list of SIMIP variables is 
+available at the following site
+<https://earthsystemcog.org/projects/wip/CMIP6DataRequest>. 
+Additionally, a new history output variable, `f_CMIP`, has been added. When `f_CMIP`
+is added to the **icefields\_nml** section of **ice\_in** then all SIMIP variables
+will be turned on for output at the frequency specified by `f_CMIP`. 
+
 
 ****************
 Diagnostic files

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -182,7 +182,9 @@ Some of the options are
 
 ``bgc*`` which turns of various bgc configurations
 
-and there are others.  These may change as needed.  Use ``cice.setup --help`` to see the latest.  To add a new option, just add the appropriate file in **configuration/scripts/options**.  For more information, see :ref:`dev_options`
+and there are others.  These may change as needed.  Use ``cice.setup --help`` to see the latest.  
+To add a new option, just add the appropriate file in **configuration/scripts/options**.  
+For more information, see :ref:`dev_test_options`
 
 Examples
 ~~~~~~~~~

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -534,7 +534,7 @@ and CICE have not significantly altered simulated ice volume using previous mode
 configurations.  Here we describe the CICE testing tools, which are applies to output 
 from five-year gx-1 simulations that use the standard CICE atmospheric forcing. 
 A scientific justification of the testing is provided in
-:cite:`Hunke2018`.
+:cite:`HRALTCDBHWDG18`.
 
 .. _paired:
 
@@ -550,7 +550,7 @@ approximated as
 :math:`\bar{h}_{d}=\tfrac{1}{n}\sum_{i=1}^n (h_{ai}{-}h_{bi})` for
 :math:`n` paired samples of ice thickness :math:`h_{ai}` and
 :math:`h_{bi}` in each grid cell of the gx-1 mesh. Following
-:cite:`Wilks2006`, the associated :math:`t`-statistic
+:cite:`Wilks06`, the associated :math:`t`-statistic
 expects a zero mean, and is therefore
 
 .. math::
@@ -582,15 +582,15 @@ equations (:eq:`t-distribution`). That is:
    \bar{h}_d=\frac{1}{n} \sum \limits_{i=1}^{n} {h}_{di}
    :label: short-means
 
-Following :cite:`Zwiers1995`, the effective sample size is
+Following :cite:`ZvS95`, the effective sample size is
 limited to :math:`n_{eff}\in[2,n]`. This definition of :math:`n_{eff}`
 assumes ice thickness evolves as an AR(1) process
-:cite:`VonStorch1999`, which can be justified by analyzing
+:cite:`vSZ99`, which can be justified by analyzing
 the spectral density of daily samples of ice thickness from 5-year
-records in CICE Consortium member models :cite:`Hunke2018`.
+records in CICE Consortium member models :cite:`HRALTCDBHWDG18`.
 The AR(1) approximation is inadmissible for paired velocity samples,
 because ice drift possesses periodicity from inertia and tides
-:cite:`Hibler2006,Lepparanta2012,Roberts2015`. Conversely,
+:cite:`HRHPSL06,LOSF12,RCWODHNCB15`. Conversely,
 tests of paired ice concentration samples may be less sensitive to ice
 drift than ice thickness. In short, ice thickness is the best variable
 for CICE Consortium quality control (QC), and for the test of the mean
@@ -599,7 +599,7 @@ in particular.
 Care is required in analyzing mean sea ice thickness changes using
 (:eq:`t-distribution`) with
 :math:`N{=}n_{eff}{-}1` degrees of freedom.
-:cite:`Zwiers1995` demonstrate that the :math:`t`-test in
+:cite:`ZvS95` demonstrate that the :math:`t`-test in
 (:eq:`t-distribution`) becomes conservative when
 :math:`n_{eff} < 30`, meaning that :math:`H_0` may be erroneously
 confirmed for highly auto-correlated series. Strong autocorrelation
@@ -607,7 +607,7 @@ frequently occurs in modeled sea ice thickness, and :math:`r_1>0.99` is
 possible in parts of the gx-1 domain for the five-year QC simulations.
 In the event that :math:`H_0` is confirmed but :math:`2\leq n_{eff}<30`,
 the :math:`t`-test progresses to the ‘Table Lookup Test’ of
-:cite:`Zwiers1995`, to check that the first-stage test
+:cite:`ZvS95`, to check that the first-stage test
 using (:eq:`t-distribution`) was not
 conservative. The Table Lookup Test chooses critical :math:`t` values
 :math:`|t|<t_{crit}({1{-}\alpha/2},N)` at the :math:`\alpha`
@@ -615,13 +615,13 @@ significance level based on :math:`r_1`. It uses the conventional
 :math:`t={\bar{h}_{d} \sqrt{n}}/{\sigma_d}` statistic with degrees of
 freedom :math:`N{=}n{-}1`, but with :math:`t_{crit}` values generated
 using the Monte Carlo technique described in
-:cite:`Zwiers1995`, and summarized in :ref:`Table-Lookup` for 5-year QC
+:cite:`ZvS95`, and summarized in :ref:`Table-Lookup` for 5-year QC
 simulations (:math:`N=1824`) at the two-sided 80% confidence interval
 (:math:`\alpha=0.2`). We choose this interval to limit Type II errors,
 whereby a QC test erroneously confirms :math:`H_0`.
 
 Table :ref:`Table-Lookup` shows the summary of two-sided :math:`t_{crit}` values for the Table
-Lookup Test of :cite:`Zwiers1995` at the 80% confidence
+Lookup Test of :cite:`ZvS95` at the 80% confidence
 interval generated for :math:`N=1824` degrees of freedom and lag-1
 autocorrelation :math:`r_1`.
 
@@ -633,8 +633,6 @@ autocorrelation :math:`r_1`.
    :math:`r_1`,-0.05,0.0,0.2,0.4,0.5,0.6,0.7,0.8,0.9,0.95,0.97,0.99
    :math:`t_{crit}`,1.32,1.32,1.54,2.02,2.29,2.46,3.17,3.99,5.59,8.44,10.85,20.44
 
-| 
-| 
 
 .. _quadratic:
 
@@ -645,7 +643,7 @@ Quadratic Skill Compliance Test
 In addition to the two-stage test of mean sea ice thickness, we also
 check that paired simulations are highly correlated and have similar
 variance using a skill metric adapted from
-:cite:`Taylor2001`. A general skill score applicable to
+:cite:`Taylor01`. A general skill score applicable to
 Taylor diagrams takes the form
 
 .. math::
@@ -654,7 +652,7 @@ Taylor diagrams takes the form
 
 where :math:`m=1` for variance-weighted skill, and :math:`m=4` for
 correlation-weighted performance, as given in equations (4) and (5) of
-:cite:`Taylor2001`, respectively. We choose :math:`m=2` to
+:cite:`Taylor01`, respectively. We choose :math:`m=2` to
 balance the importance of variance and correlation reproduction in QC
 tests, where :math:`\hat{\sigma}_{f}={\sigma_{b}}/{\sigma_{a}}` is the ratio
 of the standard deviations of simulations ‘:math:`b`’ and ‘:math:`a`’,
@@ -721,7 +719,7 @@ score :math:`S` is calculated separately for the northern and southern
 hemispheres, and must exceed a critical value nominally set to
 :math:`S_{crit}=0.99` to pass the test. Practical illustrations of this
 test and the Two-Stage test described in the previous section are
-provided in :cite:`Hunke2018`.
+provided in :cite:`HRALTCDBHWDG18`.
 
 
 Code Compliance Testing Procedure


### PR DESCRIPTION
Documentation about addition of CMIP6/SIMIP variable inclusion in history variables. Follow up to PR #191 

- Developer(s):  Alice DuVivier

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial?  bfb

- Please include the link to test results or paste the summary block from the bottom of the testing output below. n/a

- Does this PR create or have dependencies on Icepack or any other models? no

- Is the documentation being updated with this PR? Y - follow up to #191 
If not, does the documentation need to be updated separately at a later time? (Y/N)

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
