### PR TITLE
update gordon, conrad, onyx serial launch command

### DIFF
--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -71,27 +71,15 @@ endif
 
 #=======
 else if (${ICE_MACHINE} =~ onyx*) then
-if (${ICE_COMMDIR} =~ serial*) then
-cat >> ${jobfile} << EOFR
-./cice >&! \$ICE_RUNLOG_FILE
-EOFR
-else
 cat >> ${jobfile} << EOFR
 aprun -n ${ntasks} -N ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-endif
 
 #=======
 else if (${ICE_MACHINE} =~ gordon* || ${ICE_MACHINE} =~ conrad*) then
-if (${ICE_COMMDIR} =~ serial*) then
-cat >> ${jobfile} << EOFR
-./cice >&! \$ICE_RUNLOG_FILE
-EOFR
-else
 cat >> ${jobfile} << EOFR
 aprun -n ${ntasks} -N ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
-endif
 
 #=======
 else if (${ICE_MACHINE} =~ cori*) then


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update serial launch commands after PBS upgrade
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    full test suite passes on conrad, gordon, onyx 
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

We were launching the serial cases with ./cice.  As it turns out, this is not correct on Crays and uses shared resourced.  We need to use ccmrun or aprun to launch to use the batch resources.  Up to now, ./cice has been working.  With the recent PBS upgrade on conrad, gordon, and onyx, we started to run into memory issues and core dumps.  As a result, we have changed the launch to always use aprun, even for serial cases.
