### PR TITLE
Add machine defined limits on maximum processors and batch wall clock time

### DIFF
--- a/cice.setup
+++ b/cice.setup
@@ -433,6 +433,7 @@ if (${doabort} == true) then
   exit -1
 endif
 
+# Create a new sets_base variable to store sets passed to cice.setup
 set sets_base = "${sets}"
 set bfbcomp_base = "$bfbcomp"
 foreach compiler ( $ncompilers )
@@ -458,13 +459,14 @@ EOF
       continue
     endif
 
+    source ${ICE_SCRIPTS}/machines/env.${machcomp} -nomodules || exit 2
+
     # Obtain the test name, sets, grid, and PE information from .ts file
     set test = `echo $line | cut -d' ' -f1`
     set grid = `echo $line | cut -d' ' -f2`
     set pesx = `echo $line | cut -d' ' -f3`
     set sets_tmp = `echo $line | cut -d' ' -f4`
     set bfbcomp_tmp = `echo $line | cut -d' ' -f5`
-    # Create a new sets_base variable to store sets passed to cice.setup
 
     # Append sets from .ts file to the $sets variable
     set sets = "$sets_base,$sets_tmp"
@@ -480,6 +482,61 @@ EOF
     set fbfbcomp = ${spval}
     if ($bfbcomp != ${spval}) then
       set fbfbcomp = ${machcomp}_${bfbcomp}
+    endif
+
+    #------------------------------------------------------------
+    # Parse pesx with strict checking, limit pes for machine
+
+    set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*$/OK/'`
+    if (${chck} == OK) then
+      set task  = `echo ${pesx} | cut -d x -f 1`
+      set thrd  = `echo ${pesx} | cut -d x -f 2`
+      set blckx = `echo ${pesx} | cut -d x -f 3`
+      set blcky = `echo ${pesx} | cut -d x -f 4`
+      set mblck = `echo ${pesx} | cut -d x -f 5`
+      if ($?ICE_MACHINE_MAXPES) then
+        @ pesreq = ${task} * ${thrd}
+        if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
+          @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
+          @ mblck = ${mblck} * ((${pesreq} / ${ICE_MACHINE_MAXPES}) + 1)
+        endif
+      endif
+      set pesx = ${task}x${thrd}x${blckx}x${blcky}x${mblck}
+    else
+      set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*$/OK/'`
+      if (${chck} == OK) then
+        set task  = `echo ${pesx} | cut -d x -f 1`
+        set thrd  = `echo ${pesx} | cut -d x -f 2`
+        set blckx = `echo ${pesx} | cut -d x -f 3`
+        set blcky = `echo ${pesx} | cut -d x -f 4`
+        set mblck = 0
+        if ($?ICE_MACHINE_MAXPES) then
+          @ pesreq = ${task} * ${thrd}
+          if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
+            @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
+          endif
+        endif
+        set pesx = ${task}x${thrd}x${blckx}x${blcky}
+      else
+        set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*$/OK/'`
+        if (${chck} == OK) then
+          set task = `echo ${pesx} | cut -d x -f 1`
+          set thrd = `echo ${pesx} | cut -d x -f 2`
+          set blckx = 0
+          set blcky = 0
+          set mblck = 0
+          if ($?ICE_MACHINE_MAXPES) then
+            @ pesreq = ${task} * ${thrd}
+            if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
+              @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
+            endif
+          endif
+          set pesx = ${task}x${thrd}
+        else
+          echo "${0}: ERROR in -p argument, ${pesx}, must be [m]x[n], [m]x[n]x[bx]x[by], or [m]x[n]x[bx]x[by]x[mb] "
+          exit -1
+        endif
+      endif
     endif
 
     set testname_noid = ${spval}
@@ -560,7 +617,6 @@ EOF
     end
 
     cd ${casedir}
-    source ./env.${machcomp} -nomodules || exit 2
 
     set quietmode = false
     if ($?ICE_MACHINE_QUIETMODE) then
@@ -580,58 +636,6 @@ EOF
         set queue = `head -1 ~/.cice_queue`
       else
         set queue = ${ICE_MACHINE_QUEUE}
