### PR TITLE
Update gordon and onyx default queues from debug to standard

### DIFF
--- a/configuration/scripts/machines/env.gordon_cray
+++ b/configuration/scripts/machines/env.gordon_cray
@@ -49,7 +49,7 @@ setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
-setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_QUEUE "standard"
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
 setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.gordon_gnu
+++ b/configuration/scripts/machines/env.gordon_gnu
@@ -49,7 +49,7 @@ setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
-setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_QUEUE "standard"
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4 
 setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.gordon_intel
+++ b/configuration/scripts/machines/env.gordon_intel
@@ -49,7 +49,7 @@ setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
-setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_QUEUE "standard"
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
 setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.gordon_pgi
+++ b/configuration/scripts/machines/env.gordon_pgi
@@ -49,7 +49,7 @@ setenv ICE_MACHINE_INPUTDATA /p/work1/RASM_data/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT ARLAP96070PET
-setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_QUEUE "standard"
 setenv ICE_MACHINE_TPNODE 32    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 4
 setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.onyx_cray
+++ b/configuration/scripts/machines/env.onyx_cray
@@ -49,7 +49,7 @@ setenv ICE_MACHINE_INPUTDATA /p/app/unsupported/RASM/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
-setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_QUEUE "standard"
 setenv ICE_MACHINE_TPNODE 44    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 12
 setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.onyx_gnu
+++ b/configuration/scripts/machines/env.onyx_gnu
@@ -49,7 +49,7 @@ setenv ICE_MACHINE_INPUTDATA /p/app/unsupported/RASM/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
-setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_QUEUE "standard"
 setenv ICE_MACHINE_TPNODE 44    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 12
 setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.onyx_intel
+++ b/configuration/scripts/machines/env.onyx_intel
@@ -49,7 +49,7 @@ setenv ICE_MACHINE_INPUTDATA /p/app/unsupported/RASM/cice_consortium
 setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
-setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_QUEUE "standard"
 setenv ICE_MACHINE_TPNODE 44    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 12
 setenv ICE_MACHINE_QSTAT "qstat "


### PR DESCRIPTION
Change default queue on Gordon and Onyx from `debug` to `standard`.

- Developer(s):  Matt Turner

- Please suggest code Pull Request reviewers in the column at right.

- Are the code changes bit for bit, different at roundoff level, or more substantial? bfb

- Please include the link to test results or paste the summary block from the bottom of the testing output below.

- Does this PR create or have dependencies on Icepack or any other models? No

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
This change was made because a few of the tests in the test suites require longer walltimes than permitted on the debug queue.