### PR TITLE
Read HYCOM fields + other minor corrections

### DIFF
--- a/cicecore/cicedynB/analysis/ice_history.F90
+++ b/cicecore/cicedynB/analysis/ice_history.F90
@@ -1822,6 +1822,7 @@
       ! increment field
       !---------------------------------------------------------------
 
+!MHRI: CHECK THIS OMP
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block, &
       !$OMP             k,n,qn,ns,sn,rho_ocn,rho_ice,Tice,Sbr,phi,rhob, &
       !$OMP             worka,workb,worka3,Tinz4d,Sinz4d,Tsnz4d)

--- a/cicecore/cicedynB/infrastructure/ice_read_write.F90
+++ b/cicecore/cicedynB/infrastructure/ice_read_write.F90
@@ -41,6 +41,8 @@
                 ice_write,          &
                 ice_write_nc,       &
                 ice_write_ext,      &
+                ice_read_vec_nc,    &
+                ice_get_ncvarsize,  &
                 ice_close_nc
 
       interface ice_write
@@ -76,11 +78,14 @@
 !
 ! author: Tony Craig, NCAR
 
-      subroutine ice_open(nu, filename, nbits)
+      subroutine ice_open(nu, filename, nbits, algn)
 
       integer (kind=int_kind), intent(in) :: &
            nu        , & ! unit number
            nbits         ! no. of bits per variable (0 for sequential access)
+
+      integer (kind=int_kind), intent(in), optional :: algn
+      integer (kind=int_kind) :: RecSize, Remnant
 
       character (*) :: filename
 
@@ -93,7 +98,17 @@
             open(nu,file=filename,form='unformatted')
 
          else                   ! direct access