-      endif
-    endif
-
-    #------------------------------------------------------------
-    # Parse pesx with strict checking, limit pes for machine
-
-    set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*$/OK/'`
-    if (${chck} == OK) then
-      set task  = `echo ${pesx} | cut -d x -f 1`
-      set thrd  = `echo ${pesx} | cut -d x -f 2`
-      set blckx = `echo ${pesx} | cut -d x -f 3`
-      set blcky = `echo ${pesx} | cut -d x -f 4`
-      set mblck = `echo ${pesx} | cut -d x -f 5`
-      if ($?ICE_MACHINE_MAXPES) then
-        @ pesreq = ${task} * ${thrd}
-        if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
-          @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
-          @ mblck = ${mblck} * ((${pesreq} / ${ICE_MACHINE_MAXPES}) + 1)
-        endif
-      endif
-    else
-      set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*$/OK/'`
-      if (${chck} == OK) then
-        set task  = `echo ${pesx} | cut -d x -f 1`
-        set thrd  = `echo ${pesx} | cut -d x -f 2`
-        set blckx = `echo ${pesx} | cut -d x -f 3`
-        set blcky = `echo ${pesx} | cut -d x -f 4`
-        set mblck = 0
-        if ($?ICE_MACHINE_MAXPES) then
-          @ pesreq = ${task} * ${thrd}
-          if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
-            @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
-          endif
-        endif
-      else
-        set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*$/OK/'`
-        if (${chck} == OK) then
-          set task = `echo ${pesx} | cut -d x -f 1`
-          set thrd = `echo ${pesx} | cut -d x -f 2`
-          set blckx = 0
-          set blcky = 0
-          set mblck = 0
-          if ($?ICE_MACHINE_MAXPES) then
-            @ pesreq = ${task} * ${thrd}
-            if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
-              @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
-            endif
-          endif
-        else
-          echo "${0}: ERROR in -p argument, ${pesx}, must be [m]x[n], [m]x[n]x[bx]x[by], or [m]x[n]x[bx]x[by]x[mb] "
-          exit -1
-        endif
       endif
     endif
 

--- a/cice.setup
+++ b/cice.setup
@@ -584,7 +584,7 @@ EOF
     endif
 
     #------------------------------------------------------------
-    # Compute a default blocksize
+    # Parse pesx with strict checking, limit pes for machine
 
     set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*$/OK/'`
     if (${chck} == OK) then
@@ -593,6 +593,13 @@ EOF
       set blckx = `echo ${pesx} | cut -d x -f 3`
       set blcky = `echo ${pesx} | cut -d x -f 4`
       set mblck = `echo ${pesx} | cut -d x -f 5`
+      if ($?ICE_MACHINE_MAXPES) then
+        @ pesreq = ${task} * ${thrd}
+        if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
+          @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
+          @ mblck = ${mblck} * ((${pesreq} / ${ICE_MACHINE_MAXPES}) + 1)
+        endif
+      endif
     else
       set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*x[0-9][0-9]*$/OK/'`
       if (${chck} == OK) then
@@ -601,6 +608,12 @@ EOF
         set blckx = `echo ${pesx} | cut -d x -f 3`
         set blcky = `echo ${pesx} | cut -d x -f 4`
         set mblck = 0
+        if ($?ICE_MACHINE_MAXPES) then
+          @ pesreq = ${task} * ${thrd}
+          if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
+            @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
+          endif
+        endif
       else
         set chck = `echo ${pesx} | sed  's/^[0-9][0-9]*x[0-9][0-9]*$/OK/'`
         if (${chck} == OK) then
@@ -609,12 +622,21 @@ EOF
           set blckx = 0
           set blcky = 0
           set mblck = 0
+          if ($?ICE_MACHINE_MAXPES) then
+            @ pesreq = ${task} * ${thrd}
+            if (${pesreq} > ${ICE_MACHINE_MAXPES}) then
+              @ task = ${ICE_MACHINE_MAXPES} / ${thrd}
+            endif
+          endif
         else
           echo "${0}: ERROR in -p argument, ${pesx}, must be [m]x[n], [m]x[n]x[bx]x[by], or [m]x[n]x[bx]x[by]x[mb] "
           exit -1
         endif
       endif
     endif
+
+    #------------------------------------------------------------
+    # Compute a default blocksize
 
     setenv ICE_DECOMP_GRID  ${grid}
     setenv ICE_DECOMP_NTASK ${task}

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -28,17 +28,24 @@ if (${taskpernodelimit} > ${ntasks}) set taskpernodelimit = ${ntasks}
 set ptile = $taskpernode
 if ($ptile > ${maxtpn} / 2) @ ptile = ${maxtpn} / 2
 
+set runlength = ${ICE_RUNLENGTH}
+if ($?ICE_MACHINE_MAXRUNLENGTH) then
+  if (${runlength} > ${ICE_MACHINE_MAXRUNLENGTH}) then
+    set runlength = ${ICE_MACHINE_MAXRUNLENGTH}
+  endif
+endif
+
 set queue = "${ICE_QUEUE}"
 set batchtime = "00:15:00"
