### PR TITLE
Add mention of optional path/to/executable argument to cice.build script in documentation

### DIFF
--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -92,6 +92,8 @@ Other model output will be in the run directory.  The run directory is set in **
 via the ``ICE_RUNDIR`` variable.  To modify the case setup, changes should be made in the
 case directory, NOT the run directory.
 
+The script **cice.build** accepts as an optional argument the path to an existing CICE executable (usually ``ICE_RUNDIR/cice``). This can be useful to create several cases using the same source code without having to compile the model for each new case.
+
 .. _case_options:
 
 Command Line Options


### PR DESCRIPTION
Just a small addition to the documentation; it was not mentioned anywhere that **cice.build** accepts as an optional argument the path to an existing cice executable. 

- Developer(s): Philippe Blain

- Please suggest code Pull Request reviewers in the column at right. @apcraig 

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Please include the link to test results or paste the summary block from the bottom of the testing output below. No tests; only doc changes

- Does this PR create or have dependencies on Icepack or any other models? No

- Is the documentation being updated with this PR? (Y/N) Yes
If not, does the documentation need to be updated separately at a later time? (Y/N)

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
