### PR TITLE
Add maximum depth for grounding scheme

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -913,8 +913,10 @@
          hu,  & ! volume per unit area of ice at u location (mean thickness)
          hwu, & ! water depth at u location
          hcu, & ! critical thickness at u location
-         k2 = 15.0_dbl_kind , &  ! second free parameter (N/m^3) for landfast parametrization 
-         alphab = 20.0_dbl_kind  ! alphab=Cb factor in Lemieux et al 2015
+         k2 = 15.0_dbl_kind , &     ! second free parameter (N/m^3) for landfast parametrization 
+         alphab = 20.0_dbl_kind, &  ! alphab=Cb factor in Lemieux et al 2015
+         threshold_hw = 30.0_dbl_kind ! max water depth for grounding 
+                                      ! see keel data from Amundrud et al. 2004 (JGR)
 
       integer (kind=int_kind) :: &
          i, j, ij
@@ -926,15 +928,21 @@
          j = indxuj(ij)
 
          ! convert quantities to u-location
-         au  = max(aice(i,j),aice(i+1,j),aice(i,j+1),aice(i+1,j+1))
+         
          hwu = min(hwater(i,j),hwater(i+1,j),hwater(i,j+1),hwater(i+1,j+1))
-         hu  = max(vice(i,j),vice(i+1,j),vice(i,j+1),vice(i+1,j+1))
 
-         ! 1- calculate critical thickness
-         hcu = au * hwu / k1
+         if (hwu < threshold_hw) then
+         
+            au  = max(aice(i,j),aice(i+1,j),aice(i,j+1),aice(i+1,j+1))
+            hu  = max(vice(i,j),vice(i+1,j),vice(i,j+1),vice(i+1,j+1))
 
-         ! 2- calculate basal stress factor                    
-         Tbu(i,j) = k2 * max(c0,(hu - hcu)) * exp(-alphab * (c1 - au))
+            ! 1- calculate critical thickness
+            hcu = au * hwu / k1
+
+            ! 2- calculate basal stress factor                    
+            Tbu(i,j) = k2 * max(c0,(hu - hcu)) * exp(-alphab * (c1 - au))
+            
+         endif
 
       enddo                     ! ij
 

--- a/configuration/scripts/machines/Macros.fram_intel
+++ b/configuration/scripts/machines/Macros.fram_intel
@@ -15,10 +15,17 @@ FFLAGS     := -O2 -fp-model precise -convert big_endian -assume byterecl -ftz -t
 #-xHost
 FFLAGS_NOOPT:= -O0
 
-SCC   := s.cc
-SFC   := s.f90
-MPICC := s.cc -mpi
-MPIFC := s.f90 -mpi
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
+# -heap-arrays 1024 
+else
+  FFLAGS     += -O2
+endif
+
+SCC   := icc
+SFC   := ifort
+MPICC := mpicc
+MPIFC := mpif90
 
 ifeq ($(ICE_COMMDIR), mpi)
   FC := $(MPIFC)
@@ -29,7 +36,7 @@ else
 endif
 LD:= $(FC)
 
-NETCDF_PATH := $(NETCDF)
+NETCDF_PATH := /fs/ssm/hpco/tmp/eccc/201402/04/intel-2016.1.150/ubuntu-14.04-amd64-64/
 
 PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
 

--- a/configuration/scripts/machines/env.fram_intel
+++ b/configuration/scripts/machines/env.fram_intel
@@ -1,14 +1,18 @@
 #!/bin/csh -f
 
-#. ssmuse-sh -d /fs/ssm/eccc/mrd/rpn/OCEAN/cncpt-3.1.2
-#source NEMO_compiler.ksh
+source /fs/ssm/main/opt/ssmuse/ssmuse-1.7/ssmuse_1.7_all/bin/ssmuse-boot.csh >& /dev/null # package loader
+set ssmuse=`which ssmuse-csh`
+source $ssmuse -d /fs/ssm/main/opt/intelcomp/intelcomp-2016.1.156 # intel compiler
+source /fs/ssm/main/opt/intelcomp/intelcomp-2016.1.156/intelcomp_2016.1.156_multi/bin/compilervars.csh intel64 # should be sourced by above domain, but bug in csh script
+source $ssmuse -d /fs/ssm/main/opt/openmpi/openmpi-1.6.5/intelcomp-2016.1.156 # openmpi
+source $ssmuse -d /fs/ssm/hpco/tmp/eccc/201402/04/intel-2016.1.150 # netcdf (and openmpi)
 
 setenv ICE_MACHINE_ENVNAME fram
 setenv ICE_MACHINE_COMPILER intel
 setenv ICE_MACHINE_MAKE make
