### PR TITLE
Initialize revp stresses to previous time step

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -503,7 +503,7 @@
          taubx    (i,j) = c0
          tauby    (i,j) = c0
 
-         if (revp==1) then               ! revised evp
+         if (icetmask(i,j)==0) then 
             stressp_1 (i,j) = c0
             stressp_2 (i,j) = c0
             stressp_3 (i,j) = c0
@@ -516,20 +516,7 @@
             stress12_2(i,j) = c0
             stress12_3(i,j) = c0
             stress12_4(i,j) = c0
-         else if (icetmask(i,j)==0) then ! classic evp
-            stressp_1 (i,j) = c0
-            stressp_2 (i,j) = c0
-            stressp_3 (i,j) = c0
-            stressp_4 (i,j) = c0
-            stressm_1 (i,j) = c0
-            stressm_2 (i,j) = c0
-            stressm_3 (i,j) = c0
-            stressm_4 (i,j) = c0
-            stress12_1(i,j) = c0
-            stress12_2(i,j) = c0
-            stress12_3(i,j) = c0
-            stress12_4(i,j) = c0
-         endif                  ! revp
+         endif                  
       enddo                     ! i
       enddo                     ! j
 

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -165,6 +165,14 @@ cat >> ${jobfile} << EOFB
 #SBATCH --qos=standby
 EOFB
 
+else if (${ICE_MACHINE} =~ brooks*) then
+cat >> ${jobfile} << EOFB
+#PBS -N ${ICE_CASENAME}
+#PBS -j oe
+#PBS -l select=${nnodes}:ncpus=${corespernode}:mpiprocs=${taskpernodelimit}:ompthreads=${nthrds}
+#PBS -l walltime=${batchtime}
+EOFB
+
 else if (${ICE_MACHINE} =~ theia*) then
 cat >> ${jobfile} << EOFB
 #SBATCH -J ${ICE_CASENAME}

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -154,6 +154,18 @@ EOFR
 endif
 
 #=======
+else if (${ICE_MACHINE} =~ brooks*) then
+if (${ICE_COMMDIR} =~ serial*) then
+cat >> ${jobfile} << EOFR
+./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+else
+cat >> ${jobfile} << EOFR
+aprun -n ${ntasks} -N ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+endif
+
+#=======
 else if (${ICE_MACHINE} =~ theia*) then
 cat >> ${jobfile} << EOFR
 #mpirun -np ${ntasks} ./cice >&! \$ICE_RUNLOG_FILE

--- a/configuration/scripts/machines/Macros.brooks_intel
+++ b/configuration/scripts/machines/Macros.brooks_intel
@@ -1,0 +1,78 @@
+#==============================================================================
+# Makefile macros for ECCC brooks
+#==============================================================================
+# For use with intel compiler
+#==============================================================================
+
+CPP        := fpp
+CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
+CFLAGS     := -c -O2 -fp-model precise
+#-xHost
+
+FIXEDFLAGS := -132
+FREEFLAGS  := -FR
+FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback  -diag-disable 5140
+#-xHost
+FFLAGS_NOOPT:= -O0
+
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created
+# -heap-arrays 1024 
+else
+  FFLAGS     += -O2
+endif
+
+SCC   := cc
+SFC   := ftn
+MPICC := cc
+MPIFC := ftn
+
+ifeq ($(ICE_COMMDIR), mpi)
+  FC := $(MPIFC)
+  CC := $(MPICC)
+else
+  FC := $(SFC)
+  CC := $(SCC)
+endif
+LD:= $(FC)
+
+#NETCDF_PATH := /fs/ssm/hpco/tmp/eccc/201402/04/intel-2016.1.150/ubuntu-14.04-amd64-64/
+
+PIO_CONFIG_OPTS:= --enable-filesystem-hints=gpfs 
+
+#PNETCDF_PATH := $(PNETCDF)
+#PNETCDF_PATH := /glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/lib
+
+INCLDIR := $(INCLDIR)
+
+LIB_NETCDF := $(NETCDF_PATH)/lib
+LIB_PNETCDF := $(PNETCDF_PATH)/lib
+LIB_MPI := $(IMPILIBDIR)
+
+#SLIBS   := -L$(LIB_NETCDF) -lnetcdff -lnetcdf -L$(LIB_PNETCDF) -lpnetcdf -lgptl
+#SLIBS   := -L$(LIB_NETCDF) -lnetcdff -lnetcdf
+
+ifeq ($(ICE_IOTYPE), netcdf)
+   INCLDIR += $(shell nf-config --fflags)
+   SLIBS   := $(shell nf-config --flibs)
+endif
+
+
+ifeq ($(ICE_THREADED), true) 
+   LDFLAGS += -qopenmp 
+   CFLAGS += -qopenmp 
+   FFLAGS += -qopenmp 
+endif
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first!
+ifeq ($(IO_TYPE), pio)
+   PIO_PATH:=/glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/lib
+   INCLDIR += -I/glade/u/apps/ch/opt/pio/2.2/mpt/2.15f/intel/17.0.1/include
+   SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpiof
+
+   CPPDEFS :=  $(CPPDEFS) -Dncdf
+endif
+
+ifeq ($(IO_TYPE), netcdf)
+   CPPDEFS :=  $(CPPDEFS) -Dncdf
+endif

