### PR TITLE
clean up evp kernel 2 implementation

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_evp_1d.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp_1d.F90
@@ -1,3 +1,10 @@
+! ice_dyn_evp_1d
+!
+! Contains 3 Fortran modules,
+!   * dmi_omp
+!   * bench_v2
+!   * ice_dyn_evp_1d
+!
 ! Modules used for:
 !   * convert 2D arrays into 1D vectors
 !   * Do stress/stepu/halo_update interations
@@ -21,23 +28,21 @@
 
 !===============================================================================
 module dmi_omp
-  !- directives ----------------------------------------------------------------
+
   use ice_kinds_mod
+  use ice_fileunits, only: nu_diag
+  use ice_exit, only: abort_ice
+
   implicit none
   private
-  INTEGER, PARAMETER :: JPIM = SELECTED_INT_KIND(9)
+  public  :: domp_init, domp_get_domain, domp_get_thread_no
 
-  !- interfaces ----------------------------------------------------------------
   interface domp_get_domain
     module procedure domp_get_domain_rlu
   end interface 
 
+  INTEGER, PARAMETER :: JPIM = SELECTED_INT_KIND(9)
   integer(int_kind), private :: domp_iam, domp_nt
-
-  private :: domp_get_domain_rlu
-
-  !- public vars & methods -----------------------------------------------------
-  public  :: domp_init, domp_get_domain, domp_get_thread_no
 
 #if defined (_OPENMP)
   ! Please note, this constant will create a compiler info for a constant
@@ -47,8 +52,8 @@ module dmi_omp
 #endif
 
 contains
-    
-  ! ----------------------------------------------------------------------------
+
+!----------------------------------------------------------------------------
 
   subroutine domp_init(nt_out)
 
@@ -57,8 +62,10 @@ contains
 #endif
     use ice_forcing, only : dbug
 
-    !- argument(s) -------------------------------------------------------------
     integer(int_kind), intent(out) :: nt_out
+
+    character(len=*), parameter :: subname = '(domp_init)'
+    !---------------------------------------
 
     !$OMP PARALLEL DEFAULT(none)
 #if defined (_OPENMP)
@@ -74,21 +81,21 @@ contains
 
     if (dbug) then
 #if defined (_OPENACC)
-      write(*,'(a27)') 'Build with openACC support'
+      write(nu_diag,'(2a)') subname,' Build with openACC support'
 !#elif defined (_OPENMP)
-!      write(*,'(a26)') 'Build with openMP support'
+!      write(nu_diag,'(2a)') subname,' Build with openMP support'
 !#else
-!      write(*,'(a41)') 'Build without openMP and openACC support'
+!      write(nu_diag,'(2a)') subname,' Build without openMP and openACC support'
 #endif
 
       !- echo #threads:
       if (domp_nt > 1) then
-        write(*,'(a20,i5,a8)') 'Running openMP with ', domp_nt, ' threads'
+        write(nu_diag,'(2a,i5,a)') subname,' Running openMP with ', domp_nt, ' threads'
       else
 #if defined (_OPENMP)
-        write(*,'(a35)') 'Running openMP with a single thread'
+        write(nu_diag,'(2a)') subname,' Running openMP with a single thread'
 #else
-        write(*,'(a22)') 'Running without openMP'
+        write(nu_diag,'(2a)') subname,' Running without openMP'
 #endif
       endif
     endif
@@ -98,23 +105,26 @@ contains
 
   end subroutine domp_init
  
-  ! ----------------------------------------------------------------------------
+!----------------------------------------------------------------------------
 
   subroutine domp_get_domain_rlu(lower,upper,d_lower,d_upper)
+
 #if defined (_OPENMP)
     use omp_lib,   only : omp_in_parallel
 #endif
     use ice_constants, only: p5
 
-    !- arguments ---------------------------------------------------------------
     integer(KIND=JPIM), intent(in)  :: lower,upper
     integer(KIND=JPIM), intent(out) :: d_lower,d_upper
 
 #if defined (_OPENMP)
-    !  local variables ---------------------------------------------------------
+    !-- local variables
     real(kind=dbl_kind)    :: dlen
     integer(int_kind) :: lr, ur
 #endif
+
+    character(len=*), parameter :: subname = '(domp_get_domain_rlu)'
+    !---------------------------------------
 
     ! proper action in "null" cases:
     if (upper <= 0 .or. upper < lower) then
@@ -136,34 +146,53 @@ contains
 #endif
 
   if (.false.) then
-    write(*,'(a14,i3,a24,i10,i10)') 'openMP thread ', domp_iam,               &
+    write(nu_diag,'(2a,i3,a,2i10)') subname,' openMP thread ', domp_iam, &
          ' handles range: ', d_lower, d_upper
   endif
 
   end subroutine domp_get_domain_rlu
 
-  subroutine domp_get_thread_no (tnum)
-    implicit none
+!----------------------------------------------------------------------------
 
+  subroutine domp_get_thread_no (tnum)
+
+    implicit none
     integer(int_kind), intent(out) :: tnum
+    character(len=*), parameter :: subname = '(domp_get_thread_no)'
 
     tnum = domp_iam + 1
 
   end subroutine domp_get_thread_no
-  ! ----------------------------------------------------------------------------
+
+!----------------------------------------------------------------------------
+
 end module dmi_omp
+
 !===============================================================================
+!===============================================================================
+
 module bench_v2
-  !- interfaces ----------------------------------------------------------------
-  interface stress
+
+  use ice_fileunits, only: nu_diag
+  use ice_exit, only: abort_ice
+
+  implicit none
+  private
+  public :: evp1d_stress, evp1d_stepu, evp1d_halo_update
+
+  interface evp1d_stress
     module procedure stress_i
     module procedure stress_l
   end interface 
-  interface stepu
+  interface evp1d_stepu
     module procedure stepu_iter
     module procedure stepu_last
   end interface 
+
   contains
+
+!----------------------------------------------------------------------------
+
     subroutine stress_i(NA_len, &
                      ee,ne,se,lb,ub,uvel,vvel,dxt,dyt,                           & 
                      hte,htn,htem1,htnm1,                                        &
@@ -171,15 +200,15 @@ module bench_v2
                      stressm_1,stressm_2,stressm_3,stressm_4,stress12_1,         &
                      stress12_2,stress12_3,stress12_4,str1,str2,str3,str4,str5,  &
                      str6,str7,str8)
-    !- modules -------------------------------------------------------------------
+
     use ice_kinds_mod
     use dmi_omp, only : domp_get_domain
     use ice_constants, only: p027, p055, p111, p166, p222, p25, p333, p5, c1p5, c1
     use icepack_parameters, only: puny
     use ice_dyn_shared, only: ecci, denom1, arlx1i, Ktens, revp
-    !- directives ----------------------------------------------------------------
+
     implicit none
-    ! arguments ------------------------------------------------------------------
+
     integer (kind=int_kind), intent(in) :: NA_len
     integer (kind=int_kind), intent(in) :: lb,ub
     integer (kind=int_kind), dimension(:), intent(in),    contiguous :: ee,ne,se
@@ -191,7 +220,9 @@ module bench_v2
        stressm_3,stressm_4, stress12_1,stress12_2,stress12_3, stress12_4
     real    (kind=DBL_KIND), dimension(:), intent(out),   contiguous ::          &
        str1,str2,str3,str4,str5,str6,str7,str8
