### PR TITLE
Port to gaffney and koehr

### DIFF
--- a/cicecore/shared/ice_arrays_column.F90
+++ b/cicecore/shared/ice_arrays_column.F90
@@ -257,7 +257,9 @@
          restore_bgc        ! 
 
       character(char_len), public :: &
-         fe_data_type   , & ! 'default', 'clim'
+         fe_data_type   ! 'default', 'clim'
+
+      character(char_len_long), public :: &
          bgc_data_dir   ! directory for biogeochemistry data
 
       real (kind=dbl_kind), dimension(:), allocatable, public :: &  

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -71,7 +71,7 @@ cat >> ${jobfile} << EOFB
 #PBS -l nodes=1:ppn=24
 EOFB
 
-else if (${ICE_MACHINE} =~ thunder* || ${ICE_MACHINE} =~ gordon* || ${ICE_MACHINE} =~ conrad*) then
+else if (${ICE_MACHINE} =~ thunder* || ${ICE_MACHINE} =~ gordon* || ${ICE_MACHINE} =~ conrad*  || ${ICE_MACHINE} =~ gaffney* || ${ICE_MACHINE} =~ koehr*) then
 cat >> ${jobfile} << EOFB
 #PBS -N ${shortcase}
 #PBS -q ${queue}

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -37,6 +37,17 @@ cat >> ${jobfile} << EOFR
 mpiexec_mpt -np ${ntasks} omplace ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
 #=======
+else if (${ICE_MACHINE} =~ gaffney* || ${ICE_MACHINE} =~ koehr*) then
+if (${ICE_COMMDIR} =~ serial*) then
+cat >> ${jobfile} << EOFR
+./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+else
+cat >> ${jobfile} << EOFR
+mpiexec_mpt -np ${ntasks} omplace ./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+endif
+#=======
 else if (${ICE_MACHINE} =~ onyx*) then
 cat >> ${jobfile} << EOFR
 aprun -n ${ntasks} -N ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE

--- a/configuration/scripts/machines/Macros.gaffney_gnu
+++ b/configuration/scripts/machines/Macros.gaffney_gnu
@@ -1,0 +1,64 @@
+#==============================================================================
+# Macros file for NAVYDSRC gaffney, intel compiler
+#==============================================================================
+
+CPP        := ftn -E
+CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${ICE_CPPDEFS}
+CFLAGS     := -c -O2
+
+FIXEDFLAGS := -ffixed-line-length-132
+FREEFLAGS  := -ffree-form
+FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
+FFLAGS_NOOPT:= -O0
+
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+else
+  FFLAGS     += -O2
+endif
+
+ifeq ($(ICE_COMMDIR), mpi)
+  FC         := mpif90
+  LDFLAGS += -lmpi
+else
+  FC         := gfortran
+endif
+
+MPICC:= mpicc
+MPIFC:= mpif90
+#LD:= $(MPIFC)
+LD:= gfortran
+
+# defined by module
+#NETCDF_PATH := $(NETCDF)
+#PNETCDF_PATH := $(PNETCDF)
+#PNETCDF_PATH := /glade/apps/opt/pnetcdf/1.3.0/intel/default
+#LAPACK_LIBDIR := /glade/apps/opt/lapack/3.4.2/intel/12.1.5/lib
+
+#PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
+
+INCLDIR := $(INCLDIR)
+INCLDIR += -I$(NETCDF_PATH)/include
+
+LIB_NETCDF := $(NETCDF_PATH)/lib
+#LIB_PNETCDF := $(PNETCDF_PATH)/lib
+#LIB_MPI := $(IMPILIBDIR)
+SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
+
+SCC:= icc 
+
+SFC:= ifort 
+
+ifeq ($(ICE_THREADED), true) 
+   LDFLAGS += -fopenmp
+   CFLAGS += -fopenmp
+   FFLAGS += -fopenmp
+endif
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first!
+ifeq ($(ICE_IOTYPE), pio)
+   PIO_PATH:=/glade/u/home/jedwards/pio1_6_5/pio
+   INCLDIR += -I$(PIO_PATH)
+   SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpio
+endif
+

--- a/configuration/scripts/machines/Macros.gaffney_intel
+++ b/configuration/scripts/machines/Macros.gaffney_intel
@@ -51,9 +51,9 @@ SCC:= icc
 SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
-   LDFLAGS += -openmp
-   CFLAGS += -openmp
-   FFLAGS += -openmp
+   LDFLAGS += -qopenmp
+   CFLAGS += -qopenmp
+   FFLAGS += -qopenmp
 endif
 
 ### if using parallel I/O, load all 3 libraries.  PIO must be first!

