### PR TITLE
Correct sign error in y-component of momentum equation in doc

### DIFF
--- a/doc/source/science_guide/sg_dynamics.rst
+++ b/doc/source/science_guide/sg_dynamics.rst
@@ -78,7 +78,7 @@ EVP approach. First, for clarity, the two components of Equation :eq:`vpmom` are
      -C_bu +mfv - mg{\partial H_\circ\over\partial x}, \\
    m{\partial v\over\partial t} &=& {\partial\sigma_{2j}\over\partial x_j} + \tau_{ay} + 
      a_i c_w \rho_w
-     \left|{\bf U}_w - {\bf u}\right| \left[\left(U_w-u\right)\sin\theta - \left(V_w-v\right)\cos\theta\right]
+     \left|{\bf U}_w - {\bf u}\right| \left[\left(U_w-u\right)\sin\theta + \left(V_w-v\right)\cos\theta\right]
      -C_bv-mfu - mg{\partial H_\circ\over\partial y}. \end{aligned}
 
 In the code,


### PR DESCRIPTION
The equation for the y-component of the momentum equation in the doc had a sign wrong in the ice-ocean stress.

- Developer(s):Philippe Blain

- Please suggest code Pull Request reviewers in the column at right. @eclare108213 , @duvivier 

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Please include the link to test results or paste the summary block from the bottom of the testing output below. 
No tests, only doc changes

- Does this PR create or have dependencies on Icepack or any other models?  
No

- Is the documentation being updated with this PR? (Y/N) Yes
If not, does the documentation need to be updated separately at a later time? (Y/N)

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
It seems this error has been there for a very long time, a PDF that I had from a 2010 version of the doc had this error !