### PR TITLE
Add flexibility to cice.setup for test suites

### DIFF
--- a/cice.setup
+++ b/cice.setup
@@ -34,6 +34,7 @@ set stime = `date -u "+%H%M%S"`
 set docase = 0
 set dotest = 0
 set dosuite = 0
+set submit = 1
 
 if ($#argv < 1) then
   set helpheader = 1
@@ -104,6 +105,7 @@ DESCRIPTION
     --testid   : test ID, user-defined id for testing (REQUIRED with --test or --suite)
     --diff     : generate comparison against another case
     --report   : automatically post results when tests are complete
+    --no-submit: for test suites, create the tests and compile the executables but do not submit the jobs
 
 EXAMPLES
     cice.setup --version
@@ -213,6 +215,9 @@ while (1)
 # arguments without settings
   if ("$option" == "--report") then
     set report = 1
+    shift argv
+  else if ("$option" == "--no-submit") then
+    set submit = 0
     shift argv
 
 # arguments with settings
@@ -379,7 +384,7 @@ else
   cp -f ${ICE_SCRIPTS}/tests/report_results.csh ${tsdir}
   cp -f ${ICE_SCRIPTS}/tests/poll_queue.csh ${tsdir}
 
-  foreach file (${tsdir}/suite.run ${tsdir}/suite.submit)
+  foreach file (${tsdir}/suite.build ${tsdir}/suite.run ${tsdir}/suite.submit)
   cat >! $file << EOF0
 #!/bin/csh -f
 
@@ -406,6 +411,7 @@ echo "#vers = ${vers}" >> results.log
 echo "#------- " >> results.log
 EOF0
 
+  chmod +x ${tsdir}/suite.build
   chmod +x ${tsdir}/suite.run
   chmod +x ${tsdir}/suite.submit
   chmod +x ${tsdir}/results.csh
@@ -860,12 +866,13 @@ EOF2
 
     if ( ${dosuite} == 1 ) then
       cd ${ICE_SANDBOX}
-      # Write build and run commands to suite.run and suite.submit
+      # Write build commands to suite.build, suite.run, suite.submit
+      # and run commands to suite.run and suite.submit
 
 cat >> ${tsdir}/results.csh << EOF
 cat ${testname_base}/test_output >> results.log
 EOF
-  foreach file (${tsdir}/suite.run ${tsdir}/suite.submit)
+  foreach file (${tsdir}/suite.build ${tsdir}/suite.run ${tsdir}/suite.submit)
     cat >> $file  << EOF
 echo "-------test--------------"
 echo "${testname_base}"
@@ -882,7 +889,7 @@ EOF
   cat >> ${tsdir}/suite.run << EOF
 ./cice.test
 EOF
-  foreach file (${tsdir}/suite.run ${tsdir}/suite.submit)
+  foreach file (${tsdir}/suite.build ${tsdir}/suite.run ${tsdir}/suite.submit)
     cat >> $file << EOF
 cd ..
 
@@ -944,14 +951,19 @@ setenv ICE_MACHINE_QSTAT ${ICE_MACHINE_QSTAT}
 EOF0
   endif
 
-  # build and submit tests
   cd ${tsdir}
-  ./suite.submit | tee suite.log
-  if ($report == 1) then
-    echo "Reporting results"
-    ./poll_queue.csh
-    ./results.csh
-    ./report_results.csh
+  # build and submit tests
+  if ($submit == 1) then
+    ./suite.submit | tee suite.log
+    if ($report == 1) then
+      echo "Reporting results"
+      ./poll_queue.csh
+      ./results.csh
+      ./report_results.csh
+    endif
+    else
+    # only build tests
+    ./suite.build | tee suite.log
   endif
   cd ${ICE_SANDBOX}
 

--- a/cice.setup
+++ b/cice.setup
@@ -34,7 +34,8 @@ set stime = `date -u "+%H%M%S"`
 set docase = 0
 set dotest = 0
 set dosuite = 0
-set submit = 1
+set suitesubmit = 1
+set suitebuild  = 1
 
 if ($#argv < 1) then
   set helpheader = 1
@@ -106,6 +107,7 @@ DESCRIPTION
     --diff     : generate comparison against another case
     --report   : automatically post results when tests are complete
     --no-submit: for test suites, create the tests and compile the executables but do not submit the jobs
+    --no-build : for test suites, only create the test folders, do not compile the executables nor submit the jobs
 
 EXAMPLES
     cice.setup --version
@@ -217,7 +219,11 @@ while (1)
     set report = 1
     shift argv
   else if ("$option" == "--no-submit") then
-    set submit = 0
+    set suitesubmit = 0
+    shift argv
+  else if ("$option" == "--no-build") then
+    set suitesubmit = 0
+    set suitebuild = 0
     shift argv
 
 # arguments with settings
@@ -952,8 +958,8 @@ EOF0
   endif
 
   cd ${tsdir}
+  if ($suitesubmit == 1) then
   # build and submit tests
-  if ($submit == 1) then
     ./suite.submit | tee suite.log
     if ($report == 1) then
       echo "Reporting results"
@@ -961,9 +967,10 @@ EOF0
       ./results.csh
       ./report_results.csh
     endif
-    else
-    # only build tests
-    ./suite.build | tee suite.log
+  else if ($suitebuild == 1) then
+  # only build tests
+      ./suite.build | tee suite.log
+  else
   endif
   cd ${ICE_SANDBOX}
 

--- a/doc/source/developer_guide/dg_scripts.rst
+++ b/doc/source/developer_guide/dg_scripts.rst
@@ -11,7 +11,7 @@ cases, building, and running the cice stand-alone model.
 File List
 --------------
 
-The directory structure under configure/scripts is as follows.
+The directory structure under configuration/scripts is as follows.
 
 | **configuration/scripts/**
 |        **Makefile**              primary makefile

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -284,12 +284,12 @@ Test suites
 Test suites support running multiple tests specified via
 an input file.  When invoking the test suite option (``--suite``) with **cice.setup**,
 all tests will be created, built, and submitted automatically under
-a local directory called testsuite.[testid] as part of involing the suite.::
+a local directory called testsuite.[testid] ::
 
   ./cice.setup --suite base_suite --mach wolf --env gnu --testid myid
 
 Like an individual test, the ``--testid`` option must be specified and can be any 
-string.  Once the tests are complete, results can be checked by running the
+string (except strings involving the colon character ":" which creates cryptic Makefile errors).  Once the tests are complete, results can be checked by running the
 results.csh script in the [suite_name].[testid]::
 
   cd testsuite.[testid]
@@ -312,8 +312,27 @@ If a user adds ``--set`` to the suite, all tests in that suite will add that opt
 
   ./cice.setup --suite base_suite,decomp_suite --mach wolf --env gnu --testid myid -s debug
 
-The option settings defined in the suite have precendent over the command line
+The option settings defined in the suite have precedent over the command line
 values if there are conflicts.
+
+It is also possible to separately setup, build and submit the test cases. To setup and build the tests, use the ``--no-submit`` option with the ``buildincremental`` preset :
+::
+
+  ./cice.setup --suite base_suite --mach wolf --env gnu --testid myid --no-submit -s buildincremental
+  # wait for builds to complete
+  cd testsuite.[testid]
+  ./suite.submit  # submit the jobs
+
+To only setup the tests, use the ``--no-build`` option with the ``buildincremental`` preset :
+::
+
+  ./cice.setup --suite base_suite --mach wolf --env gnu --testid myid --no-build -s buildincremental
+  # wait for setup to complete
+  cd testsuite.[testid]
+  ./suite.submit  # build and submit
+  # or separately
+  ./suite.build
+  ./suite.submit
 
 The predefined test suites are defined under **configuration/scripts/tests** and 
 the files defining the suites
@@ -379,6 +398,12 @@ following options are valid for suites,
 
 ``--report``
   This is only used by ``--suite`` and when set, invokes a script that sends the test results to the results page when all tests are complete.  Please see :ref:`testreporting` for more information.
+
+  ``--no-submit``
+  Create the tests and compile the executables but do not submit the jobs
+
+``--no-build``
+  Only create the test folders, do not compile the executables nor submit the jobs
 
 Please see :ref:`case_options` and :ref:`indtests` for more details about how these options are used.
 


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Add --no-submit and --no-build options to cice.setup
- [x] Developer(s): 
    Philippe Blain
- [x] Suggest PR reviewers from list in the column to the right. @apcraig 
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    No changes to code, so I did not perform the full base_suite. I tested to check that the new options work as they should
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [x] Yes
https://external-builds.readthedocs.io/html/cice-consortium-cice/357/user_guide/ug_testing.html#test-suites

    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:

I added two options to cice.setup (for test suites) that I considered useful for my workflow.
1. --no-submit  : this creates the test case folders and compiles the executables but does not submit the jobs. This is useful when doing both a baseline + test (regression test) : I can use` ./cice.setup` to setup, build and submit the 'baseline' base_suite and then `./cice.setup --no-submit` to setup and build the 'test' base_suite (I don't want to submit it immediately since the 'baseline' base_suite might not be finished running, so some tests in the 'test' base_suite might run before the corresponding ones in the 'baseline' suite, which would make them fail). The 'test' suite can then be manually submitted with the existing suite.submit script.
2. --no-build : this only creates the test case folders. The tests can then be built with the new script `suite.build` and then submitted with `suite.submit`. 

Do you think that the options would be better named --build-only (instead of --no-submit) and --setup-only (instead of --no-build) ?