-    ! local variables ------------------------------------------------------------
+
+    !-- local variables
+
     integer (kind=int_kind) :: iw,il,iu
     real    (kind=DBL_KIND) ::                                                   &
       divune, divunw, divuse, divusw,tensionne, tensionnw, tensionse, tensionsw, & 
@@ -205,6 +236,9 @@ module bench_v2
       tmp_vvel_ne, tmp_uvel_ne, tmp_uvel_se
     real    (kind=DBL_KIND) :: dxhy,dyhx,cxp,cyp,cxm,cym,tinyarea
    
+    character(len=*), parameter :: subname = '(stress_i)'
+    !---------------------------------------
+
 #ifdef _OPENACC
     !$acc parallel                                                                 &
     !$acc present(ee,ne,se,strength,uvel,vvel,dxt,dyt,                             &
@@ -419,8 +453,11 @@ module bench_v2
 #ifdef _OPENACC
     !$acc end parallel
 #endif
+
   end subroutine stress_i
   
+!----------------------------------------------------------------------------
+
   subroutine stress_l(NA_len, tarear, &
                      ee,ne,se,lb,ub,uvel,vvel,dxt,dyt,                           & 
                      hte,htn,htem1,htnm1,                                        &
@@ -429,15 +466,15 @@ module bench_v2
                      stress12_2,stress12_3,stress12_4,                           &
                      divu,rdg_conv,rdg_shear,shear,                              &
                      str1,str2,str3,str4,str5,str6,str7,str8                     )
-    !- modules -------------------------------------------------------------------
+
     use ice_kinds_mod
     use dmi_omp, only : domp_get_domain
     use ice_constants, only: p027, p055, p111, p166, p222, p25, p333, p5, c1p5, c0, c1
     use icepack_parameters, only: puny
     use ice_dyn_shared, only: ecci, denom1, arlx1i, Ktens, revp
-    !- directives ----------------------------------------------------------------
+
     implicit none
-    ! arguments ------------------------------------------------------------------
+
     integer (kind=int_kind), intent(in) :: NA_len
     integer (kind=int_kind), intent(in) :: lb,ub
     integer (kind=int_kind), dimension(:), intent(in),    contiguous :: ee,ne,se
@@ -451,7 +488,9 @@ module bench_v2
        str1,str2,str3,str4,str5,str6,str7,str8
     real    (kind=dbl_kind), dimension(:), intent(out),   contiguous ::          &
        divu,rdg_conv,rdg_shear,shear
-    ! local variables ------------------------------------------------------------
+
+    !-- local variables
+
     integer (kind=int_kind) :: iw,il,iu
     real    (kind=DBL_KIND) ::                                                   &
       divune, divunw, divuse, divusw,tensionne, tensionnw, tensionse, tensionsw, & 
@@ -465,6 +504,9 @@ module bench_v2
       tmp_vvel_ne, tmp_uvel_ne, tmp_uvel_se
     real    (kind=DBL_KIND) :: dxhy,dyhx,cxp,cyp,cxm,cym,tinyarea
   
+    character(len=*), parameter :: subname = '(stress_l)'
+    !---------------------------------------
+
 #ifdef _OPENACC
     !$acc parallel                                                                 &
     !$acc present(ee,ne,se,strength,uvel,vvel,dxt,dyt,tarear,                      &
@@ -687,18 +729,20 @@ module bench_v2
 #endif
   end subroutine stress_l
   
+!----------------------------------------------------------------------------
+
   subroutine stepu_iter(NA_len,rhow, &
                     lb,ub,Cw,aiu,uocn,vocn,forcex,forcey,umassdti,fm,uarear,Tbu, &
                     uvel_init,vvel_init,uvel,vvel,                               &
                     str1,str2,str3,str4,str5,str6,str7,str8, nw,sw,se,skipme)
-    !- modules -------------------------------------------------------------------
+
     use ice_kinds_mod
     use dmi_omp, only : domp_get_domain
     use ice_dyn_shared, only: brlx, revp
     use ice_constants, only: c0, c1
-    !- directives ----------------------------------------------------------------
+
     implicit none
-    ! arguments ------------------------------------------------------------------
+
     integer (kind=int_kind), intent(in) :: NA_len
     real (kind=dbl_kind), intent(in) :: rhow
     integer(kind=int_kind),intent(in)   :: lb,ub
@@ -714,7 +758,9 @@ module bench_v2
     real (kind=dbl_kind), parameter :: &
            cosw = c1   , & ! cos(ocean turning angle)  ! turning angle = 0
            sinw = c0   
-    ! local variables
+
+    !-- local variables
+
     integer (kind=int_kind) :: iw,il,iu
     real    (kind=dbl_kind) :: uold, vold, vrel,cca,ccb,ab2,cc1,cc2,taux,tauy,Cb
     real    (kind=dbl_kind) :: tmp_str2_nw,tmp_str3_se,tmp_str4_sw, tmp_strintx
@@ -722,6 +768,9 @@ module bench_v2
     real    (kind=dbl_kind) :: waterx,watery
     real    (kind=dbl_kind) :: u0 = 5.e-5_dbl_kind    ! residual velocity for basal stress (m/s)
   
+    character(len=*), parameter :: subname = '(stepu_iter)'
+    !---------------------------------------
+
 #ifdef _OPENACC
     !$acc parallel                                                       &
     !$acc present(Cw,aiu,uocn,vocn,forcex,forcey,umassdti,fm,uarear,Tbu, &
@@ -770,20 +819,22 @@ module bench_v2
 
   end subroutine stepu_iter
   
+!----------------------------------------------------------------------------
+
   subroutine stepu_last(NA_len, rhow, &
                     lb,ub,Cw,aiu,uocn,vocn,forcex,forcey,umassdti,fm,uarear,Tbu, &
                     strintx,strinty,taubx,tauby,                                 &
                     uvel_init,vvel_init,uvel,vvel,                               &
                     str1,str2,str3,str4,str5,str6,str7,str8, nw,sw,se,skipme)
-    !- modules -------------------------------------------------------------------
+
     use ice_kinds_mod
     use dmi_omp, only : domp_get_domain
     use ice_constants, only: c0, c1
     use icepack_parameters, only: puny
     use ice_dyn_shared, only: brlx, revp, basalstress
-    !- directives ----------------------------------------------------------------
+
     implicit none
-    ! arguments ------------------------------------------------------------------
+
     integer (kind=int_kind), intent(in) :: NA_len
     real (kind=dbl_kind), intent(in) :: rhow
     logical(kind=log_kind),intent(in), dimension(:)   :: skipme
@@ -799,7 +850,9 @@ module bench_v2
     real (kind=dbl_kind), parameter :: &
            cosw = c1   , & ! cos(ocean turning angle)  ! turning angle = 0
            sinw = c0   
-    ! local variables
+
+    !-- local variables
+
     integer (kind=int_kind) :: iw,il,iu
     real    (kind=dbl_kind) :: uold, vold, vrel,cca,ccb,ab2,cc1,cc2,taux,tauy,Cb
     real    (kind=dbl_kind) :: tmp_str2_nw,tmp_str3_se,tmp_str4_sw
@@ -807,6 +860,9 @@ module bench_v2
     real    (kind=dbl_kind) :: waterx,watery
     real    (kind=dbl_kind) :: u0 = 5.e-5_dbl_kind    ! residual velocity for basal stress (m/s)
    
+    character(len=*), parameter :: subname = '(stepu_last)'
+    !---------------------------------------
+
 #ifdef _OPENACC
     !$acc parallel                                                                 &
     !$acc present(Cw,aiu,uocn,vocn,forcex,forcey,umassdti,fm,uarear,Tbu,           &
@@ -857,21 +913,29 @@ module bench_v2
 #ifdef _OPENACC
     !$acc end parallel
 #endif
+
   end subroutine stepu_last
 
-  subroutine halo_update(NAVEL_len,lb,ub,uvel,vvel, halo_parent)
-    !- modules -------------------------------------------------------------------
+!----------------------------------------------------------------------------
+
+  subroutine evp1d_halo_update(NAVEL_len,lb,ub,uvel,vvel, halo_parent)
+
     use ice_kinds_mod
     use dmi_omp, only : domp_get_domain
-    !- directives ----------------------------------------------------------------
+
     implicit none
-    ! arguments ------------------------------------------------------------------
+
     integer (kind=int_kind), intent(in) :: NAVEL_len
     integer(kind=int_kind),intent(in)   :: lb,ub
     integer(kind=int_kind),dimension(:), intent(in), contiguous :: halo_parent
     real(kind=dbl_kind),dimension(:), intent(inout), contiguous :: uvel,vvel
-    ! local variables
+
+    !-- local variables
+
     integer (kind=int_kind) :: iw,il,iu
+
+    character(len=*), parameter :: subname = '(evp1d_halo_update)'
+    !---------------------------------------
 
 #ifdef _OPENACC
     !$acc parallel                                   &
@@ -889,20 +953,30 @@ module bench_v2
 #ifdef _OPENACC
     !$acc end parallel
 #endif
-  end subroutine halo_update
+
+  end subroutine evp1d_halo_update
+
+!----------------------------------------------------------------------------
 
 end module bench_v2
   
 !===============================================================================
+!===============================================================================
   
 !-- One dimension representation of EVP 2D arrays used for EVP kernels
 module ice_dyn_evp_1d
+
   use ice_kinds_mod
+  use ice_fileunits, only: nu_diag
   use ice_exit, only: abort_ice
   !-- BEGIN: specific for the KERNEL
   use ice_dyn_shared, only: revp, ecci, denom1, arlx1i, brlx
   !-- END: specific for the KERNEL
+
   implicit none
+  private
+  public :: evp_copyin, evp_copyout, evp_kernel_v2
+
   interface evp_copyin
 !    module procedure evp_copyin_v1
     module procedure evp_copyin_v2
@@ -911,9 +985,7 @@ module ice_dyn_evp_1d
 !    module procedure convert_2d_1d_v1
     module procedure convert_2d_1d_v2
   end interface 
-  public :: evp_copyin, evp_copyout, evp_kernel_v2
-  private
-  save
+
   integer(kind=int_kind) ::                                        &
     NA_len, NAVEL_len
   logical(kind=log_kind), dimension(:), allocatable ::             &
@@ -936,11 +1008,21 @@ module ice_dyn_evp_1d
   real (kind=dbl_kind), dimension(:), allocatable ::               &
     HTE,HTN,                                                       &
     HTEm1,HTNm1
+
   contains
+
+!----------------------------------------------------------------------------
+
   subroutine alloc1d(na)
+
     implicit none
+
     integer(kind=int_kind),intent(in) :: na
     integer(kind=int_kind)            :: ierr,nb
+
+    character(len=*), parameter :: subname = '(alloc1d)'
+    !---------------------------------------
+
     nb=na
     allocate(                                                      &
       ! U+T cells
@@ -968,22 +1050,43 @@ module ice_dyn_evp_1d
       uvel_init(1:nb),vvel_init(1:nb),                                    &
       taubx(1:nb),tauby(1:nb),                                            &
       stat=ierr)
-    if (ierr/=0) call abort_ice('(ice_dyn_evp_1d) : Error allocating 1D')
+
+    if (ierr/=0) call abort_ice(subname//': ERROR allocating 1D')
+
   end subroutine alloc1d
+
+!----------------------------------------------------------------------------
+
   subroutine alloc1d_navel(navel)
+
     implicit none
+
     integer(kind=int_kind),intent(in) :: navel
     integer(kind=int_kind)            :: ierr
+
+    character(len=*), parameter :: subname = '(alloc1d_navel)'
+    !---------------------------------------
+
     allocate(                                                            &
       uvel(1:navel),vvel(1:navel), indij(1:navel), halo_parent(1:navel), &
       str1(1:navel),str2(1:navel),str3(1:navel),str4(1:navel),           &
       str5(1:navel),str6(1:navel),str7(1:navel),str8(1:navel),           &
       stat=ierr)
-    if (ierr/=0) call abort_ice('(ice_dyn_evp_1d) : Error allocating 1D navel')
+    if (ierr/=0) call abort_ice(subname// ': Error allocating 1D navel')
+
   end subroutine alloc1d_navel
+
+!----------------------------------------------------------------------------
+
   subroutine dealloc1d
+
     implicit none
+
     integer(kind=int_kind) :: ierr
+
+    character(len=*), parameter :: subname = '(dealloc1d)'
+    !---------------------------------------
+
     deallocate(                                   &
       ! U+T cells
       ! Helper index for neighbours
@@ -1009,24 +1112,29 @@ module ice_dyn_evp_1d
       ! NAVEL 
       uvel,vvel, indij, halo_parent,              &
       stat=ierr)
-    if (ierr/=0) call abort_ice('(ice_dyn_evp_1d) : Error de-allocating 1D')
+
+    if (ierr/=0) call abort_ice(subname//': Error de-allocating 1D')
+
 !v1    if (allocated(tinyarea)) then
 !v1      deallocate(                                 &
 !v1        dxhy,dyhx,cyp,cxp,cym,cxm,tinyarea,       &
 !v1        waterx,watery,                            &
 !v1        stat=ierr)
-!v1      if (ierr/=0) call abort_ice('(ice_dyn_evp_1d) : Error de-allocating 1D, v1')
+!v1      if (ierr/=0) call abort_ice(subname//': Error de-allocating 1D, v1')
 !v1    endif
+
     if (allocated(HTE)) then
       deallocate(                                 &
         ! Grid distances: HTE,HTN + "-1 neighbours" 
         HTE,HTN, HTEm1,HTNm1,                     &
         stat=ierr)
-      if (ierr/=0) call abort_ice('(ice_dyn_evp_1d) : Error de-allocating 1D, v2')
+      if (ierr/=0) call abort_ice(subname//': Error de-allocating 1D, v2')
     endif
+
   end subroutine dealloc1d
-!===============================================================================
-!===============================================================================
+
+!----------------------------------------------------------------------------
+
   subroutine evp_copyin_v2(nx,ny,nblk,nx_glob,ny_glob,                                &
        I_HTE,I_HTN,                                                                   &
 !v1       I_dxhy,I_dyhx,I_cyp,I_cxp,I_cym,I_cxm,I_tinyarea,                              &
@@ -1038,11 +1146,14 @@ module ice_dyn_evp_1d
         I_stressp_1 ,I_stressp_2, I_stressp_3, I_stressp_4,                           &
         I_stressm_1 ,I_stressm_2, I_stressm_3, I_stressm_4,                           &
        I_stress12_1,I_stress12_2,I_stress12_3,I_stress12_4                            )
+
     use ice_gather_scatter, only: gather_global_ext
     use ice_domain, only: distrb_info
     use ice_communicate, only: my_task, master_task
     use ice_constants, only: c0,c1,p5
+
     implicit none
+
     integer(int_kind), intent(in) :: nx, ny, nblk, nx_glob, ny_glob
     integer (kind=int_kind),dimension (nx,ny,nblk), intent(in) :: I_icetmask
     logical (kind=log_kind),dimension (nx,ny,nblk), intent(in) :: I_iceumask
@@ -1056,7 +1167,9 @@ module ice_dyn_evp_1d
        I_stressp_1, I_stressp_2, I_stressp_3, I_stressp_4,                            &
        I_stressm_1, I_stressm_2, I_stressm_3, I_stressm_4,                            &
        I_stress12_1,I_stress12_2,I_stress12_3,I_stress12_4
-    ! local variables
+
+    !-- local variables
+
     integer (kind=int_kind),dimension (nx_glob,ny_glob) :: G_icetmask
     logical (kind=log_kind),dimension (nx_glob,ny_glob) :: G_iceumask
     real (kind=dbl_kind), dimension(nx_glob,ny_glob) ::                               &
@@ -1070,7 +1183,11 @@ module ice_dyn_evp_1d
        G_stressm_1, G_stressm_2, G_stressm_3, G_stressm_4,                            &
        G_stress12_1,G_stress12_2,G_stress12_3,G_stress12_4
     integer(kind=int_kind) :: na, navel
+
+    character(len=*), parameter :: subname = '(evp_copyin_v2)'
+    !---------------------------------------
     !-- Gather data into one single block --
+
     call gather_global_ext(G_icetmask, I_icetmask, master_task, distrb_info)
     call gather_global_ext(G_iceumask, I_iceumask, master_task, distrb_info)
     call gather_global_ext(G_HTE, I_HTE, master_task, distrb_info)
@@ -1116,9 +1233,9 @@ module ice_dyn_evp_1d
     call gather_global_ext(G_stress12_2, I_stress12_2, master_task, distrb_info)
     call gather_global_ext(G_stress12_3, I_stress12_3, master_task, distrb_info)
     call gather_global_ext(G_stress12_4, I_stress12_4, master_task, distrb_info)
-    ! END: Gather data
 
     !-- All calculations has to be done on the master-task --
+
     if (my_task == master_task) then
       !-- Find number of active points and allocate vectors --
       call calc_na(nx_glob,ny_glob,na,G_icetmask)
@@ -1144,32 +1261,39 @@ module ice_dyn_evp_1d
       NA_len=na
       NAVEL_len=navel
     endif
-      !-- write check
+
+    !-- write check
 !if (1 == 1) then
-!  write(*,*)'MHRI: INDICES start: evp-copyin'
-!  write(*,*) 'na,navel  ', na,navel
-!  write(*,*) 'Min/max ee', minval(ee(1:na)), maxval(ee(1:na))
-!  write(*,*) 'Min/max ne', minval(ne(1:na)), maxval(ne(1:na))
-!  write(*,*) 'Min/max se', minval(se(1:na)), maxval(se(1:na))
-!  write(*,*) 'Min/max nw', minval(nw(1:na)), maxval(nw(1:na))
-!  write(*,*) 'Min/max sw', minval(sw(1:na)), maxval(sw(1:na))
-!  write(*,*) 'Min/max sse', minval(sse(1:na)), maxval(sse(1:na))
-!  write(*,*)'MHRI: INDICES end: evp-copyin'
+!  write(nu_diag,*) subname,' MHRI: INDICES start:'
+!  write(nu_diag,*) 'na,navel  ', na,navel
+!  write(nu_diag,*) 'Min/max ee', minval(ee(1:na)), maxval(ee(1:na))
+!  write(nu_diag,*) 'Min/max ne', minval(ne(1:na)), maxval(ne(1:na))
+!  write(nu_diag,*) 'Min/max se', minval(se(1:na)), maxval(se(1:na))
+!  write(nu_diag,*) 'Min/max nw', minval(nw(1:na)), maxval(nw(1:na))
+!  write(nu_diag,*) 'Min/max sw', minval(sw(1:na)), maxval(sw(1:na))
+!  write(nu_diag,*) 'Min/max sse', minval(sse(1:na)), maxval(sse(1:na))
+!  write(nu_diag,*) subname,' MHRI: INDICES end:'
 !endif
+
   end subroutine evp_copyin_v2
-  !===============================================================================
+
+!----------------------------------------------------------------------------
+
   subroutine evp_copyout(nx,ny,nblk,nx_glob,ny_glob,                    &
                I_uvel,I_vvel, I_strintx,I_strinty,                      &
                I_stressp_1, I_stressp_2, I_stressp_3, I_stressp_4,      &
                I_stressm_1, I_stressm_2, I_stressm_3, I_stressm_4,      &
                I_stress12_1,I_stress12_2,I_stress12_3,I_stress12_4,     &
                I_divu,I_rdg_conv,I_rdg_shear,I_shear,I_taubx,I_tauby    )
+
     use ice_constants, only : c0, field_loc_center, field_loc_NEcorner, &
                                   field_type_scalar, field_type_vector
     use ice_gather_scatter, only: scatter_global_ext, scatter_global
     use ice_domain, only: distrb_info
     use ice_communicate, only: my_task, master_task
+
     implicit none
+
     integer(int_kind), intent(in) :: nx,ny,nblk, nx_glob,ny_glob
     real(dbl_kind), dimension(nx,ny,nblk), intent(out) ::       &
        I_uvel,I_vvel, I_strintx,I_strinty,                      &
@@ -1177,7 +1301,9 @@ module ice_dyn_evp_1d
        I_stressm_1, I_stressm_2, I_stressm_3, I_stressm_4,      &
        I_stress12_1,I_stress12_2,I_stress12_3,I_stress12_4,     &
        I_divu,I_rdg_conv, I_rdg_shear,I_shear, I_taubx,I_tauby
-    ! local variables
+
+    !-- local variables
+
     real(dbl_kind), dimension(nx_glob,ny_glob) :: &
        G_uvel,G_vvel, G_strintx,G_strinty,                      &
        G_stressp_1, G_stressp_2, G_stressp_3, G_stressp_4,      &
@@ -1185,8 +1311,12 @@ module ice_dyn_evp_1d
        G_stress12_1,G_stress12_2,G_stress12_3,G_stress12_4,     &
        G_divu,G_rdg_conv, G_rdg_shear,G_shear, G_taubx,G_tauby
     integer(int_kind) :: i,j,iw, nx_block
+
+    character(len=*), parameter :: subname = '(evp_copyout)'
+    !---------------------------------------
     ! Remap 1d to 2d and fill in
     nx_block=nx_glob  ! Total block size in x-dir 
+
     if (my_task == master_task) then
       G_uvel       = c0
       G_vvel       = c0
@@ -1251,7 +1381,7 @@ module ice_dyn_evp_1d
 
     !-- Scatter data into blocks --
     !--   has to be done on all tasks --
-    ! BEGIN: Scatter data
+
     call scatter_global_ext(I_uvel, G_uvel, master_task, distrb_info)
     call scatter_global_ext(I_vvel, G_vvel, master_task, distrb_info)
     call scatter_global_ext(I_strintx, G_strintx, master_task, distrb_info)
@@ -1274,22 +1404,31 @@ module ice_dyn_evp_1d
     call scatter_global_ext(I_shear, G_shear, master_task, distrb_info)
     call scatter_global_ext(I_taubx, G_taubx, master_task, distrb_info)
     call scatter_global_ext(I_tauby, G_tauby, master_task, distrb_info)
+
   end subroutine evp_copyout
-  !===============================================================================
+
+!----------------------------------------------------------------------------
+
   subroutine evp_kernel_v2
+
     use ice_constants, only : c0
     use ice_dyn_shared, only: ndte
-    use bench_v2, only : stress, stepu, halo_update
+    use bench_v2, only : evp1d_stress, evp1d_stepu, evp1d_halo_update
     use dmi_omp, only : domp_init
     use icepack_intfc, only: icepack_query_parameters
     use ice_communicate, only: my_task, master_task
     implicit none
+
     real(kind=dbl_kind) :: rhow
     integer (kind=int_kind) :: ierr, lun, i, nthreads
     integer (kind=int_kind) :: na,nb,navel
 
+    character(len=*), parameter :: subname = '(evp_kernel_v2)'
+    !---------------------------------------
     !-- All calculations has to be done on one single node (choose master-task) --
+
     if (my_task == master_task) then
+
       !- Read constants...
       call icepack_query_parameters(rhow_out=rhow)
       na=NA_len
@@ -1309,10 +1448,11 @@ module ice_dyn_evp_1d
       str7=c0
       str8=c0
    
-      if (ndte<2) STOP 'ndte must be 2 or higher for this kernel'
+      if (ndte<2) call abort_ice(subname//' ERROR: ndte must be 2 or higher for this kernel')
+
       !$OMP PARALLEL PRIVATE(i)
       do i = 1, ndte-1
-        call stress (NA_len, &
+        call evp1d_stress(NA_len,                                                    &
                      ee,ne,se,1,na,uvel,vvel,dxt,dyt,                                &
                      hte,htn,htem1,htnm1,                                            &
                      strength,stressp_1,stressp_2,stressp_3,stressp_4,               &
@@ -1320,15 +1460,16 @@ module ice_dyn_evp_1d
                      stress12_2,stress12_3,stress12_4,str1,str2,str3,                &
                      str4,str5,str6,str7,str8)
         !$OMP BARRIER
-        call stepu(NA_len, rhow, &
+        call evp1d_stepu(NA_len, rhow,                                               &
                      1,nb,cdn_ocn,aiu,uocn,vocn,forcex,forcey,umassdti,fm,uarear,Tbu,&
                      uvel_init,vvel_init,uvel,vvel,                                  &
                      str1,str2,str3,str4,str5,str6,str7,str8, nw,sw,sse,skipucell)
         !$OMP BARRIER
-        call halo_update(NA_len,1,navel,uvel,vvel, halo_parent)
+        call evp1d_halo_update(NA_len,1,navel,uvel,vvel, halo_parent)
         !$OMP BARRIER
       enddo
-      call stress   (NA_len, tarear,                                                 &
+
+      call evp1d_stress(NA_len, tarear,                                              &
                      ee,ne,se,1,na,uvel,vvel,dxt,dyt,                                &
                      hte,htn,htem1,htnm1,                                            &
                      strength,stressp_1,stressp_2,stressp_3,stressp_4,               &
@@ -1337,25 +1478,35 @@ module ice_dyn_evp_1d
                      divu,rdg_conv,rdg_shear,shear,                                  &
                      str1,str2,str3,str4,str5,str6,str7,str8)
       !$OMP BARRIER
-      call stepu     (NA_len, rhow, &
+      call evp1d_stepu(NA_len, rhow,                                                 &
                      1,nb,cdn_ocn,aiu,uocn,vocn,forcex,forcey,umassdti,fm,uarear,Tbu,&
                      strintx,strinty,taubx,tauby,                                    &
                      uvel_init,vvel_init,uvel,vvel,                                  &
                      str1,str2,str3,str4,str5,str6,str7,str8, nw,sw,sse,skipucell)
       !$OMP BARRIER
-      call halo_update(NA_len,1,navel,uvel,vvel, halo_parent)
+      call evp1d_halo_update(NA_len,1,navel,uvel,vvel, halo_parent)
       !$OMP END PARALLEL
+
     endif
+
   end subroutine evp_kernel_v2
-  !===============================================================================
+
+!----------------------------------------------------------------------------
+
   subroutine calc_na(nx,ny,na,icetmask)
     ! Calculate number of active points (na)
     use ice_blocks, only: nghost
+
     implicit none
+
     integer(int_kind),intent(in) :: nx,ny
     integer(int_kind),intent(out) :: na
     integer (kind=int_kind),dimension (nx,ny), intent(in) :: icetmask
     integer(int_kind) :: i,j
+
+    character(len=*), parameter :: subname = '(calc_na)'
+    !---------------------------------------
+
     na = 0
 ! Note: The icellt mask includes north and east ghost cells. (ice_dyn_shared.F90)
     do j = 1+nghost, ny ! -nghost
@@ -1365,14 +1516,25 @@ module ice_dyn_evp_1d
         endif
     enddo
     enddo
+
   end subroutine calc_na
+
+!----------------------------------------------------------------------------
+
   subroutine calc_2d_indices(nx,ny,na,icetmask,iceumask)
+
     use ice_blocks, only: nghost
+
     implicit none
+
     integer(int_kind),intent(in) :: nx,ny,na
     integer (kind=int_kind),dimension (nx,ny), intent(in) :: icetmask
     logical (kind=log_kind),dimension (nx,ny), intent(in) :: iceumask
     integer(int_kind) :: i,j,Nmaskt
+
+    character(len=*), parameter :: subname = '(calc_2d_indices)'
+    !---------------------------------------
+
     skipucell(:)=.false.
     indi=0
     indj=0
@@ -1392,21 +1554,32 @@ module ice_dyn_evp_1d
     enddo
     enddo
     if (Nmaskt.ne.na) then
-      write(*,*)'Nmaskt,na: ',Nmaskt,na
-      call abort_ice('(ice_dyn_evp_1d) : Problem Nmaskt != na')
+      write(nu_diag,*) subname,' Nmaskt,na: ',Nmaskt,na
+      call abort_ice(subname//': ERROR Problem Nmaskt != na')
     endif
     if (Nmaskt==0) then
-      write(*,*)'WARNING: NO ICE'
+      write(nu_diag,*) subname,' WARNING: NO ICE'
     endif
+
   end subroutine calc_2d_indices
+
+!----------------------------------------------------------------------------
+
   subroutine calc_navel(nx_block,ny_block,na,navel)
     ! Calculate number of active points including needed halo points (navel)
+
     implicit none
+
     integer(int_kind),intent(in)  :: nx_block,ny_block,na
     integer(int_kind),intent(out) :: navel
+
     integer(int_kind) :: iw,i,j
     integer(int_kind),dimension(1:na) :: Iin,Iee,Ine,Ise,Inw,Isw,Isse
     integer(int_kind),dimension(1:7*na) :: util1,util2
+
+    character(len=*), parameter :: subname = '(calc_navel)'
+
+    !---------------------------------------
     ! Additional indices used for finite differences (FD)
     do iw=1,na
       i=indi(iw)
@@ -1419,6 +1592,7 @@ module ice_dyn_evp_1d
       Isw(iw) = i+1 + (j-0)*nx_block  ! (+1,+1)
       Isse(iw)= i   + (j-0)*nx_block  ! ( 0,+1)
     enddo
+
     !-- Find number of points needed for finite difference calculations
     call union(Iin,  Iee,na,na,util1,i)
     call union(util1,Ine, i,na,util2,j)
@@ -1426,15 +1600,20 @@ module ice_dyn_evp_1d
     call union(util1,Inw, i,na,util2,j)
     call union(util2,Isw, j,na,util1,i)
     call union(util1,Isse,i,na,util2,navel)
+
     !-- Check bounds
     do iw=1,navel
       if (util2(iw)>nx_block*ny_block .or. util2(iw)<1) then
-        write(*,*)'nx_block,ny_block,nx_block*ny_block: ',nx_block,ny_block,nx_block*ny_block
-        write(*,*)'na,navel,iw,util2(iw): ',na,navel,iw,util2(iw)
-        call abort_ice('(ice_dyn_evp_1d) : Problem with boundary. Check halo zone values')
+        write(nu_diag,*) subname,' nx_block,ny_block,nx_block*ny_block: ',nx_block,ny_block,nx_block*ny_block
+        write(nu_diag,*) subname,' na,navel,iw,util2(iw): ',na,navel,iw,util2(iw)
+        call abort_ice(subname//': Problem with boundary. Check halo zone values')
       endif
     enddo
+
   end subroutine calc_navel
+
+!----------------------------------------------------------------------------
+
   subroutine convert_2d_1d_v2(nx,ny, na,navel,                &
        I_HTE,I_HTN,                                           &
 !v1       I_dxhy,I_dyhx,I_cyp,I_cxp,I_cym,I_cxm,I_tinyarea,      &
@@ -1446,7 +1625,9 @@ module ice_dyn_evp_1d
         I_stressp_1 ,I_stressp_2, I_stressp_3, I_stressp_4,   &
         I_stressm_1 ,I_stressm_2, I_stressm_3, I_stressm_4,   &
        I_stress12_1,I_stress12_2,I_stress12_3,I_stress12_4    )
+
     implicit none
+
     integer(int_kind),intent(in) :: nx,ny,na,navel
     real (kind=dbl_kind), dimension(nx,ny), intent(in)    ::  &
        I_HTE,I_HTN,                                           &
@@ -1459,10 +1640,15 @@ module ice_dyn_evp_1d
         I_stressp_1 ,I_stressp_2, I_stressp_3, I_stressp_4,   &
         I_stressm_1 ,I_stressm_2, I_stressm_3, I_stressm_4,   &
        I_stress12_1,I_stress12_2,I_stress12_3,I_stress12_4
+
     integer(int_kind) :: iw,i,j, nx_block
     integer(int_kind),dimension(1:na) :: Iin,Iee,Ine,Ise,Inw,Isw,Isse
     integer(int_kind),dimension(1:7*na) :: util1,util2
     integer(int_kind) :: nachk
+
+    character(len=*), parameter :: subname = '(convert_2d_1d_v2)'
+
+    !---------------------------------------
     ! Additional indices used for finite differences (FD)
     nx_block=nx  ! Total block size in x-dir 
     do iw=1,na
@@ -1476,6 +1662,7 @@ module ice_dyn_evp_1d
       Isw(iw) = i+1 + (j-0)*nx_block  ! (+1,+1)
       Isse(iw)= i   + (j-0)*nx_block  ! ( 0,+1)
     enddo
+
     !-- Find number of points needed for finite difference calculations
     call union(Iin,  Iee,na,na,util1,i)
     call union(util1,Ine, i,na,util2,j)
@@ -1483,15 +1670,17 @@ module ice_dyn_evp_1d
     call union(util1,Inw, i,na,util2,j)
     call union(util2,Isw, j,na,util1,i)
     call union(util1,Isse,i,na,util2,nachk)
+
     if (nachk .ne. navel) then
-      write(*,*)'ERROR: navel badly chosen: na,navel,nachk = ',na,navel,nachk
-      call abort_ice('(ice_dyn_evp_1d) : ERROR: navel badly chosen')
+      write(nu_diag,*) subname,' ERROR: navel badly chosen: na,navel,nachk = ',na,navel,nachk
+      call abort_ice(subname//': ERROR: navel badly chosen')
     endif
 
     ! indij: vector with target points (sorted) ...
     do iw=1,na
       indij(iw)=Iin(iw)
     enddo
+
     ! indij: ... followed by extra points (sorted)
     call setdiff(util2,Iin,navel,na,util1,j)
     do iw=na+1,navel
@@ -1508,14 +1697,14 @@ module ice_dyn_evp_1d
 
     !-- write check
 !if (1 == 2) then
-!    write(*,*)'MHRI: INDICES start: convert_2d_1d_v2'
-!    write(*,*) 'Min/max ee', minval(ee), maxval(ee)
-!    write(*,*) 'Min/max ne', minval(ne), maxval(ne)
-!    write(*,*) 'Min/max se', minval(se), maxval(se)
-!    write(*,*) 'Min/max nw', minval(nw), maxval(nw)
-!    write(*,*) 'Min/max sw', minval(sw), maxval(sw)
-!    write(*,*) 'Min/max sse',minval(sse),maxval(sse)
-!    write(*,*)'MHRI: INDICES end: convert_2d_1d_v2'
+!    write(nu_diag,*) subname,' MHRI: INDICES start:'
+!    write(nu_diag,*) 'Min/max ee', minval(ee), maxval(ee)
+!    write(nu_diag,*) 'Min/max ne', minval(ne), maxval(ne)
+!    write(nu_diag,*) 'Min/max se', minval(se), maxval(se)
+!    write(nu_diag,*) 'Min/max nw', minval(nw), maxval(nw)
+!    write(nu_diag,*) 'Min/max sw', minval(sw), maxval(sw)
+!    write(nu_diag,*) 'Min/max sse',minval(sse),maxval(sse)
+!    write(nu_diag,*) subname,' MHRI: INDICES end:'
 !endif
 
     ! Write 1D data from 2D: Here only extra FD part, the rest follows...
@@ -1580,20 +1769,33 @@ module ice_dyn_evp_1d
       HTNm1(iw) = I_HTN(i,j-1)
     enddo
     !$OMP END PARALLEL DO
+
   end subroutine convert_2d_1d_v2
+
+!----------------------------------------------------------------------------
+
   subroutine calc_halo_parent(nx,ny,na,navel, I_icetmask)
+
     implicit none
+
     integer(kind=int_kind),intent(in) :: nx,ny,na,navel
     integer(kind=int_kind), dimension(nx,ny), intent(in) :: I_icetmask
+
     integer(kind=int_kind) :: iw,i,j !,masku,maskt
     integer(kind=int_kind),dimension(1:navel) :: Ihalo
+
+    character(len=*), parameter :: subname = '(calc_halo_parent)'
+
+    !---------------------------------------
     ! Indices for halo update:
     !      0: no halo point
     !     >0: index for halo point parent. Finally related to indij vector
     ! TODO: ONLY for nghost==1
     ! TODO: ONLY for circular grids - NOT tripole grids
+
     Ihalo(:)=0
     halo_parent(:)=0
+
     !$OMP PARALLEL DO PRIVATE(iw,i,j)
     do iw=1,navel
       j=int((indij(iw)-1)/(nx))+1
@@ -1605,13 +1807,14 @@ module ice_dyn_evp_1d
       if (j==1  .and. I_icetmask(i,ny-1)==1) Ihalo(iw)=     i+(ny-2)*nx
     enddo
     !$OMP END PARALLEL DO
+
     ! Relate halo indices to indij vector
     call findXinY_halo(Ihalo,indij,navel,navel,halo_parent)
 
     !-- write check
 !if (1 == 1) then
 !    integer(kind=int_kind) :: iiw,ii,jj !,masku,maskt  MHRI
-!    write(*,*)'MHRI: halo boundary start: calc_halo_parent '
+!    write(nu_diag,*) subname,' MHRI: halo boundary start:'
 !    do iw=1,navel
 !      if (halo_parent(iw)>0) then
 !      iiw=halo_parent(iw)
@@ -1621,23 +1824,33 @@ module ice_dyn_evp_1d
 !      jj=j
 !      j=int((indij(iw)-1)/(nx))+1
 !      i=indij(iw)-(j-1)*nx
-!      write(*,*)iw,i,j,iiw,ii,jj
+!      write(nu_diag,*)iw,i,j,iiw,ii,jj
 !      endif
 !    enddo
-!    write(*,*)'MHRI: halo boundary end: calc_halo_parent '
+!    write(nu_diag,*) subname,' MHRI: halo boundary end:'
 !endif
+
   end subroutine calc_halo_parent
-  !=======================================================================
+
+!----------------------------------------------------------------------------
+
   subroutine union(x,y,nx,ny,xy,nxy)
     ! Find union (xy) of two sorted integer vectors (x and y)
     !   ie. Combined values of the two vectors with no repetitions.
     !use ice_kinds_mod
+
     implicit none
+
     integer (int_kind) :: i,j,k
     integer (int_kind),intent(in)  :: nx,ny
     integer (int_kind),intent(in)  :: x(1:nx),y(1:ny)
     integer (int_kind),intent(out) :: xy(1:nx+ny)
     integer (int_kind),intent(out) :: nxy
+
+    character(len=*), parameter :: subname = '(union)'
+
+    !---------------------------------------
+
     i=1
     j=1
     k=1
@@ -1655,6 +1868,7 @@ module ice_dyn_evp_1d
       endif
       k=k+1
     enddo
+
     ! The rest
     do while (i<=nx)
       xy(k)=x(i)
@@ -1667,18 +1881,27 @@ module ice_dyn_evp_1d
       k=k+1
     enddo
     nxy=k-1
+
   end subroutine union
-  !=======================================================================
+
+!----------------------------------------------------------------------------
+
   subroutine setdiff(x,y,nx,ny,xy,nxy)
     ! Find element (xy) of two sorted integer vectors (x and y)
     !   that are in x, but not in y ... or in y, but not in x
     !use ice_kinds_mod
+
     implicit none
+
     integer (int_kind) :: i,j,k
     integer (int_kind),intent(in)  :: nx,ny
     integer (int_kind),intent(in)  :: x(1:nx),y(1:ny)
     integer (int_kind),intent(out) :: xy(1:nx+ny)
     integer (int_kind),intent(out) :: nxy
+
+    character(len=*), parameter :: subname = '(setdiff)'
+    !---------------------------------------
+
     i=1
     j=1
     k=1
@@ -1696,6 +1919,7 @@ module ice_dyn_evp_1d
         j=j+1
       endif
     enddo
+
     ! The rest
     do while (i<=nx)
       xy(k)=x(i)
@@ -1708,8 +1932,11 @@ module ice_dyn_evp_1d
       k=k+1
     enddo
     nxy=k-1
+
   end subroutine setdiff
-  !=======================================================================
+
+!----------------------------------------------------------------------------
+
   subroutine findXinY(x,y,nx,ny,indx)
     ! Find indx vector so that x(1:na)=y(indx(1:na))
     !
@@ -1722,11 +1949,17 @@ module ice_dyn_evp_1d
     !  Return: indx(1:na)
     !
     !use ice_kinds_mod
+
     implicit none
+
     integer (int_kind),intent(in)  :: nx,ny
     integer (int_kind),intent(in)  :: x(1:nx),y(1:ny)
     integer (int_kind),intent(out) :: indx(1:nx)
     integer (int_kind) :: i,j1,j2
+
+    character(len=*), parameter :: subname = '(findXinY)'
+    !---------------------------------------
+
     i=1
     j1=1
     j2=nx+1
@@ -1744,13 +1977,17 @@ module ice_dyn_evp_1d
       else if (x(i)>y(j2) ) then !.and. j2<ny) then
         j2=j2+1
       else
-        write(*,*)'nx,ny: ',nx,ny
-        write(*,*)'i,j1,j2: ',i,j1,j2
-        write(*,*)'x(i),y(j1),y(j2): ',x(i),y(j1),y(j2)
-        call abort_ice('(ice_dyn_evp_1d) : ERROR in findXinY')
+        write(nu_diag,*) subname,' nx,ny: ',nx,ny
+        write(nu_diag,*) subname,' i,j1,j2: ',i,j1,j2
+        write(nu_diag,*) subname,' x(i),y(j1),y(j2): ',x(i),y(j1),y(j2)
+        call abort_ice(subname//': ERROR')
       endif
     end do
+
   end subroutine findXinY
+
+!----------------------------------------------------------------------------
+
   subroutine findXinY_halo(x,y,nx,ny,indx)
     ! Find indx vector so that x(1:na)=y(indx(1:na))
     !
@@ -1763,11 +2000,17 @@ module ice_dyn_evp_1d
     !  Return: indx(1:na)
     !
     !use ice_kinds_mod
+
     implicit none
+
     integer (int_kind),intent(in)  :: nx,ny
     integer (int_kind),intent(in)  :: x(1:nx),y(1:ny)
     integer (int_kind),intent(out) :: indx(1:nx)
     integer (int_kind) :: i,j1,nloop
+
+    character(len=*), parameter :: subname = '(findXinY_halo)'
+    !---------------------------------------
+
     nloop=1
     i=1
     j1=int((ny+1)/2) ! initial guess in the middle
@@ -1791,24 +2034,33 @@ module ice_dyn_evp_1d
           nloop=nloop+1
           if (nloop>2) then
             ! Stop for inf. loop. This check should not be necessary for halo
-            write(*,*)'nx,ny: ',nx,ny
-            write(*,*)'i,j1: ',i,j1
-            write(*,*)'x(i),y(j1): ',x(i),y(j1)
-            call abort_ice('(ice_dyn_evp_1d) : ERROR in findXinY_halo: too many loops')
+            write(nu_diag,*) subname,' nx,ny: ',nx,ny
+            write(nu_diag,*) subname,' i,j1: ',i,j1
+            write(nu_diag,*) subname,' x(i),y(j1): ',x(i),y(j1)
+            call abort_ice(subname//': ERROR too many loops')
           endif
         endif
       endif
     end do
+
   end subroutine findXinY_halo
 
-  !=======================================================================
+!----------------------------------------------------------------------------
+
   subroutine numainit(l,u,uu)
-    !- modules -----------------------------------------------------------------
+
     use dmi_omp, only  : domp_get_domain
     use ice_constants, only: c0
+
     implicit none
+
     integer(kind=int_kind),intent(in) :: l,u,uu
+
     integer(kind=int_kind) :: lo,up
+
+    character(len=*), parameter :: subname = '(numainit)'
+    !---------------------------------------
+
     call domp_get_domain(l,u,lo,up)
     ee(lo:up)=0
     ne(lo:up)=0
@@ -1877,8 +2129,10 @@ module ice_dyn_evp_1d
     str6(lo:up)=c0
     str7(lo:up)=c0
     str8(lo:up)=c0
+
   end subroutine numainit
   
-  !=======================================================================
+!----------------------------------------------------------------------------
+
 end module ice_dyn_evp_1d
 

--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -40,10 +40,10 @@
          revised_evp  ! if true, use revised evp procedure
 
       integer (kind=int_kind), public :: &
-         evp_kernel_ver ! 0 = 2D org version
-                        ! 1 = 1D representation raw (not implemented)
-                        ! 2 = 1D + calculate distances inline (implemented)
-                        ! 3 = 1D + calculate distances inline + real*4 internal (not implemented yet)
+         kevp_kernel ! 0 = 2D org version
+                     ! 1 = 1D representation raw (not implemented)
+                     ! 2 = 1D + calculate distances inline (implemented)
+                     ! 3 = 1D + calculate distances inline + real*4 internal (not implemented yet)
       ! other EVP parameters
 
       character (len=char_len), public :: & 

--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -92,7 +92,7 @@
                           grid_type, grid_format, &
                           dxrect, dyrect
       use ice_dyn_shared, only: ndte, kdyn, revised_evp, yield_curve, &
-                                evp_kernel_ver, &
+                                kevp_kernel, &
                                 basalstress, k1, Ktens, e_ratio, coriolis, &
                                 kridge, ktransport, brlx, arlx
       use ice_transport_driver, only: advection
@@ -180,7 +180,7 @@
 
       namelist /dynamics_nml/ &
         kdyn,           ndte,           revised_evp,    yield_curve,    &
-        evp_kernel_ver,                                                 &
+        kevp_kernel,                                                    &
         brlx,           arlx,                                           &
         advection,      coriolis,       kridge,         ktransport,     &
         kstrength,      krdg_partic,    krdg_redist,    mu_rdg,         &
@@ -283,7 +283,7 @@
       kdyn = 1           ! type of dynamics (-1, 0 = off, 1 = evp, 2 = eap)
       ndtd = 1           ! dynamic time steps per thermodynamic time step
       ndte = 120         ! subcycles per dynamics timestep:  ndte=dt_dyn/dte
-      evp_kernel_ver = 0 ! EVP kernel (0 = 2D, >0: 1D. Only ver. 2 is implemented yet)
+      kevp_kernel = 0    ! EVP kernel (0 = 2D, >0: 1D. Only ver. 2 is implemented yet)
       brlx   = 300.0_dbl_kind ! revised_evp values. Otherwise overwritten in ice_dyn_shared
       arlx   = 300.0_dbl_kind ! revised_evp values. Otherwise overwritten in ice_dyn_shared
       revised_evp = .false.  ! if true, use revised procedure for evp dynamics
@@ -546,7 +546,7 @@
       call broadcast_scalar(kdyn,               master_task)
       call broadcast_scalar(ndtd,               master_task)
       call broadcast_scalar(ndte,               master_task)
-      call broadcast_scalar(evp_kernel_ver,     master_task)
+      call broadcast_scalar(kevp_kernel,        master_task)
       call broadcast_scalar(brlx,               master_task)
       call broadcast_scalar(arlx,               master_task)
       call broadcast_scalar(revised_evp,        master_task)
@@ -996,10 +996,8 @@
          endif
          write(nu_diag,1020) ' ndtd                      = ', ndtd
          write(nu_diag,1020) ' ndte                      = ', ndte
-         write(nu_diag,1010) ' revised_evp               = ', &
-                               revised_evp
-         write(nu_diag,1020) ' evp_kernel_ver            = ', &
-                               evp_kernel_ver
+         write(nu_diag,1010) ' revised_evp               = ', revised_evp
+         write(nu_diag,1020) ' kevp_kernel               = ', kevp_kernel
          write(nu_diag,1005) ' brlx                      = ', brlx
          write(nu_diag,1005) ' arlx                      = ', arlx
          if (kdyn == 1) &
@@ -1190,8 +1188,23 @@
          abort_flag = 20
       endif
 
+      ! check for valid kevp_kernel
+      ! tcraig, kevp_kernel=2 is not validated, do not allow use
+      !         use "102" to test "2" for now
+      if (kevp_kernel /= 0) then
+         if (kevp_kernel == 102) then
+            kevp_kernel = 2
+         else
+            if (my_task == master_task) write(nu_diag,*) subname//' ERROR: kevp_kernel = ',kevp_kernel
+            if (kevp_kernel == 2) then
+                if (my_task == master_task) write(nu_diag,*) subname//' kevp_kernel=2 not validated, use kevp_kernel=102 for testing until it is validated'
+            endif
+            abort_flag = 21
+        endif
+      endif
+
       if (abort_flag /= 0) then
-        call flush_fileunit(nu_diag)
+         call flush_fileunit(nu_diag)
       endif
       call ice_barrier()
       if (abort_flag /= 0) then

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -102,7 +102,7 @@
     kdyn            = 1
     ndte            = 240
     revised_evp     = .false.
-    evp_kernel_ver  = 0
+    kevp_kernel     = 0
     brlx            = 300.0
     arlx            = 300.0
     advection       = 'remap'

--- a/doc/source/developer_guide/dg_dynamics.rst
+++ b/doc/source/developer_guide/dg_dynamics.rst
@@ -37,8 +37,18 @@ The dynamics solvers are found in **cicecore/cicedynB/dynamics/**.  A couple of 
 available including EVP, revised EVP, and EAP.  The dynamics solver is specified in namelist with the
 ``kdyn`` variable.  ``kdyn=1`` is evp, ``kdyn=2`` is eap, and revised evp requires the ``revised_evp``
 namelist flag be set to true.
-A vectorized version of EVP is available through the namelist flag ``evp_kernel_ver``. Default is "normal"
-EVP as usual ``evp_kernel_ver=0``, whereas an vectorized version (ver.2) is available ``evp_kernel_ver=2``.
+
+Multiple evp solvers are supported thru the namelist flag ``kevp_kernel``.  The standard implementation
+and current default is ``kevp_kernel=0``.  In this case, the stress is solved on the regular decomposition
+via subcycling and calls to subroutine stress and subroutine stepu with MPI global sums required in each
+subcycling call.  With ``kevp_kernel=2``, the data required to compute the stress is gathered to the root
+MPI process and the stress calculation is performed on the root task without any MPI global sums.  OpenMP
+parallelism is supported in ``kevp_kernel=2``.  The solutions with ``kevp_kernel`` set to 0 or 2 will 
+not be bit-for-bit
+identical but should be the same to roundoff and produce the same climate.  ``kevp_kernel=2`` may perform
+better for some configurations, some machines, and some pe counts.  ``kevp_kernel=2`` is not supported
+with the tripole grid and is still being validated.  Until ``kevp_kernel=2`` is fully validated, it will
+abort if set.  To override the abort, use value 102 for testing.
 
 
 Transport


### PR DESCRIPTION
Clean up EVP kernel=2 implementation, addresses some of the issues in #279 

-- renamed namelist evp_kernel_ver to kevp_kernel
-- cleaned up ice_dyn_evp_1d.F90 to more closely meet cice coding standard, changed stops to aborts, added subname, updated write/print statements, and updated spacing a little.
-- updated documentation, noted that kevp_kernel=2 is not validated
-- added an abort if kevp_kernel=2 is set.  Also added an option so if kevp_kernel=102, the value of 2 is used.  That allows testing.  When kevp_kernel=2 is validated, this will have to be removed again.

- Developer(s): tcraig

- Are the code changes bit for bit, different at roundoff level, or more substantial? bit-for-bit

- Does this PR create or have dependencies on Icepack or any other models? N

- Is the documentation being updated with this PR? (Y/N) Y

- Other Relevant Details:

test results are bit-for-bit, see #280d5caca949396 at https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks.  I also ran a broad test suite with evp kernel=2 before and after and am comfortable the results were not changed for that option either.

