### PR TITLE
Machine files changes for cesium

### DIFF
--- a/configuration/scripts/machines/Macros.cesium_intel
+++ b/configuration/scripts/machines/Macros.cesium_intel
@@ -22,10 +22,10 @@ else
   FFLAGS     += -O2
 endif
 
-SCC   := s.cc
-SFC   := s.f90
-MPICC := s.cc -mpi
-MPIFC := s.f90 -mpi
+SCC   := icc
+SFC   := ifort
+MPICC := mpicc
+MPIFC := mpif90
 
 ifeq ($(ICE_COMMDIR), mpi)
   FC := $(MPIFC)
@@ -36,7 +36,7 @@ else
 endif
 LD:= $(FC)
 
-NETCDF_PATH := $(NETCDF)
+NETCDF_PATH := /fs/ssm/hpco/tmp/eccc/201402/04/intel-2016.1.150/ubuntu-14.04-amd64-64/
 
 PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
 

--- a/configuration/scripts/machines/Macros.cesium_intel
+++ b/configuration/scripts/machines/Macros.cesium_intel
@@ -16,7 +16,8 @@ FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceb
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except
+  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init snans -init arrays
+# -heap-arrays 1024 
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/env.cesium_intel
+++ b/configuration/scripts/machines/env.cesium_intel
@@ -5,7 +5,7 @@
 
 setenv ICE_MACHINE_ENVNAME cesium
 setenv ICE_MACHINE_COMPILER intel
-setenv ICE_MACHINE_MAKE make
+setenv ICE_MACHINE_MAKE colormake-short
 setenv ICE_MACHINE_WKDIR  /users/dor/afsg/phb/local/CICEDIRS/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /users/dor/afsg/phb/local/FORCING
 setenv ICE_MACHINE_BASELINE /users/dor/afsg/phb/local/CICEDIRS/CICE_BASELINE

--- a/configuration/scripts/machines/env.cesium_intel
+++ b/configuration/scripts/machines/env.cesium_intel
@@ -1,7 +1,10 @@
 #!/bin/csh -f
 
-#. ssmuse-sh -d /fs/ssm/eccc/mrd/rpn/OCEAN/cncpt-3.1.2
-#source NEMO_compiler.ksh
+set ssmuse=/fs/ssm/main/env/20180430/all/bin/ssmuse-csh # package loader
+source $ssmuse -d /fs/ssm/main/opt/intelcomp/intelcomp-2016.1.156 # intel compiler
+source /fs/ssm/main/opt/intelcomp/intelcomp-2016.1.156/intelcomp_2016.1.156_multi/bin/compilervars.csh intel64 # should be sourced by above domain, but bug in csh script
+source $ssmuse -d /fs/ssm/main/opt/openmpi/openmpi-1.6.5/intelcomp-2016.1.156 # openmpi
+source $ssmuse -d /fs/ssm/hpco/tmp/eccc/201402/04/intel-2016.1.150 # netcdf (and openmpi)
 
 setenv ICE_MACHINE_ENVNAME cesium
 setenv ICE_MACHINE_COMPILER intel
@@ -13,7 +16,7 @@ setenv ICE_MACHINE_SUBMIT "qsub"
 setenv ICE_MACHINE_TPNODE 36
 setenv ICE_MACHINE_ACCT P0000000
 setenv ICE_MACHINE_QUEUE "debug"
-setenv ICE_MACHINE_BLDTHRDS 1
+setenv ICE_MACHINE_BLDTHRDS 4
 setenv ICE_MACHINE_QSTAT "qstat "
 
 if (-e ~/.cice_proj) then


### PR DESCRIPTION
Change to Macros and env files for machine cesium

- Developer(s): Philippe Blain

- Please suggest code Pull Request reviewers in the column at right. @apcraig 

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Please include the link to test results or paste the summary block from the bottom of the testing output below.
No tests (only machine file changed)

- Does this PR create or have dependencies on Icepack or any other models? No

- Is the documentation being updated with this PR? (Y/N) No
If not, does the documentation need to be updated separately at a later time? (Y/N) No

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Remove in-house compiler wrapper, call intel compiler directly
- Load needed packages direcly in env file
- Add NaN initialization in debug mode to help debugging
- Build in parallel by default
