### PR TITLE
TravisCI xenial updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 
+dist: xenial
+
 sudo: false
 
 addons:
@@ -9,7 +11,7 @@ addons:
     packages:
       - tcsh
       - pkg-config
-      - netcdf-bin libnetcdf-dev #libnetcdff-dev (only required on Debian)
+      - netcdf-bin libnetcdf-dev libnetcdff-dev
       - gfortran
       - gcc
       - openmpi-bin libopenmpi-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: cpp
-dist: trusty
 
 dist: xenial
 


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update to support xenial build environment in travis CI
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested on conrad+gnu.  https://github.com/CICE-Consortium/Test-Results/wiki/6a30b42b40.conrad.gnu.190729.190930
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please provide any additional information or relevant details below:

Testing xenial which has become the default build environment on travisCI.  It was failing with netcdf.  The workaround is to add dist: trusty to the current setup, but this PR attempts to get things working with xenial.

For now, this PR is just providing the ability to test travis.  We can decide later how to proceed, whether to stay with trusty or move to xenial, etc.