### PR TITLE
Fix bug in comparebfb.csh when restart data is missing in both test and base directories

### DIFF
--- a/configuration/scripts/tests/comparebfb.csh
+++ b/configuration/scripts/tests/comparebfb.csh
@@ -65,6 +65,8 @@ if ($filearg == 1) then
 
 else
   set end_date = `ls -t1 $test_dir | head -1 | sed 's|^.*\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9][0-9]\).*|\1|'`
+  # set nonomatch so that if foreach does not find anything it does not end the script
+  set nonomatch
   foreach test_data (${test_dir}/iced*${end_date}*)
     set test_file = "${test_data:t}"
     if ($restart == 1) then
@@ -86,6 +88,7 @@ else
       echo "  missing data"
     endif
   end
+  unset nonomatch
 endif
 
 exit ${failure}


### PR DESCRIPTION
If no restart files are present in neither `base_dir` nor `test_dir`, the script  `comparebfb.csh` would simply exit with the error 

> foreach: No match.

with error code 1 (csh default I guess) and so the script `cice.test` would report 
> Regression baseline and test dataset are different

which is incorrect. I just added `set nonomatch` before the foreach so that if no restart files are present the script does not error but correctly reports :

> base_data: $baseline_dir/$baseline_name/$test_name/restart/iced**
test_data: $baseline_dir/$baseline_name/$test_name/r/restart/iced**
      missing data
Missing data

- Developer(s): Philippe Blain

- Please suggest code Pull Request reviewers in the column at right. @apcraig 

- Are the code changes bit for bit, different at roundoff level, or more substantial? BFB

- Please include the link to test results or paste the summary block from the bottom of the testing output below.
No tests
- Does this PR create or have dependencies on Icepack or any other models? 
No
- Is the documentation being updated with this PR? (Y/N) No
If not, does the documentation need to be updated separately at a later time? (Y/N) No

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:

I stumbled upon that bug because I was running the model for just 3 time steps with a custom test suite and had forgotten to set the `dump_last` namelist variable to true, which caused no restart files to be written since I was running for less than a day.