### PR TITLE
Add POP tx1 grid.

### DIFF
--- a/configuration/scripts/options/set_nml.tx1
+++ b/configuration/scripts/options/set_nml.tx1
@@ -1,0 +1,12 @@
+dt = 3600.0
+runtype = 'initial'
+ice_ic  = 'default'
+grid_format = 'bin'
+grid_type   = 'tripole'
+grid_file   = 'ICE_MACHINE_INPUTDATA/CICE_data/grid/tx1/grid_tx1.bin'
+kmt_file    = 'ICE_MACHINE_INPUTDATA/CICE_data/grid/tx1/kmt_tx1.bin'
+fyear_init      = 1997
+atm_data_format = 'bin'
+atm_data_type   = 'clim'
+atm_data_dir    = 'none'
+

--- a/configuration/scripts/tests/base_suite.ts
+++ b/configuration/scripts/tests/base_suite.ts
@@ -9,6 +9,7 @@ smoke          gx3     4x2        diag1,run5day          smoke_gx3_8x2_diag1_run
 smoke          gx3     4x1        diag1,run5day,thread   smoke_gx3_8x2_diag1_run5day
 decomp         gx3     4x2x25x29x5
 restart        gx1     40x4       droundrobin,short
+restart        tx1     40x4       dsectrobin,short
 restart        gx3     4x4        none
 restart        gx3     4x4        iobinary
 restart        gx3     6x2        alt01

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -100,7 +100,9 @@ including that used for the column configuration. The input files
 **global\_gx3.grid** and **global\_gx3.kmt** contain the
 :math:`\left<3^\circ\right>` POP grid and land mask;
 **global\_gx1.grid** and **global\_gx1.kmt** contain the
-:math:`\left<1^\circ\right>` grid and land mask. These are binary
+:math:`\left<1^\circ\right>` grid and land mask, and **global\_tx1.grid** 
+and **global\_tx1.kmt** contain the :math:`\left<1^\circ\right>` POP 
+tripole grid and land mask. These are binary
 unformatted, direct access files produced on an SGI (Big Endian). If you
 are using an incompatible (Little Endian) architecture, choose
 `rectangular` instead of `displaced\_pole` in **ice\_in**, or follow

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -125,7 +125,7 @@ Testing will be described in greater detail in the :ref:`testing` section.
   specifies a batch account number.  This is optional.  See :ref:`account` for more information.
 
 ``--grid``, ``-g`` GRID
-  specifies the grid.  This is a string and for the current CICE driver, gx1 and gx3 are supported. (default = gx3)
+  specifies the grid.  This is a string and for the current CICE driver, gx1, gx3, and tx1 are supported. (default = gx3)
 
 ``--set``,  ``-s`` SET1,SET2,SET3
   specifies the optional settings for the case.  The settings for ``--suite`` are defined in the suite file.  Multiple settings can be specified by providing a comma deliminated set of values without spaces between settings.  The available settings are in **configurations/scripts/options** and ``cice.setup --help`` will also list them.  These settings files can change either the namelist values or overall case settings (such as the debug flag).
@@ -162,7 +162,7 @@ Some of the options are
 
 ``short``, ``medium``, ``long`` which change the batch time limit
 
-``gx3`` and ``gx1`` are associate with grid specific settings
+``gx3``, ``gx1``, ``tx1`` are associate with grid specific settings
 
 ``diag1`` which turns on diagnostics each timestep
 
@@ -355,7 +355,7 @@ Table :ref:`comp-ice` shows configuration options available in **comp_ice**.
    +---------------------+--------------------------------------+------------------------------------------------------------------------------------+
    | variable            | options                              | description                                                                        |
    +=====================+======================================+====================================================================================+
-   |RES                  | col, gx3, gx1                        | grid resolution                                                                    |
+   |RES                  | col, gx3, gx1, tx1                   | grid resolution                                                                    |
    +---------------------+--------------------------------------+------------------------------------------------------------------------------------+
    |NTASK                | (integer)                            | total number of processors                                                         |
    +---------------------+--------------------------------------+------------------------------------------------------------------------------------+


### PR DESCRIPTION
I have added support for the tx1 POP tripole grid. There is also a test added to base_suite here. Currently it uses the uniform climatological forcing and ice_ic = 'default'. It is mainly for testing purposes. I will add the tripole grid and kmt files to the ftp downloads.

- Developer(s): D. Bailey

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Please include the link to test results or paste the summary block from the bottom of the testing output below.

- Does this PR create or have dependencies on Icepack or any other models? N

- Is the documentation being updated with this PR? (Y/N) Y
If not, does the documentation need to be updated separately at a later time? (Y/N)

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
