### PR TITLE
Build system improvements

### DIFF
--- a/cice.setup
+++ b/cice.setup
@@ -533,7 +533,7 @@ EOF
     endif
 
     # from basic script dir to case
-    foreach file (cice.build cice.settings Makefile ice_in makdep.c setup_run_dirs.csh)
+    foreach file (cice.build cice.make cice.settings Makefile ice_in makdep.c setup_run_dirs.csh)
       if !(-e ${ICE_SCRIPTS}/$file) then
         echo "${0}: ERROR, ${ICE_SCRIPTS}/$file not found"
         exit -1

--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -60,6 +60,7 @@ OBJS  := $(addsuffix .o, $(sort $(basename $(notdir $(SRCS)))))
 DEPS  := $(addsuffix .d, $(sort $(basename $(notdir $(SRCS)))))
 INCS  := $(patsubst %,-I%, $(VPATH) )
 OBJS_DEPGEN := $(addprefix $(ICE_CASEDIR)/,$(addsuffix .c, $(notdir $(DEPGEN))))
+MODDIR:= -I.
 RM    := rm
 
 .SUFFIXES:
@@ -98,10 +99,10 @@ db_flags:
 	@echo "* %.d : %.F   := $(DEPGEN) $(INCS)"
 	@echo "* %.d : %.F90 := $(DEPGEN) $(INCS)"
 	@echo "* %.d : %.H   := $(DEPGEN) $(INCS)"
-	@echo "* cpp     := $(CPP) $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR)"
-	@echo "* .c.o    := $(CC) $(CFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR)"
-	@echo "* .F.o    := $(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR)"
-	@echo "* .F90.o  := $(FC) -c $(FFLAGS) $(FREEFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR)"
+	@echo "* cpp     := $(CPP) $(CPPFLAGS) $(CPPDEFS) $(INCLDIR)"
+	@echo "* .c.o    := $(CC) $(CFLAGS) $(CPPDEFS) $(INCLDIR)"
+	@echo "* .F.o    := $(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(CPPDEFS) $(INCLDIR)"
+	@echo "* .F90.o  := $(FC) -c $(FFLAGS) $(FREEFLAGS) $(CPPDEFS) $(MODDIR) $(INCLDIR)"
 	@echo "* $(notdir $(EXEC)) := $(LD) $(LDFLAGS) $(ULIBS) $(SLIBS)"
 
 #-------------------------------------------------------------------------------
@@ -125,13 +126,13 @@ $(EXEC): $(OBJS)
 	$(LD) -o $(EXEC) $(LDFLAGS) $(OBJS) $(ULIBS) $(SLIBS)
 
 .c.o:
-	$(CC) $(CFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $<
+	$(CC) $(CFLAGS) $(CPPDEFS) $(INCLDIR) $<
 
 .F.o:
-	$(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $<
+	$(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(CPPDEFS) $(INCLDIR) $<
 
 .F90.o:
-	$(FC) -c $(FFLAGS) $(FREEFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $<
+	$(FC) -c $(FFLAGS) $(FREEFLAGS) $(CPPDEFS) $(MODDIR) $(INCLDIR) $<
 
 mostlyclean:
 	$(RM) -f *.f *.f90 

--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -8,7 +8,6 @@
 #   SRCS=<files>   ~ list of src files, default is all .c .F .F90 files in VPATH
 #   VPFILE=<file>  ~ file with list of dirs, used to create VPATH
 #   SRCFILE=<file> ~ file with list of src files, used to create SRCS
-#   DEPGEN=<exec>  ~ dependency generator utility, default is makdep
 #
 #   <macro defns>  ~ any macro definitions found in this file or the included 
 #                    MACFILE will be over-riden by cmd-line macro definitions
@@ -31,7 +30,9 @@ VPFILE   := NONE
 VPATH    := .
 SRCFILE  := NONE
 SRCS     := NONE
-DEPGEN   := ./makdep  # an externally provided dependency generator
+
+# dependency generator
+DEPGEN   := ./makdep
 
 ifneq ($(VPATH),.)
   # this variable was specified on cmd line or in an env var
@@ -58,6 +59,7 @@ endif
 OBJS  := $(addsuffix .o, $(sort $(basename $(notdir $(SRCS)))))
 DEPS  := $(addsuffix .d, $(sort $(basename $(notdir $(SRCS)))))
 INCS  := $(patsubst %,-I%, $(VPATH) )
+OBJS_DEPGEN := $(addprefix $(ICE_CASEDIR)/,$(addsuffix .c, $(notdir $(DEPGEN))))
 RM    := rm
 
 .SUFFIXES:
@@ -105,7 +107,8 @@ ifndef $(CFLAGS_HOST)
   CFLAGS_HOST :=
 endif
 
-$(DEPGEN): $(ICE_CASEDIR)/makdep.c
+$(DEPGEN): $(OBJS_DEPGEN)
+	@ echo "Building makdep"
 	$(SCC) -o $@ $(CFLAGS_HOST) $<
 
 #-------------------------------------------------------------------------------
@@ -138,7 +141,7 @@ realclean:
 # Build & include dependency files
 #-------------------------------------------------------------------------------
 # ASSUMPTIONS:
-# o an externally provided dependency generator, $(DEPGEN), is available, 
+# o the dependency generator, $(DEPGEN), can be built, 
 #   its cmd line syntax is compatible with the build rules below.   Eg, for 
 #   each .o file, there is a corresponding .d (dependency) file, and both
 #   will be dependent on the same src file, eg.    foo.o foo.d : foo.F90
@@ -146,16 +149,16 @@ realclean:
 #   are understood & accepted.
 #-------------------------------------------------------------------------------
 
-%.d : %.c
+%.d : %.c $(DEPGEN)
 	@ echo "Building dependency for $@"
 	@ $(DEPGEN) -f $(INCS) $< | head -3  > $@
-%.d : %.F
+%.d : %.F $(DEPGEN)
 	@ echo "Building dependency for $@"
 	@ $(DEPGEN) -f $(INCS) $<  > $@
-%.d : %.F90
+%.d : %.F90 $(DEPGEN)
 	@ echo "Building dependency for $@"
 	@ $(DEPGEN) -f $(INCS) $<  > $@
-%.d : %.H
+%.d : %.H $(DEPGEN)
 	@ echo "Building dependency for $@"
 	@ $(DEPGEN) -f $(INCS) $<  > $@
 

--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -69,12 +69,9 @@ all: $(EXEC)
 
 #-------------------------------------------------------------------------------
 # include the file that provides macro definitions required by build rules
-# note: the MACFILE may not be needed for certain goals
 #-------------------------------------------------------------------------------
 
-ifneq ($(MAKECMDGOALS), db_files)
-  -include $(MACFILE)
-endif
+-include $(MACFILE)
 
 #-------------------------------------------------------------------------------
 # echo file names, paths, compile flags, etc. used during build
@@ -91,12 +88,21 @@ db_files:
 	@echo "* SRCS    := $(SRCS)"
 	@echo "* OBJS    := $(OBJS)"
 	@echo "* DEPS    := $(DEPS)"
+	@echo "* ULIBS   := $(ULIBS)"
+	@echo "* SLIBS   := $(SLIBS)"
+	@echo "* INCLDIR := $(INCLDIR)"
 db_flags:
 	@echo " "
+	@echo "* $(DEPGEN) := $(SCC) $(CFLAGS_HOST)"
+	@echo "* %.d : %.c   := $(DEPGEN) $(INCS)"
+	@echo "* %.d : %.F   := $(DEPGEN) $(INCS)"
+	@echo "* %.d : %.F90 := $(DEPGEN) $(INCS)"
+	@echo "* %.d : %.H   := $(DEPGEN) $(INCS)"
 	@echo "* cpp     := $(CPP) $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR)"
-	@echo "* cc      := $(CC) -c $(CFLAGS) $(INCS) $(INCLDIR)"
-	@echo "* .F.o    := $(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(INCS) $(INCLDIR)"
-	@echo "* .F90.o  := $(FC) -c $(FFLAGS) $(FREEFLAGS) $(INCS) $(INCLDIR)"
+	@echo "* .c.o    := $(CC) $(CFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR)"
+	@echo "* .F.o    := $(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR)"
+	@echo "* .F90.o  := $(FC) -c $(FFLAGS) $(FREEFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR)"
+	@echo "* $(notdir $(EXEC)) := $(LD) $(LDFLAGS) $(ULIBS) $(SLIBS)"
 
 #-------------------------------------------------------------------------------
 # build rule for makdep: MACFILE, cmd-line, or env vars must provide

--- a/configuration/scripts/cice.build
+++ b/configuration/scripts/cice.build
@@ -88,10 +88,6 @@ echo "Filepath = "
 cat ${ICE_OBJDIR}/Filepath
 echo " "
 
-echo "building makdep"
-${ICE_MACHINE_MAKE} \
-        -f  ${ICE_CASEDIR}/Makefile MACFILE=${ICE_CASEDIR}/Macros.${ICE_MACHCOMP} makdep || exit 2
-
 echo "building cice > ${ICE_OBJDIR}/${ICE_BLDLOG_FILE}"
 
 if !(-d ${ICE_RUNDIR}) mkdir -p ${ICE_RUNDIR}

--- a/configuration/scripts/cice.make
+++ b/configuration/scripts/cice.make
@@ -1,0 +1,48 @@
+#! /bin/csh -f
+
+source ./cice.settings
+source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} || exit 2
+
+if (${ICE_MACHINE} != ${ICE_MACHINE_ENVNAME}) then
+  echo "WARNING, is ICE_MACHINE setting OK, ${ICE_MACHINE}, ${ICE_MACHINE_ENVNAME}"
+endif
+
+if (${ICE_COMPILER} != ${ICE_MACHINE_COMPILER}) then
+  echo "WARNING, is ICE_COMPILER setting OK, ${ICE_COMPILER}, ${ICE_MACHINE_COMPILER}"
+endif
+
+echo " "
+
+if !(-d ${ICE_OBJDIR}) mkdir -p ${ICE_OBJDIR}
+cd ${ICE_OBJDIR}
+
+setenv ICE_CPPDEFS " "
+
+if (${ICE_IOTYPE} == 'netcdf') then
+  set IODIR = io_netcdf
+  setenv ICE_CPPDEFS "${ICE_CPPDEFS} -Dncdf"
+else if (${ICE_IOTYPE} == 'pio') then
+  set IODIR = io_pio
+  setenv ICE_CPPDEFS "${ICE_CPPDEFS} -Dncdf"
+else
+  set IODIR = io_binary
+endif
+
+### List of source code directories (in order of importance).
+cat >! Filepath << EOF
+${ICE_SANDBOX}/cicecore/drivers/${ICE_DRVOPT}
+${ICE_SANDBOX}/cicecore/cicedynB/dynamics
+${ICE_SANDBOX}/cicecore/cicedynB/general
+${ICE_SANDBOX}/cicecore/cicedynB/analysis
+${ICE_SANDBOX}/cicecore/cicedynB/infrastructure
+${ICE_SANDBOX}/cicecore/cicedynB/infrastructure/io/$IODIR
+${ICE_SANDBOX}/cicecore/cicedynB/infrastructure/comm/${ICE_COMMDIR}
+${ICE_SANDBOX}/cicecore/shared
+${ICE_SANDBOX}/icepack/columnphysics
+EOF
+
+if !(-d ${ICE_RUNDIR}) mkdir -p ${ICE_RUNDIR}
+
+echo "make $*"
+${ICE_MACHINE_MAKE} -j ${ICE_MACHINE_BLDTHRDS} VPFILE=Filepath EXEC=${ICE_RUNDIR}/cice \
+    -f  ${ICE_CASEDIR}/Makefile MACFILE=${ICE_CASEDIR}/Macros.${ICE_MACHCOMP} $*

--- a/doc/source/developer_guide/dg_scripts.rst
+++ b/doc/source/developer_guide/dg_scripts.rst
@@ -17,6 +17,7 @@ The directory structure under configure/scripts is as follows.
 |        **Makefile**              primary makefile
 |        **cice.batch.csh**        creates batch scripts for particular machines
 |        **cice.build**            compiles the code
+|        **cice.make**             wraps Make
 |        **cice.decomp.csh**       computes a decomposition given a grid and task/thread count
 |        **cice.launch.csh**       creates script logic that runs the executable
 |        **cice.run.setup.csh**    sets up the run scripts

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -57,6 +57,7 @@ Once a case/test is created, several files are placed in the case directory
 - **Macros.[machine]** defines the Makefile macros
 - **Makefile** is the makefile used to build the model
 - **cice.build** is a script that builds and compiles the model
+- **cice.make** is a script that wraps Make. It can be used to call Make with the different goals in the Makefile.
 - **ice\_in** is the namelist input file
 - **setup\_run\_dirs.csh** is a script that will create the run directories.  This will be called automatically from the **cice.run** script if the user does not invoke it.
 - **cice.run** is a batch run script


### PR DESCRIPTION
Improvements to the build system, add cice.make script

- Developer(s): Philippe Blain

- Please suggest code Pull Request reviewers in the column at right. @apcraig 

- Are the code changes bit for bit, different at roundoff level, or more substantial? 
BFB (only scripts are touched)

- Please include the link to test results or paste the summary block from the bottom of the testing output below. 
\-
- Does this PR create or have dependencies on Icepack or any other models? 
No. I can issue a similar PR for Icepack if you agree with these changes.

- Is the documentation being updated with this PR? (Y/N) Yes
If not, does the documentation need to be updated separately at a later time? (Y/N)

Note: "Documentation" includes information on the wiki and .rst files in doc/source/, 
which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.

- Other Relevant Details:
  - This PR adds a "cice.make" script that is added to the case directory (mostly a slimmed down "cice.build"). This script can be used to call make with the different goals that are defined in the Makefile, which are useful for debugging (db_files, db_flags, clean). I also updated the output of these flags.
  - I also changed the Makefile so that only a single "-I." flag is used for the call to the compiler, instead of having a "-Ipath/to/source/directory" flag for each source directory, which is useless in our case since all compiled modules are put in the ${ICE_OBJDIR} directory, where the compilation takes place (see commit message of 01f38739581e14). I think this is a historical artifact dating from when the code used "include" instead of "use" directives.
  - Finally, I changed the Makefile so that the program 'makdep' is listed as a prerequisite of the rules that build the dependencies, so we don't need to call "make makdep" separately in cice.build to compile it. 