### PR TITLE
fix iobinary failure introduced in recent PR, address non-mpi launch …

### DIFF
--- a/cice.setup
+++ b/cice.setup
@@ -862,6 +862,12 @@ echo "#fail = \$failures" >> results.log
 echo "#pend = \$pends" >> results.log
 
 echo ""
+echo "Descriptors:"
+echo " PASS - successful completion"
+echo " COPY - previously compiled code was copied for new test"
+echo " PEND - run has been submitted to queue and is waiting or failed submission"
+echo " FAIL - test is still executing, did not complete, or completed and failed"
+echo ""
 echo "\$success of \$total tests PASSED"
 echo "\$failures of \$total tests FAILED"
 echo "\$pends of \$total tests PENDING"

--- a/cicecore/cicedynB/infrastructure/ice_read_write.F90
+++ b/cicecore/cicedynB/infrastructure/ice_read_write.F90
@@ -2201,6 +2201,7 @@
          cvar
       character(len=*), parameter :: subname = '(ice_get_ncvarsize)'
 
+#ifdef ncdf
       if (my_task ==  master_task) then
          status=nf90_inquire(fid, nDimensions = nDims)
          if (status /= nf90_noerr) then
@@ -2218,6 +2219,10 @@
             call abort_ice (subname//'ERROR: Did not find variable '//trim(varname) )
          endif
       endif
+#else
+      write(*,*) 'ERROR: ncdf not defined during compilation'
+      recsize = 0 ! to satisfy intent(out) attribute
+#endif
       end subroutine ice_get_ncvarsize
 
 !=======================================================================

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -26,69 +26,75 @@ if (${ICE_MACHINE} =~ cheyenne*) then
 cat >> ${jobfile} << EOFR
 mpiexec_mpt -n ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ hobart*) then
 cat >> ${jobfile} << EOFR
 mpiexec -n ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ thunder*) then
 cat >> ${jobfile} << EOFR
 mpiexec_mpt -np ${ntasks} omplace ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ onyx*) then
 cat >> ${jobfile} << EOFR
 aprun -n ${ntasks} -N ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ gordon* || ${ICE_MACHINE} =~ conrad*) then
+if (${ICE_COMMDIR} =~ serial*) then
+cat >> ${jobfile} << EOFR
+./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+else
 cat >> ${jobfile} << EOFR
 aprun -n ${ntasks} -N ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+endif
+#=======
 else if (${ICE_MACHINE} =~ cori*) then
 cat >> ${jobfile} << EOFR
 srun -n ${ntasks} -c ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ wolf*) then
 cat >> ${jobfile} << EOFR
 mpirun -np ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ pinto*) then
 cat >> ${jobfile} << EOFR
 mpirun -np ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ fram*) then
 cat >> ${jobfile} << EOFR
 mpirun -np ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ cesium*) then
 cat >> ${jobfile} << EOFR
 mpirun -np ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ testmachine*) then
 cat >> ${jobfile} << EOFR
 ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
+#=======
 else if (${ICE_MACHINE} =~ travisCI*) then
 cat >> ${jobfile} << EOFR
 mpirun -np ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-
 #cat >> ${jobfile} << EOFR
 #srun -n ${ntasks} -c ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
 #EOFR
-
+#=======
 else
   echo "${0} ERROR ${ICE_MACHINE} unknown"
   exit -1
 endif
+#=======
 
 exit 0


### PR DESCRIPTION
fix iobinary failure introduced in recent PR, address non-mpi launch or serial cases, add test results descriptions

- Developer(s): tcraig

- Are the code changes bit for bit, different at roundoff level, or more substantial? bit-for-bit

- Please include the link to test results or paste the summary block from the bottom of the testing output below.
  Tested iobinary cases on conrad and passing.
  Tested travis suite on all 4 compilers on conrad and all passing and bit-for-bit, validates serial/mpi launch differences.

- Does this PR create or have dependencies on Icepack or any other models?  No

- Is the documentation being updated with this PR? (Y/N) No
If not, does the documentation need to be updated separately at a later time? (Y/N) No

- Other Relevant Details:

addresses iobinary failure in recent PR for hycom, needed #ifdef ncdf around new netcdf code
tests and validates serial vs mpi launch #216 , implemented for conrad and gordon by default
adds desciptions for test results output #221.
