### PR TITLE
Modified the documentation for the revised EVP. 

### DIFF
--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -847,6 +847,28 @@
   pages = {211-228},
   url = {http://dx.doi.org/10.3189/2015AoG69A760}
 }
+
+@Article{Kimmritz15
+  author = "M. Kimmritz and S. Danilov and M. Losch",
+  title = "{On the convergence of the modified elastic-viscous-plastic method for solving the sea ice momentum equation}",
+  journal = JCP,
+  year = {2015},
+  volume = {296},
+  pages = {90-100},
+  url = {http://dx.doi.org/10.1016/j.jcp.2015.04.051}
+}
+
+@Article{Lemieux12
+  author = "J.F. Lemieux and D.A. Knoll and B. Tremblay and D.M. Holland and M. Losch",
+  title = "{A comparison of the {J}acobian-free {N}ewton {K}rylov method and the {EVP} model for solving the sea ice momentum equation with a
+  viscous-plastic formulation: a serial algorithm study}",
+  journal = JCP,
+  year = {2012},
+  volume = {231},
+  pages = {5926-5944},
+  url = {http://dx.doi.org/10.1016/j.jcp.2012.05.024}
+}
+
 @Article{Lemieux16
   author = "J.F. Lemieux and F. Dupont and P. Blain and F. Roy and G.C. Smith and G.M. Flato",
   title = "{Improving the simulation of landfast ice by combining tensile strength and a parameterization for grounded ridges}",


### PR DESCRIPTION
The documentation is now in line with revpv4 (PR 226). 

I also did a few other minor modifications to the classic EVP and the basal stress sections. Elizabeth feel free to keep these or not. I thought it was a good idea to include the discretized (in time) equations for the stresses (as it is done for the u and v momentum equations). By doing so it is easier to introduce the revised EVP equations. 

- Developer(s): JF Lemieux

- Please suggest code Pull Request reviewers in the column at 

@eclare108213

- Are the code changes bit for bit, different at roundoff level, or more substantial? N.A.

- Please include the link to test results or paste the summary block from the bottom of the testing output below.

- Does this PR create or have dependencies on Icepack or any other models? No

- Is the documentation being updated with this PR? (Y/N) Y
If not, does the documentation need to be updated separately at a later time? (Y/N)

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:


