### PR TITLE
Corrected k1 parameter for grounding scheme

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -691,8 +691,7 @@
          endif
 
       !-----------------------------------------------------------------
-      ! replacement pressure/Delta                   ! kg/s
-      ! save replacement pressure for principal stress calculation
+      ! strength/Delta                   ! kg/s
       !-----------------------------------------------------------------
          c0ne = strength(i,j)/max(Deltane,tinyarea(i,j))
          c0nw = strength(i,j)/max(Deltanw,tinyarea(i,j))

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -943,7 +943,7 @@
          hu,  & ! volume per unit area of ice at u location (mean thickness)
          hwu, & ! water depth at u location
          hcu, & ! critical thickness at u location
-         k1 = 20.0_dbl_kind , &  ! first free parameter for landfast parametrization 
+         k1 = 8.0_dbl_kind , &  ! first free parameter for landfast parametrization 
          k2 = 15.0_dbl_kind , &  ! second free parameter (N/m^3) for landfast parametrization 
          alphab = 20.0_dbl_kind  ! alphab=Cb factor in Lemieux et al 2015
 


### PR DESCRIPTION
[Remove this and add a short summary line]:

- Developer(s): JF Lemieux

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? NA

- Please include the link to test results or paste the summary block from the bottom of the testing output below.

- Does this PR create or have dependencies on Icepack or any other models? N

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:

k1 was 20. It is now set to the rigth value (k1=8). 

I also removed a comment in ice_dyn_evp.F90 saying that we save the replacement pressure for principal_stress (not used anymore).
