### PR TITLE
Issue333

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: trusty
 
 sudo: false
 

--- a/configuration/scripts/tests/QC/cice.t-test.py
+++ b/configuration/scripts/tests/QC/cice.t-test.py
@@ -174,6 +174,13 @@ def two_stage_test(data_a, num_files, data_d, fname, path):
         for x in maenumerate(data_d):
             min_val = np.min(np.abs(df[x]-df_table))
             idx = np.where(np.abs(df[x]-df_table) == min_val)
+            # Handle the cases where the data point falls exactly half way between
+            # 2 critical T-values (i.e., idx has more than 1 value in it)
+            while True:
+                try:
+                    idx = idx[0]
+                except:
+                    break
             t_crit[x] = t_crit_table[idx]
 
         # Create an array of Pass / Fail values for each grid cell


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix a bug in the CICE QC script that occurs only when a data point falls exactly half way between 2 critical T-values.
- [X] Developer(s): 
    @mattdturner
- [ ] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    I tested the QC script by generating identical datasets for a 5 year simulation.  I also tested it using the data provided by @phil-blain in issue #333  
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
  -There are also a few changes to reduce the memory footprint of the script.
    - This causes the script to be slightly slower.
    - According to the `memory_profiler` package in Python, the script now requires `5.25 GB` of memory in order to run the test for a full 5-year `gx1` simulation.

  -This PR addresses Issue #333
