### PR TITLE
Revised EVP updated v2

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -40,7 +40,7 @@
           p2, p222, p25, p333, p5, c1
       use ice_dyn_shared, only: stepu, dyn_prep1, dyn_prep2, dyn_finish, &
           ndte, yield_curve, ecci, denom1, arlx1i, fcor_blk, uvel_init,  &
-          vvel_init, basal_stress_coeff, basalstress, Ktens
+          vvel_init, basal_stress_coeff, basalstress, Ktens, revp
       use ice_fileunits, only: nu_diag
       use ice_exit, only: abort_ice
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
@@ -710,24 +710,24 @@
       ! (1) northeast, (2) northwest, (3) southwest, (4) southeast
       !-----------------------------------------------------------------
 
-         stressp_1(i,j) = (stressp_1(i,j) + c1ne*(divune*(c1+Ktens) - Deltane*(c1-Ktens))) &
+         stressp_1(i,j) = (stressp_1(i,j)*(c1-arlx1i*revp) + c1ne*(divune*(c1+Ktens) - Deltane*(c1-Ktens))) &
                           * denom1
-         stressp_2(i,j) = (stressp_2(i,j) + c1nw*(divunw*(c1+Ktens) - Deltanw*(c1-Ktens))) &
+         stressp_2(i,j) = (stressp_2(i,j)*(c1-arlx1i*revp) + c1nw*(divunw*(c1+Ktens) - Deltanw*(c1-Ktens))) &
                           * denom1
-         stressp_3(i,j) = (stressp_3(i,j) + c1sw*(divusw*(c1+Ktens) - Deltasw*(c1-Ktens))) &
+         stressp_3(i,j) = (stressp_3(i,j)*(c1-arlx1i*revp) + c1sw*(divusw*(c1+Ktens) - Deltasw*(c1-Ktens))) &
                           * denom1
-         stressp_4(i,j) = (stressp_4(i,j) + c1se*(divuse*(c1+Ktens) - Deltase*(c1-Ktens))) &
+         stressp_4(i,j) = (stressp_4(i,j)*(c1-arlx1i*revp) + c1se*(divuse*(c1+Ktens) - Deltase*(c1-Ktens))) &
                           * denom1
 
-         stressm_1(i,j) = (stressm_1(i,j) + c0ne*tensionne*(c1+Ktens)) * denom1
-         stressm_2(i,j) = (stressm_2(i,j) + c0nw*tensionnw*(c1+Ktens)) * denom1
-         stressm_3(i,j) = (stressm_3(i,j) + c0sw*tensionsw*(c1+Ktens)) * denom1
-         stressm_4(i,j) = (stressm_4(i,j) + c0se*tensionse*(c1+Ktens)) * denom1
+         stressm_1(i,j) = (stressm_1(i,j)*(c1-arlx1i*revp) + c0ne*tensionne*(c1+Ktens)) * denom1
+         stressm_2(i,j) = (stressm_2(i,j)*(c1-arlx1i*revp) + c0nw*tensionnw*(c1+Ktens)) * denom1
+         stressm_3(i,j) = (stressm_3(i,j)*(c1-arlx1i*revp) + c0sw*tensionsw*(c1+Ktens)) * denom1
+         stressm_4(i,j) = (stressm_4(i,j)*(c1-arlx1i*revp) + c0se*tensionse*(c1+Ktens)) * denom1
 
-         stress12_1(i,j) = (stress12_1(i,j) + c0ne*shearne*p5*(c1+Ktens)) * denom1
-         stress12_2(i,j) = (stress12_2(i,j) + c0nw*shearnw*p5*(c1+Ktens)) * denom1
-         stress12_3(i,j) = (stress12_3(i,j) + c0sw*shearsw*p5*(c1+Ktens)) * denom1
-         stress12_4(i,j) = (stress12_4(i,j) + c0se*shearse*p5*(c1+Ktens)) * denom1
+         stress12_1(i,j) = (stress12_1(i,j)*(c1-arlx1i*revp) + c0ne*shearne*p5*(c1+Ktens)) * denom1
+         stress12_2(i,j) = (stress12_2(i,j)*(c1-arlx1i*revp) + c0nw*shearnw*p5*(c1+Ktens)) * denom1
+         stress12_3(i,j) = (stress12_3(i,j)*(c1-arlx1i*revp) + c0sw*shearsw*p5*(c1+Ktens)) * denom1
+         stress12_4(i,j) = (stress12_4(i,j)*(c1-arlx1i*revp) + c0se*shearse*p5*(c1+Ktens)) * denom1
 
       !-----------------------------------------------------------------
       ! Eliminate underflows.

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -242,8 +242,9 @@
 
       if (revised_evp) then       ! Bouillon et al, Ocean Mod 2013
          revp   = c1
-         arlx1i = c2*xi/Se        ! 1/alpha1
-         brlx = c2*Se*xi*gamma/xmin**2 ! beta
+         denom1 = c1
+         !TAR: According to mail of Martin Loesch: for a ~25km grid:
+         !      brlx=300 , arlx1i = c1/brlx
 
 ! classic evp parameters (but modified equations)
 !         arlx1i = dte2T
