### PR TITLE
Move makdep compilation to Makefile

### DIFF
--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -97,6 +97,18 @@ db_flags:
 	@echo "* .F90.o  := $(FC) -c $(FFLAGS) $(FREEFLAGS) $(INCS) $(INCLDIR)"
 
 #-------------------------------------------------------------------------------
+# build rule for makdep: MACFILE, cmd-line, or env vars must provide
+# the needed macros
+#-------------------------------------------------------------------------------
+
+ifndef $(CFLAGS_HOST)
+  CFLAGS_HOST :=
+endif
+
+makdep: $(ICE_CASEDIR)/makdep.c
+	$(SCC) -o $@ $(CFLAGS_HOST) $<
+
+#-------------------------------------------------------------------------------
 # build rules: MACFILE, cmd-line, or env vars must provide the needed macros
 #-------------------------------------------------------------------------------
 

--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -105,7 +105,7 @@ ifndef $(CFLAGS_HOST)
   CFLAGS_HOST :=
 endif
 
-makdep: $(ICE_CASEDIR)/makdep.c
+$(DEPGEN): $(ICE_CASEDIR)/makdep.c
 	$(SCC) -o $@ $(CFLAGS_HOST) $<
 
 #-------------------------------------------------------------------------------

--- a/configuration/scripts/cice.build
+++ b/configuration/scripts/cice.build
@@ -89,7 +89,8 @@ cat ${ICE_OBJDIR}/Filepath
 echo " "
 
 echo "building makdep"
-cc -o makdep ${ICE_CASEDIR}/makdep.c     || exit 2
+${ICE_MACHINE_MAKE} \
+        -f  ${ICE_CASEDIR}/Makefile MACFILE=${ICE_CASEDIR}/Macros.${ICE_MACHCOMP} makdep || exit 2
 
 echo "building cice > ${ICE_OBJDIR}/${ICE_BLDLOG_FILE}"
 

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -16,6 +16,8 @@ The CICE scripts are written to allow quick setup of cases and tests.  Once a ca
 generated, users can manually modify the namelist and other files to custom configure
 the case.  Several settings are available via scripts as well.
 
+.. _overview:
+
 Overview
 ~~~~~~~~
 
@@ -201,7 +203,7 @@ Once the cases are created, users are free to modify the cice.settings and ice_i
 Porting
 -------
 
-To port, an **env.[machine]_[environment]** and **Macros.[machine]_[environment}** file have to be added to the
+To port, an **env.[machine]_[environment]** and **Macros.[machine]_[environment]** file have to be added to the
 **configuration/scripts/machines/** directory and the 
 **configuration/scripts/cice.batch.csh** file needs to be modified.
 In general, the machine is specified in ``cice.setup`` with ``--mach``
@@ -228,6 +230,16 @@ file until the case can build and run.  Then copy the files from the case
 directory back to **configuration/scripts/machines/** and update 
 the **configuration/scripts/cice.batch.csh** file, retest, 
 and then add and commit the updated machine files to the repository.
+
+.. _cross_compiling:
+
+Cross-compiling
+~~~~~~~~~~~~~~~
+It can happen that the model must be built on a platform and run on another, for example when the run environment is only available in a batch queue. The program **makdep** (see :ref:`overview`), however, is both compiled and run as part of the build process.
+
+In order to support this, the Makefile uses a variable ``CFLAGS_HOST`` that can hold compiler flags specfic to the build machine for the compilation of makdep. If this feature is needed, add the variable ``CFLAGS_HOST`` to the **Macros.[machine]_[environment]** file. For example : ::
+
+  CFLAGS_HOST = -xHost
 
 .. _account:
 


### PR DESCRIPTION
* makdep compiled from a makdep rule in the Makefile
* Add CFLAG_HOST macro
* makdep is only compiled if needed
* This addresses #306

- Developer(s): Philippe Blain

- Please suggest code Pull Request reviewers in the column at right. @apcraig 

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Please include the link to test results or paste the summary block from the bottom of the testing output below. 
I didn't run tests since I didn't touch the code itself.

- Does this PR create or have dependencies on Icepack or any other models? No, but I will do the same for Icepack.

- Is the documentation being updated with this PR? (Y/N) Yes
[https://cice-phil-blain.readthedocs.io/en/build-system-robustness/user_guide/ug_running.html#cross-compiling](https://cice-phil-blain.readthedocs.io/en/build-system-robustness/user_guide/ug_running.html#cross-compiling)
If not, does the documentation need to be updated separately at a later time? (Y/N) No

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.