-setenv ICE_MACHINE_WKDIR /home/dormrb01/zephyr4/armn/jfl/local1/Minor_modif4july2018/CICE/tests/CICE_RUNS
-setenv ICE_MACHINE_INPUTDATA /users/dor/armn/jfl/local1/CICE6/CICE/configuration/data/gx3Ncar
-setenv ICE_MACHINE_BASELINE /home/dormrb01/zephyr4/armn/jfl/local1/Minor_modif4july2018/CICE/tests/CICE_BASELINE
+setenv ICE_MACHINE_WKDIR /home/dormrb01/zephyr4/armn/jfl/local1/CICEDIRS/CICE_RUNS
+setenv ICE_MACHINE_INPUTDATA /users/dor/armn/jfl/local1/FORCING
+setenv ICE_MACHINE_BASELINE /home/dormrb01/zephyr4/armn/jfl/local1/CICEDIRS/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub"
 setenv ICE_MACHINE_QUEUE "default"
 setenv ICE_MACHINE_TPNODE 36

--- a/doc/source/science_guide/sg_dynamics.rst
+++ b/doc/source/science_guide/sg_dynamics.rst
@@ -190,7 +190,7 @@ above hydrostatic balance and the value of :math:`k_2`. It is, however, the para
 The value of :math:`k_1` can be changed at runtime using the namelist variable ``k1``. The grounding scheme can be turned on or off using the namelist logical basalstress. 
 
 Note that the user must provide a bathymetry field for using this grounding 
-scheme. Grounding occurs up to water depth of ~25 m. It is suggested to have a bathymetry field with water depths larger than 5 m that represents well shallow water regions such as the Laptev Sea and the East Siberian Sea. 
+scheme. Grounding occurs up to water depth of ~25 m (:math:`T_b` is set to zero when :math:`h_{wu}` is larger than 30 m). It is suggested to have a bathymetry field with water depths larger than 5 m that represents well shallow water regions such as the Laptev Sea and the East Siberian Sea. 
 
    
 .. _internal-stress:

--- a/doc/source/science_guide/sg_dynamics.rst
+++ b/doc/source/science_guide/sg_dynamics.rst
@@ -190,7 +190,11 @@ above hydrostatic balance and the value of :math:`k_2`. It is, however, the para
 The value of :math:`k_1` can be changed at runtime using the namelist variable ``k1``. The grounding scheme can be turned on or off using the namelist logical basalstress. 
 
 Note that the user must provide a bathymetry field for using this grounding 
-scheme. Grounding occurs up to water depth of ~25 m (:math:`T_b` is set to zero when :math:`h_{wu}` is larger than 30 m). It is suggested to have a bathymetry field with water depths larger than 5 m that represents well shallow water regions such as the Laptev Sea and the East Siberian Sea. 
+scheme. It is suggested to have a bathymetry field with water depths larger than 
+5 m that represents well shallow water regions such as the Laptev Sea and the 
+East Siberian Sea. To prevent unrealistic grounding, :math:`T_b` is set to zero when :math:`h_{wu}` 
+is larger than 30 m. This maximum value is chosen based on observations of large 
+keels in the Arctic Ocean :cite:`Amundrud04`.
 
    
 .. _internal-stress:


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Add a maximum depth at which the basal stress parameterization is active
- [x] Developer(s): 
    J-F Lemieux
- [x] Suggest PR reviewers from list in the column to the right. @eclare108213 @apcraig 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    I have not had the time to completely port to our clusters yet (I'm working on that) but I expect the base_suite to not be BFB since these changes will change the ice velocity at some grid points *if* the basal stress parameterization is active (probably it will only change at very few grid points though). I've tried to run the quality control run (5 years) on my local workstation but that was too much to ask, it made my computer shut down...
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [x] more substantial -> **probably**, not verified
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:

Would it be possible for someone to run the base_suite, as well as the quality control suite ? JF wanted this to make it into the release.. I understand if you have other stuff, and I'll keep working on porting (I'm having trouble getting help about using our custom tools...) If I suceed I will update the PR with the test results.

What would be needed to test this:
1. run the base_suite (it will probably not be BFB for the tests where the basalstress is active, i.e. any tests with options alt01, alt03 or boxrestore)
2. run the quality control test (baseline + test), modifying the namelist for both as follows:
    ```
   use_bathymetry=.true.
   basalstress=.true.
    ```
   so that we check if the new code changes will affect the statistical response if the basal stress is active.
