### PR TITLE
Fix -init compiler argument syntax for cesium Macros file

### DIFF
--- a/configuration/scripts/machines/Macros.cesium_intel
+++ b/configuration/scripts/machines/Macros.cesium_intel
@@ -16,7 +16,7 @@ FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceb
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init snans -init arrays
+  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 # -heap-arrays 1024 
 else
   FFLAGS     += -O2


### PR DESCRIPTION
I made an error in my previous machine file update (sorry!), the init argument needs a "="

- Developer(s): Philippe Blain

- Please suggest code Pull Request reviewers in the column at right. @apcraig 

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Please include the link to test results or paste the summary block from the bottom of the testing output below.
Machine files - no tests
- Does this PR create or have dependencies on Icepack or any other models? 
No
- Is the documentation being updated with this PR? (Y/N) No
If not, does the documentation need to be updated separately at a later time? (Y/N) No

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.
