### PR TITLE
Change COPY to also PASS

### DIFF
--- a/cice.setup
+++ b/cice.setup
@@ -837,7 +837,7 @@ cat >> ./${tsdir}/results.csh << EOF
 cat ./results.log
 set pends = \`cat ./results.log | grep PEND | wc -l\`
 set failures = \`cat ./results.log | grep FAIL | wc -l\`
-set success = \`cat ./results.log | grep PASS | wc -l\`
+set success = \`cat ./results.log | grep 'PASS\|COPY' | wc -l\`
 set comments = \`cat ./results.log | grep "#" | wc -l\`
 set alltotal = \`cat ./results.log | wc -l\`
 @ total = \$alltotal - \$comments


### PR DESCRIPTION
Change the results.csh script to view COPY and PASS as a PASS

- Developer(s):  Matt Turner

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? bfb

- Please include the link to test results or paste the summary block from the bottom of the testing output below.

- Does this PR create or have dependencies on Icepack or any other models? No

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
- Ran the `quick_suite`, and there were no longer any missing tests (where tests with COPY were not included in the summary output at the end).