-if (${ICE_RUNLENGTH} >  0) set batchtime = "00:29:00"
-if (${ICE_RUNLENGTH} == 1) set batchtime = "00:59:00"
-if (${ICE_RUNLENGTH} == 2) set batchtime = "2:00:00"
-if (${ICE_RUNLENGTH} == 3) set batchtime = "3:00:00"
-if (${ICE_RUNLENGTH} == 4) set batchtime = "4:00:00"
-if (${ICE_RUNLENGTH} == 5) set batchtime = "5:00:00"
-if (${ICE_RUNLENGTH} == 6) set batchtime = "6:00:00"
-if (${ICE_RUNLENGTH} == 7) set batchtime = "7:00:00"
-if (${ICE_RUNLENGTH} >= 8) set batchtime = "8:00:00"
+if (${runlength} == 0) set batchtime = "00:29:00"
+if (${runlength} == 1) set batchtime = "00:59:00"
+if (${runlength} == 2) set batchtime = "2:00:00"
+if (${runlength} == 3) set batchtime = "3:00:00"
+if (${runlength} == 4) set batchtime = "4:00:00"
+if (${runlength} == 5) set batchtime = "5:00:00"
+if (${runlength} == 6) set batchtime = "6:00:00"
+if (${runlength} == 7) set batchtime = "7:00:00"
+if (${runlength} >= 8) set batchtime = "8:00:00"
 
 set shortcase = `echo ${ICE_CASENAME} | cut -c1-15`
 

--- a/configuration/scripts/cice.settings
+++ b/configuration/scripts/cice.settings
@@ -27,7 +27,7 @@ setenv ICE_BASEGEN    undefined
 setenv ICE_BASECOM    undefined
 setenv ICE_BFBCOMP    undefined
 setenv ICE_SPVAL      undefined
-setenv ICE_RUNLENGTH  0
+setenv ICE_RUNLENGTH  -1
 setenv ICE_ACCOUNT    undefined
 setenv ICE_QUEUE      undefined
 

--- a/configuration/scripts/machines/env.conrad_intel
+++ b/configuration/scripts/machines/env.conrad_intel
@@ -50,6 +50,8 @@ setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "qsub "
 setenv ICE_MACHINE_ACCT P00000000
 setenv ICE_MACHINE_QUEUE "debug"
-setenv ICE_MACHINE_TPNODE 32    # tasks per node
+setenv ICE_MACHINE_TPNODE 32        # tasks per node
+setenv ICE_MACHINE_MAXPES 8000      # maximum total pes (tasks * threads) available
+setenv ICE_MACHINE_MAXRUNLENGTH 168 # maximum batch wall time limit in hours (integer)
 setenv ICE_MACHINE_BLDTHRDS 4
 setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.travisCI_gnu
+++ b/configuration/scripts/machines/env.travisCI_gnu
@@ -7,7 +7,9 @@ setenv ICE_MACHINE_WKDIR ~/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA ~
 setenv ICE_MACHINE_BASELINE ~/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT " "
-setenv ICE_MACHINE_TPNODE 4
+setenv ICE_MACHINE_TPNODE 4       # maximum tasks per node
+setenv ICE_MACHINE_MAXPES 4       # maximum total pes (tasks * threads) available
+setenv ICE_MACHINE_MAXRUNLENGTH 1 # maximum batch wall time limit in hours (integer)
 setenv ICE_MACHINE_ACCT P0000000
 setenv ICE_MACHINE_QUEUE "default"
 setenv ICE_MACHINE_BLDTHRDS 1

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -309,7 +309,7 @@ There are several machine specific variables defined in the **env.$[machine]**. 
 variables are used to generate working cases for a given machine, compiler, and batch
 system.  Some variables are optional.
 
-.. csv-table:: *CICE settings*
+.. csv-table:: *Machine Settings*
    :header: "variable", "format", "description"
    :widths: 15, 15, 25
 
@@ -317,16 +317,16 @@ system.  Some variables are optional.
    "ICE_MACHINE_COMPILER", "string", "compiler"
    "ICE_MACHINE_MAKE", "string", "make command"
    "ICE_MACHINE_WKDIR", "string", "root work directory"
-   "ICE_MACHINE_INPUTDATA", "root input data directory"
+   "ICE_MACHINE_INPUTDATA", "string", "root input data directory"
    "ICE_MACHINE_BASELINE", "string", "root regression baseline directory"
-   "ICE_MACHINE_SUBMIT", "string", "job submission command"
-   "ICE_MACHINE_TPNODE", "integer", "machine maximum tasks per node"
+   "ICE_MACHINE_SUBMIT", "string", "batch job submission command"
+   "ICE_MACHINE_TPNODE", "integer", "machine maximum MPI tasks per node"
    "ICE_MACHINE_MAXPES", "integer", "machine maximum total processors per job (optional)"
    "ICE_MACHINE_MAXRUNLENGTH", "integer", "batch wall time limit in hours (optional)"
    "ICE_MACHINE_ACCT", "string", "batch default account"
    "ICE_MACHINE_QUEUE", "string", "batch default queue"
    "ICE_MACHINE_BLDTHRDS", "integer", "number of threads used during build"
