### PR TITLE
Fix recent QC crash

### DIFF
--- a/configuration/scripts/tests/QC/cice.t-test.py
+++ b/configuration/scripts/tests/QC/cice.t-test.py
@@ -238,6 +238,13 @@ def two_stage_test(data_a, num_files, data_d, fname, path):
     for x in maenumerate(data_d):
         min_val = np.min(np.abs(r1[x]-r1_table))
         idx = np.where(np.abs(r1[x]-r1_table) == min_val)
+        # Handle the cases where the data point falls exactly half way between
+        # 2 critical T-values (i.e., idx has more than 1 value in it)
+        while True:
+            try:
+                idx = idx[0]
+            except:
+                break
         t_crit[x] = t_crit_table[idx]
 
     # Create an array showing locations of Pass / Fail grid cells


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Edit the QC script to fix an oversight in #337 
- [x] Developer(s): 
    @mattdturner 
- [ ] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    N/A
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:
    - The fix implemented in this PR is identical to the fix in #337 .
    -  PR #337 implemented the fix in 1 location that had the problem, but there were 2 spots in the code with the same exact problem.
    - I tested this updated script on the @abouchat output data provided in #333  and the test completed with the following output

```
INFO:__main__:Running QC test on the following directories:
INFO:__main__:  /p/work1/turner/cice_qc_debug/brooks_intel_smoke_gx1_44x1_alt02_medium_qc.qc_base_original_alt02/
INFO:__main__:  /p/work1/turner/cice_qc_debug/brooks_intel_smoke_gx1_44x1_alt02_medium_qc.qc_test_alt02/
INFO:__main__:Number of files: 1825
INFO:__main__:2 Stage Test Passed
INFO:__main__:Quadratic Skill Test Failed for Northern Hemisphere
INFO:__main__:Quadratic Skill Test Failed for Southern Hemisphere
INFO:__main__:
ERROR:__main__:Quality Control Test FAILED
```