--- a/configuration/scripts/machines/env.brooks_intel
+++ b/configuration/scripts/machines/env.brooks_intel
@@ -1,0 +1,25 @@
+#!/bin/csh -f
+
+source /opt/modules/default/init/csh
+module load PrgEnv-intel # Intel compiler
+module load cray-mpich # MPI (Cray MPICH)
+module load cray-netcdf # NetCDF
+module load cray-hdf5 # HDF5
+
+setenv ICE_MACHINE_ENVNAME brooks
+setenv ICE_MACHINE_COMPILER intel
+setenv ICE_MACHINE_MAKE make
+setenv ICE_MACHINE_WKDIR ~/data/brooks/cice/runs 
+setenv ICE_MACHINE_INPUTDATA /home/ords/cmdd/cmde/phb001/
+setenv ICE_MACHINE_BASELINE ~/data/brooks/cice/baselines
+setenv ICE_MACHINE_SUBMIT "qsub"
+setenv ICE_MACHINE_TPNODE 36
+setenv ICE_MACHINE_ACCT P0000000
+setenv ICE_MACHINE_QUEUE "development"
+setenv ICE_MACHINE_BLDTHRDS 4
+setenv ICE_MACHINE_QSTAT "qstat "
+
+if (-e ~/.cice_proj) then
+   set account_name = `head -1 ~/.cice_proj`
+   setenv CICE_ACCT ${account_name}
+endif

--- a/doc/source/science_guide/sg_dynamics.rst
+++ b/doc/source/science_guide/sg_dynamics.rst
@@ -557,7 +557,7 @@ Introducing another numerical parameter :math:`\alpha=2T \Delta t_e ^{-1}` :cite
    
 where as opposed to the classic EVP, the second term in each equation is at iteration :math:`k` :cite:`Bouillon13`. Also, as opposed to the classic EVP, 
 :math:`\Delta t_e` times the number of subcycles (or iterations) does not need to be equal to the advective time step :math:`\Delta t`. 
-A last difference between the classic EVP and the revised approach is that the latter one initializes the stresses to 0 at the beginning of each time step, 
-while the classic EVP approach uses the previous time level value. The revised EVP is activated by setting the namelist parameter `revised\_evp` = true. 
+Finally, as with the classic EVP approach, the stresses are initialized using the previous time level values. 
+The revised EVP is activated by setting the namelist parameter `revised\_evp` = true. 
 In the code :math:`\alpha = arlx` and :math:`\beta = brlx`. The values of :math:`arlx` and :math:`brlx` can be set in the namelist. 
 It is recommended to use large values of these parameters and to set :math:`arlx=brlx` :cite:`Kimmritz15`.


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Change stress initialization to previous time step for revp, to be up-to-date with litterature.
- [X] Developer(s): 
    Amélie Bouchat
- [X] Suggest PR reviewers from list in the column to the right. @eclare108213  
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    base_suite: 
       210 of 214 tests PASSED
       4 of 214 tests FAILED
       0 of 214 tests PENDING
    The tests that failed are 'alt02' and 'boxrestore' since revp is activated. 
    We are working on running the quality control suite, but still having the same issues reported by @phil-blain in PR #325 .

- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [] No, does the documentation need to be updated at a later time?
        - [] Yes 
        - [ ] No 
- [ ] Please provide any additional information or relevant details below:
The stresses for revp were currently initialized to zero at the beginning of the subcycling, however in the latest litterature they are initialized to the previous time step (see references below). Changing initialization to the previous time step makes more sense for the evolution of the stresses with subcycling:
![ellipse_compare_stress_init](https://user-images.githubusercontent.com/50667934/60911896-32836280-a252-11e9-97fc-629a9fcf3067.png)


I could not perform the quality control suite since we are having issues with running the test on our environment. @phil-blain and I will keep working on this.

Kimmritz et al., 2017, https://doi.org/10.1016/j.ocemod.2017.05.006
Koldunov et al., 2019, https://doi.org/10.1029/2018MS001485