-   "ICE_MACHINE_QSTAT", "string", "job status command (optional)"
+   "ICE_MACHINE_QSTAT", "string", "batch job status command (optional)"
    "ICE_MACHINE_QUIETMODE", "true/false", "flag to reduce build output (optional)"
 
 .. _cross_compiling:

--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -300,6 +300,35 @@ directory back to **configuration/scripts/machines/** and update
 the **configuration/scripts/cice.batch.csh** file, retest, 
 and then add and commit the updated machine files to the repository.
 
+.. _machvars: 
+
+Machine variables
+~~~~~~~~~~~~~~~~~~~~~~
+
+There are several machine specific variables defined in the **env.$[machine]**.  These
+variables are used to generate working cases for a given machine, compiler, and batch
+system.  Some variables are optional.
+
+.. csv-table:: *CICE settings*
+   :header: "variable", "format", "description"
+   :widths: 15, 15, 25
+
+   "ICE_MACHINE_ENVNAME", "string", "machine name"
+   "ICE_MACHINE_COMPILER", "string", "compiler"
+   "ICE_MACHINE_MAKE", "string", "make command"
+   "ICE_MACHINE_WKDIR", "string", "root work directory"
+   "ICE_MACHINE_INPUTDATA", "root input data directory"
+   "ICE_MACHINE_BASELINE", "string", "root regression baseline directory"
+   "ICE_MACHINE_SUBMIT", "string", "job submission command"
+   "ICE_MACHINE_TPNODE", "integer", "machine maximum tasks per node"
+   "ICE_MACHINE_MAXPES", "integer", "machine maximum total processors per job (optional)"
+   "ICE_MACHINE_MAXRUNLENGTH", "integer", "batch wall time limit in hours (optional)"
+   "ICE_MACHINE_ACCT", "string", "batch default account"
+   "ICE_MACHINE_QUEUE", "string", "batch default queue"
+   "ICE_MACHINE_BLDTHRDS", "integer", "number of threads used during build"
+   "ICE_MACHINE_QSTAT", "string", "job status command (optional)"
+   "ICE_MACHINE_QUIETMODE", "true/false", "flag to reduce build output (optional)"
+
 .. _cross_compiling:
 
 Cross-compiling
@@ -370,3 +399,4 @@ should be rebuilt before being resubmitted.  It is always recommended that users
 modify the scripts and input settings in the case directory, NOT the run directory.
 In general, files in the run directory are overwritten by versions in the case
 directory when the model is built, submitted, and run.
+


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Add machine defined limits on maximum processors and batch wall clock time
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    #2253cca91c8bb7e at  https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks 
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

Two new optional machine env variables were added,

  ICE_MACHINE_MAXPES
  ICE_MACHINE_MAXRUNLENGTH

This is a relatively quick fix to allow test suites and cases to run on machines with limited processors or batch wall times.  These constraints will be imposed on the case as follows,
  - The batch wall time will be limited to the one specified in the env machine file but this will not be reflected directly in the cice.settings ICE_RUNLENGTH variable.  It will just be adjusted in the batch submission scripts.
  - The tasks and threads will be corrected such that the tasks*threads will not be greater than ICE_MACHINE_MAXPES.  If a user has also specified a particular decomposition with max blocks, then the max blocks will also automatically be increased if the tasks are decreased.  This will appear in the cice.settings file and it will also change the name of the test.  So a case name of conrad_intel_smoke_gx3_8x4x10x12x8.testid will be changed to 2x4x10x12x32 if the MAXPES variable is 8.  In this case, the testname will reflect the actual test being done which is important.

A full test suite was run on conrad with two compilers.  Manual testing was also done on conrad imposing limits on the pes and time limit to make sure the script was working as designed.

There are some other issues that could be tackled such as
 - adjusting both tasks and threads if the MAXPES is violated
 - adding other machine constraints such as a max threads per task or max threads per node
 - updating the RUNLENGTH logic in various ways to make it more flexible, but what I'm thinking would require a signficant refactor and an additional step between cice.setup and cice.build that would generate the resolved scripts.  In that case, a use could create a case, change some things in the cice.settings, then generate the scripts, build and run.  That extra step could also be useful for updating the case scripts after the case is created.  But I view that largely as "too much".  It's easy enough to generate a new case as needed at this point.