--- a/configuration/scripts/machines/Macros.gaffney_intel
+++ b/configuration/scripts/machines/Macros.gaffney_intel
@@ -1,0 +1,65 @@
+#==============================================================================
+# Macros file for NAVYDSRC gaffney, intel compiler
+#==============================================================================
+
+CPP        := fpp
+CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${ICE_CPPDEFS}
+CFLAGS     := -c -O2 -fp-model precise   -xHost
+
+FIXEDFLAGS := -132
+FREEFLAGS  := -FR
+FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback   -xHost
+FFLAGS_NOOPT:= -O0
+
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -init=snan,arrays
+else
+  FFLAGS     += -O2
+endif
+
+ifeq ($(ICE_COMMDIR), mpi)
+  FC         := ifort
+  LDFLAGS += -lmpi
+else
+  FC         := ifort
+endif
+
+MPICC:= icc
+
+MPIFC:= ifort
+LD:= $(MPIFC)
+
+# defined by module
+#NETCDF_PATH := $(NETCDF)
+#PNETCDF_PATH := $(PNETCDF)
+#PNETCDF_PATH := /glade/apps/opt/pnetcdf/1.3.0/intel/default
+#LAPACK_LIBDIR := /glade/apps/opt/lapack/3.4.2/intel/12.1.5/lib
+
+#PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
+
+INCLDIR := $(INCLDIR)
+INCLDIR += -I$(NETCDF_PATH)/include
+
+LIB_NETCDF := $(NETCDF_PATH)/lib
+#LIB_PNETCDF := $(PNETCDF_PATH)/lib
+#LIB_MPI := $(IMPILIBDIR)
+SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
+
+SCC:= icc 
+
+SFC:= ifort 
+
+ifeq ($(ICE_THREADED), true) 
+   LDFLAGS += -openmp
+   CFLAGS += -openmp
+   FFLAGS += -openmp
+endif
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first!
+ifeq ($(ICE_IOTYPE), pio)
+   PIO_PATH:=/glade/u/home/jedwards/pio1_6_5/pio
+   INCLDIR += -I$(PIO_PATH)
+   SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpio
+endif
+

--- a/configuration/scripts/machines/Macros.koehr_intel
+++ b/configuration/scripts/machines/Macros.koehr_intel
@@ -1,0 +1,65 @@
+#==============================================================================
+# Macros file for NAVYDSRC koehr, intel compiler
+#==============================================================================
+
+CPP        := fpp
+CPPDEFS    := -DFORTRANUNDERSCORE -DNO_R16 -DHAVE_F2008_CONTIGUOUS -DLINUX -DCPRINTEL ${ICE_CPPDEFS}
+CFLAGS     := -c -O2 -fp-model precise   -xHost
+
+FIXEDFLAGS := -132
+FREEFLAGS  := -FR
+FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback   -xHost
+FFLAGS_NOOPT:= -O0
+
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -init=snan,arrays
+else
+  FFLAGS     += -O2
+endif
+
+ifeq ($(ICE_COMMDIR), mpi)
+  FC         := ifort
+  LDFLAGS += -lmpi
+else
+  FC         := ifort
+endif
+
+MPICC:= icc
+
+MPIFC:= ifort
+LD:= $(MPIFC)
+
+# defined by module
+#NETCDF_PATH := $(NETCDF)
+#PNETCDF_PATH := $(PNETCDF)
+#PNETCDF_PATH := /glade/apps/opt/pnetcdf/1.3.0/intel/default
+#LAPACK_LIBDIR := /glade/apps/opt/lapack/3.4.2/intel/12.1.5/lib
+
+#PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
+
+INCLDIR := $(INCLDIR)
+INCLDIR += -I$(NETCDF_PATH)/include
+
+LIB_NETCDF := $(NETCDF_PATH)/lib
+#LIB_PNETCDF := $(PNETCDF_PATH)/lib
+#LIB_MPI := $(IMPILIBDIR)
+SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
+
+SCC:= icc 
+
+SFC:= ifort 
+
+ifeq ($(ICE_THREADED), true) 
+   LDFLAGS += -openmp
+   CFLAGS += -openmp
+   FFLAGS += -openmp
+endif
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first!
+ifeq ($(ICE_IOTYPE), pio)
+   PIO_PATH:=/glade/u/home/jedwards/pio1_6_5/pio
+   INCLDIR += -I$(PIO_PATH)
+   SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpio
+endif
+

--- a/configuration/scripts/machines/Macros.koehr_intel
+++ b/configuration/scripts/machines/Macros.koehr_intel
@@ -51,9 +51,9 @@ SCC:= icc
 SFC:= ifort 
 
 ifeq ($(ICE_THREADED), true) 
-   LDFLAGS += -openmp
-   CFLAGS += -openmp
-   FFLAGS += -openmp
+   LDFLAGS += -qopenmp
+   CFLAGS += -qopenmp
+   FFLAGS += -qopenmp
 endif
 
 ### if using parallel I/O, load all 3 libraries.  PIO must be first!