-            open(nu,file=filename,recl=nx_global*ny_global*nbits/8, &
+            RecSize = nx_global*ny_global*nbits/8
+            if (present(algn)) then
+              ! If data is keept in blocks using given sizes (=algn)
+              if (algn /= 0) then
+                Remnant = modulo(RecSize,algn)
+                if (Remnant /= 0) then
+                  RecSize = RecSize + (algn - Remnant)
+                endif
+              endif
+            endif
+            open(nu,file=filename,recl=RecSize, &
                   form='unformatted',access='direct')
          endif                   ! nbits = 0
 
@@ -1842,7 +1857,7 @@
            nrec              ! record number 
 
      character (char_len), intent(in) :: & 
-           varname           ! field name in netcdf file        
+           varname           ! field name in netcdf file
 
       real (kind=dbl_kind), dimension(nx_global,ny_global), &
            intent(out) :: &
@@ -2101,6 +2116,121 @@
       work = c0 ! to satisfy intent(out) attribute
 #endif
       end subroutine ice_read_nc_uv
+
+!=======================================================================
+! Read a vector in a netcdf file.
+! Just like ice_read_global_nc except that it returns a vector.
+! work_g is a real vector
+!
+! Adapted by William Lipscomb, LANL, from ice_read
+! Adapted by Ann Keen, Met Office, to read from a netcdf file
+
+      subroutine ice_read_vec_nc (fid,  nrec, varname, work_g, diag)
+
+      integer (kind=int_kind), intent(in) :: &
+           fid           , & ! file id
+           nrec              ! record number
+
+      character (char_len), intent(in) :: &
+           varname           ! field name in netcdf file
+
+      real (kind=dbl_kind), dimension(nrec), &
+           intent(out) :: &
+           work_g            ! output array (real, 8-byte)
+
+      logical (kind=log_kind) :: &
+           diag              ! if true, write diagnostic output
+
+      ! local variables
+
+      character(len=*), parameter :: subname = '(ice_read_vec_nc)'
+
+#ifdef ncdf
+! netCDF file diagnostics:
+      integer (kind=int_kind) :: &
+         varid,           & ! netcdf id for field
+         status,          & ! status output from netcdf routines
+         nvar               ! sizes of netcdf vector
+
+      real (kind=dbl_kind) :: &
+         amin, amax         ! min, max values of input vector
+
+      character (char_len) :: &
+         dimname            ! dimension name
+!
+      work_g(:) = c0
+
+      if (my_task == master_task) then
+
+        !-------------------------------------------------------------
+        ! Find out ID of required variable
+        !-------------------------------------------------------------
+
+         status = nf90_inq_varid(fid, trim(varname), varid)
+
+         if (status /= nf90_noerr) then
+           call abort_ice (subname//'ERROR: Cannot find variable '//trim(varname) )
+         endif
+
+       !--------------------------------------------------------------
+       ! Read global array
+       !--------------------------------------------------------------
+
+         status = nf90_get_var( fid, varid, work_g, &
+               start=(/1/), &
+               count=(/nrec/) )
+      endif                     ! my_task = master_task
+
+      !-------------------------------------------------------------------
+      ! optional diagnostics
+      !-------------------------------------------------------------------
+
+      if (my_task == master_task .and. diag) then
+         amin = minval(work_g)
+         amax = maxval(work_g)
+         write(nu_diag,*) 'min, max, nrec = ', amin, amax, nrec
+      endif
+
+#else
+      write(*,*) 'ERROR: ncdf not defined during compilation'
+      work_g = c0 ! to satisfy intent(out) attribute
+#endif
+      end subroutine ice_read_vec_nc
+
+!=======================================================================
+! Get number of variables of a given variable
+      subroutine ice_get_ncvarsize(fid,varname,recsize)
+
+      integer (kind=int_kind), intent(in) :: &
+         fid                 ! file id
+      character (char_len), intent(in) :: &
+         varname             ! field name in netcdf file
+      integer (kind=int_kind), intent(out) :: &
+         recsize             ! Number of records in file
+      integer (kind=int_kind) :: &
+         ndims, i, status
+      character (char_len) :: &
+         cvar
+      character(len=*), parameter :: subname = '(ice_get_ncvarsize)'
+
+      if (my_task ==  master_task) then
+         status=nf90_inquire(fid, nDimensions = nDims)
+         if (status /= nf90_noerr) then
+           call abort_ice (subname//'ERROR: inquire nDimensions' )
+         endif
+         do i=1,nDims
+            status = nf90_inquire_dimension(fid,i,name=cvar,len=recsize)
+            if (status /= nf90_noerr) then
+              call abort_ice (subname//'ERROR: inquire len for variable '//trim(cvar) )
+            endif
+            call flush(nu_diag)
+            if (trim(cvar) == trim(varname)) exit
+         enddo
+         if (trim(cvar) .ne. trim(varname)) then
+            call abort_ice (subname//'ERROR: Did not find variable '//trim(varname) )
+         endif
+      endif
+      end subroutine ice_get_ncvarsize
 
 !=======================================================================
 


### PR DESCRIPTION
1) Subroutines for reading HYCOM initial SST+SSS forcing and HYCOM like NetCDF atmospheric forcing

2) Minor corrections in popgrid_nc in ice_grid.F90: All records are the first - unlike for binary file formats

3) Minor changes to "read_basalstress_bathy" in ice.grid.F90 and by default called, if "bathymetry.nc" file exists.

--o--

- Developer(s): Mads Hvid Ribergaard, DMI

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial?
Yes, BFB

- Please include the link to test results or paste the summary block from the bottom of the testing output below.

- Does this PR create or have dependencies on Icepack or any other models? 

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) Don't think so.

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:

ad 1) HYCOM forcing:
Do not conflict with other stuff. But nice to have for DMI :-)

ad 2) "popgrid_nc" record-numbers in ice_grid.F90
Corrected all nrec to 1, as it is the first record that is needed for each variables: htn, hte, kmt, etc.
There is ONLY one record for each variable! This is different from "popgrid"-binary, which consists of 7 variables - ie. need a specific record number.

ad 3) read_basalstress_bathy:
This is a suggestion made in parallel to PR #222 by dabail22, which I was not aware of. Perhaps useful to merge, perhaps not... 

--o--

I think by this PR, the #160 can be deleted. Its content is included within:
1) #205 : EVP kernel vectorized.
1a) #205 OMP issues. Indication of where to look. Some of them has already been changed / comment out.
2) #219 : revised EVP.
3) Splitting namelist. I do not think this is relevant anymore, after the reading has been re-structured into one single file.
4) #224 DMI (HYCOM) specific: This one:-)
5) #195 : Allocatable dynamics (Implemented)