@@ -253,6 +254,8 @@
          revp   = c0
          arlx1i = dte2T
          brlx   = dt*dtei
+         denom1 = c1/(c1+arlx1i)
+
 
 ! revised evp parameters
 !         arlx1i = c2*xi/Se        ! 1/alpha1
@@ -266,8 +269,6 @@
                   p5*brlx/gamma*xmin**2, &
                   p5*xmin*sqrt(brlx*arlx1i/gamma)
       endif            
-
-      denom1 = c1/(c1+arlx1i)
 
       end subroutine set_evp_parameters
 

--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -90,7 +90,7 @@
                           dxrect, dyrect
       use ice_dyn_shared, only: ndte, kdyn, revised_evp, yield_curve, &
                                 basalstress, Ktens, e_ratio, coriolis, &
-                                kridge, ktransport
+                                kridge, ktransport, brlx, arlx1i
       use ice_transport_driver, only: advection
       use ice_restoring, only: restore_ice
 #ifdef CESMCOUPLED
@@ -164,6 +164,7 @@
 
       namelist /dynamics_nml/ &
         kdyn,           ndte,           revised_evp,    yield_curve,    &
+        brlx,           arlx1i,                                         &
         advection,      coriolis,       kridge,         ktransport,     &
         kstrength,      krdg_partic,    krdg_redist,    mu_rdg,         &
         e_ratio,        Ktens,          Cf,             basalstress
@@ -275,6 +276,8 @@
       kdyn = 1           ! type of dynamics (-1, 0 = off, 1 = evp, 2 = eap)
       ndtd = 1           ! dynamic time steps per thermodynamic time step
       ndte = 120         ! subcycles per dynamics timestep:  ndte=dt_dyn/dte
+      brlx   = 300.0_dbl_kind ! revised_evp values. Otherwise overwritten in ice_dyn_shared
+      arlx1i = c1/brlx        ! revised_evp values. Otherwise overwritten in ice_dyn_shared
       revised_evp = .false.  ! if true, use revised procedure for evp dynamics
       yield_curve = 'ellipse'
       kstrength = 1          ! 1 = Rothrock 75 strength, 0 = Hibler 79
@@ -542,6 +545,8 @@
       call broadcast_scalar(kdyn,               master_task)
       call broadcast_scalar(ndtd,               master_task)
       call broadcast_scalar(ndte,               master_task)
+      call broadcast_scalar(brlx,               master_task)
+      call broadcast_scalar(arlx1i,             master_task)
       call broadcast_scalar(revised_evp,        master_task)
       call broadcast_scalar(yield_curve,        master_task)
       call broadcast_scalar(kstrength,          master_task)
@@ -983,6 +988,8 @@
          write(nu_diag,1020) ' ndte                      = ', ndte
          write(nu_diag,1010) ' revised_evp               = ', &
                                revised_evp
+         write(nu_diag,1006) ' brlx                      = ', brlx
+         write(nu_diag,1006) ' arlx1i                    = ', arlx1i
          if (kdyn == 1) &
          write(nu_diag,*)    ' yield_curve               = ', &
                                trim(yield_curve)
@@ -1275,6 +1282,7 @@
 
  1000    format (a30,2x,f9.2)  ! a30 to align formatted, unformatted statements
  1005    format (a30,2x,f9.6)  ! float
+ 1006    format (a30,2x,f11.6) ! float
  1010    format (a30,2x,l6)    ! logical
  1020    format (a30,2x,i6)    ! integer
  1021    format (a30,2x,a8,i6) ! char, int


### PR DESCRIPTION
Update of:
https://github.com/CICE-Consortium/CICE/pull/184/

--o--

Revised EVP parameters, according to Kimmirtz, Danilov and Losch, 2015

- Developer(s): Till Rasmussen and Mads Hvid Ribergaard, DMI
- Please suggest code Pull Request reviewers in the column at right.
    Elisabeth?, Tony?, Jean-Francois?
- Are the code changes bit for bit, different at roundoff level, or more substantial?
- With conservative settings - AND revised_evp=.false. - it should output Bit-for-bit identical.
    With revised_evp=.true. the settings has changed. Therefore obvious NOT bit-to-bit identical
- Is the documentation being updated with this PR? (Y/N) N
- If not, does the documentation need to be updated separately at a later time? (Y/N) ??
    Note: "Documentation" includes information on the wiki and .rst files in doc/source/,
    which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:

affected files:
./cicecore/cicedynB/dynamics/ice_dyn_evp.F90
./cicecore/cicedynB/dynamics/ice_dyn_shared.F90 (for namelist)
./cicecore/cicedynB/general/ice_init.F90 (for namelist)

Namelist (these are the default values, ONLY relevant for revised_evp=.true.):
&dynamics_nml
brlx = 300.0
arlx1i = 1.0/300.0

NOTE: The values for "brlx and arlx1i" are overwritten in ice_dyn_shared for revised_evp=.false.