--- a/configuration/scripts/machines/env.gaffney_gnu
+++ b/configuration/scripts/machines/env.gaffney_gnu
@@ -1,0 +1,41 @@
+#!/bin/csh -f
+
+set inp = "undefined"
+if ($#argv == 1) then
+  set inp = $1
+endif
+
+if ("$inp" != "-nomodules") then
+
+source ${MODULESHOME}/init/csh
+
+module unload compiler
+module unload mpt
+
+module load costinit
+module load git
+module load gcc/7.3.0
+module load mpt/2.18
+module load netcdf-fortran/gnu/4.4.2
+
+setenv NETCDF_PATH /app/COST/netcdf-fortran/4.4.2/gnu
+
+setenv MPI_DSM_DISTRIBUTE 0
+setenv KMP_AFFINITY disabled
+limit coredumpsize unlimited
+limit stacksize unlimited
+
+endif
+
+setenv ICE_MACHINE_ENVNAME gaffney
+setenv ICE_MACHINE_COMPILER gnu
+setenv ICE_MACHINE_MAKE gmake
+setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
+setenv ICE_MACHINE_INPUTDATA /p/home/apcraig/cice-consortium-data/cice_consortium
+setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
+setenv ICE_MACHINE_SUBMIT "qsub "
+setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_TPNODE 48    # tasks per node
+setenv ICE_MACHINE_BLDTHRDS 4
+setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.gaffney_intel
+++ b/configuration/scripts/machines/env.gaffney_intel
@@ -1,0 +1,41 @@
+#!/bin/csh -f
+
+set inp = "undefined"
+if ($#argv == 1) then
+  set inp = $1
+endif
+
+if ("$inp" != "-nomodules") then
+
+source ${MODULESHOME}/init/csh
+
+module unload compiler
+module unload mpt
+
+module load costinit
+module load git
+module load compiler/intel/18.0.1.163
+module load mpt/2.18
+module load netcdf-fortran/intel/4.4.2
+
+setenv NETCDF_PATH /app/COST/netcdf-fortran/4.4.2/intel
+
+setenv MPI_DSM_DISTRIBUTE 0
+setenv KMP_AFFINITY disabled
+limit coredumpsize unlimited
+limit stacksize unlimited
+
+endif
+
+setenv ICE_MACHINE_ENVNAME gaffney
+setenv ICE_MACHINE_COMPILER intel
+setenv ICE_MACHINE_MAKE gmake
+setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
+setenv ICE_MACHINE_INPUTDATA /p/home/apcraig/cice-consortium-data/cice_consortium
+setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
+setenv ICE_MACHINE_SUBMIT "qsub "
+setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_TPNODE 48    # tasks per node
+setenv ICE_MACHINE_BLDTHRDS 4
+setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.koehr_intel
+++ b/configuration/scripts/machines/env.koehr_intel
@@ -1,0 +1,41 @@
+#!/bin/csh -f
+
+set inp = "undefined"
+if ($#argv == 1) then
+  set inp = $1
+endif
+
+if ("$inp" != "-nomodules") then
+
+source ${MODULESHOME}/init/csh
+
+module unload compiler
+module unload mpt
+
+module load costinit
+module load git
+module load compiler/intel/18.0.1.163
+module load mpt/2.18
+module load netcdf-fortran/intel/4.4.2
+
+setenv NETCDF_PATH /app/COST/netcdf-fortran/4.4.2/intel
+
+setenv MPI_DSM_DISTRIBUTE 0
+setenv KMP_AFFINITY disabled
+limit coredumpsize unlimited
+limit stacksize unlimited
+
+endif
+
+setenv ICE_MACHINE_ENVNAME koehr
+setenv ICE_MACHINE_COMPILER intel
+setenv ICE_MACHINE_MAKE gmake
+setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
+setenv ICE_MACHINE_INPUTDATA /p/home/apcraig/cice-consortium-data/cice_consortium
+setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
+setenv ICE_MACHINE_SUBMIT "qsub "
+setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_TPNODE 48    # tasks per node
+setenv ICE_MACHINE_BLDTHRDS 4
+setenv ICE_MACHINE_QSTAT "qstat "


### PR DESCRIPTION
Port CICE to gaffney and koehr with intel compiler

- Developer(s): tcraig

- Are the code changes bit for bit, different at roundoff level, or more substantial? bit-for-bit
https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks
hash aff46951a

- Does this PR create or have dependencies on Icepack or any other models?  No

- Is the documentation being updated with this PR? (Y/N) N
If not, does the documentation need to be updated separately at a later time? (Y/N) N

- Other Relevant Details:

Also fixes a character string length issue found with this port.

Possibility to use gnu and pgi compilers, but requires netcdf builds to be updated.
