### PR TITLE
Update zenodo json template and report_results script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ doc/build
 
 # Ignore testsuite file/directories
 testsuite*
+caselist*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ doc/build
 
 # Ignore macOS cache files
 .DS_Store
+
+# Ignore testsuite file/directories
+testsuite*

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -37,7 +37,7 @@
         }, 
         {
             "affiliation": "National Oceanographic and Atmospheric Administration (CTR)", 
-            "name": "Tony Craig"
+            "name": "Anthony Craig"
         }, 
         {
             "affiliation": "Environment and Climate Change Canada", 
@@ -80,7 +80,7 @@
             "name": "Andrew Roberts"
         }, 
         {
-            "affiliation": "Naval Research Laboratory Stennis Space Center (CTR)", 
+            "affiliation": "Los Alamos National Laboratory", 
             "name": "Matthew Turner"
         }, 
         {
@@ -91,12 +91,10 @@
     "access_right": "open", 
     "related_identifiers": [
         {
-            "scheme": "url", 
             "identifier": "https://github.com/CICE-Consortium/CICE/tree/CICE6.0.1", 
             "relation": "isSupplementTo"
         }, 
         {
-            "scheme": "doi", 
             "identifier": "10.5281/zenodo.1205674", 
             "relation": "isNewVersionOf"
         }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
     "license": "other-open", 
     "description": "No description provided", 
-    "language": "English", 
+    "language": "eng", 
     "title": "CICE-Consortium/CICE: CICE Version m.n.p", 
     "keywords": [
         "sea ice model, CICE, Icepack"
@@ -98,7 +98,7 @@
         {
             "scheme": "doi", 
             "identifier": "10.5281/zenodo.1205674", 
-            "relation": "isVersionOf"
+            "relation": "isNewVersionOf"
         }
     ]
 }

--- a/cice.setup
+++ b/cice.setup
@@ -953,6 +953,15 @@ end
 
 if ( ${dosuite} == 1 ) then
 
+  # Delete reused ciceexe files at the end to save space
+foreach file (${tsdir}/suite.run ${tsdir}/suite.submit)
+cat >> $file << EOF0
+
+set nonomatch && rm -f ciceexe.* && unset nonomatch
+
+EOF0
+end
+
   # Add code to results.csh to count the number of failures
 cat >> ${tsdir}/results.csh << EOF
 cat ./results.log

--- a/configuration/scripts/tests/report_results.csh
+++ b/configuration/scripts/tests/report_results.csh
@@ -52,21 +52,17 @@ set compilers = `grep -v "#" results.log | grep ${mach}_ | cut -d "_" -f 2 | sor
 #echo "debug ${fail}"
 #echo "debug ${cases}"
 
-set xcdat = `echo $cdat | sed 's|-||g' | cut -c 3-`
+set xcdat = `echo $cdat | cut -c 3-`
 set xctim = `echo $ctim | sed 's|:||g'`
 set shrepo = `echo $repo | tr '[A-Z]' '[a-z]'`
 
 set tsubdir = cice_master
 set hfile = "cice_by_hash"
 set mfile = "cice_by_mach"
-set vfile = "cice_by_vers"
-set bfile = "cice_by_bran"
 if ("${shrepo}" !~ "*cice-consortium*") then
   set tsubdir = cice_dev
   set hfile = {$hfile}_forks
   set mfile = {$mfile}_forks
-  set vfile = {$vfile}_forks
-  set bfile = {$bfile}_forks
 endif
 
 set noglob
@@ -287,10 +283,8 @@ EOF
 
 set hashfile = "${wikiname}/${tsubdir}/${hfile}.md"
 set machfile = "${wikiname}/${tsubdir}/${mfile}.md"
-set versfile = "${wikiname}/${tsubdir}/${vfile}.md"
-set branfile = "${wikiname}/${tsubdir}/${bfile}.md"
 
-foreach xfile ($hashfile $machfile $versfile $branfile)
+foreach xfile ($hashfile $machfile)
   if (-e ${xfile}) then
     cp -f ${xfile} ${xfile}.prev
   endif
@@ -320,29 +314,6 @@ else
 endif
 
 #=====================
-# update versfile
-#=====================
-
-set chk = 0
-if (-e ${versfile}) set chk = `grep "\*\*${vers}" ${versfile} | wc -l`
-if ($chk == 0) then
-cat >! ${versfile} << EOF
-**${vers}** :
-
-| machine | compiler | hash | date | test fail | comp fail | total |
-| ------ | ------ | ------ | ------  | ------ | ------ | ------ |
-| ${mach} | ${compiler} | ${shhash} | ${cdat} | ${tcolor} ${tfail}, ${tunkn} | ${rcolor} ${rfail}, ${rothr} | [${ttotl}](${ofile}) |
-
-EOF
-if (-e ${versfile}.prev) cat ${versfile}.prev >> ${versfile}
-
-else
-  set oline = `grep -n "\*\*${vers}" ${versfile} | head -1 | cut -d : -f 1`
-  @ nline = ${oline} + 3
-  sed -i "$nline a | ${mach} | ${compiler} | ${shhash} | ${cdat} | ${tcolor} ${tfail}, ${tunkn} | ${rcolor} ${rfail}, ${rothr} | [${ttotl}](${ofile}) | " ${versfile}
-endif
-
-#=====================
 # update machfile
 #=====================
 
@@ -365,29 +336,6 @@ else
   sed -i "$nline a | ${vers} | ${shhash} | ${compiler} | ${cdat} | ${tcolor} ${tfail}, ${tunkn} | ${rcolor} ${rfail}, ${rothr} | [${ttotl}](${ofile}) | " ${machfile}
 endif
 
-#=====================
-# update branfile
-#=====================
-
-set chk = 0
-if (-e ${branfile}) set chk = `grep "\*\*${bran}" ${branfile} | wc -l`
-if ($chk == 0) then
-cat >! ${branfile} << EOF
-**${bran}** **${repo}**:
-
-| machine | compiler | hash | date | test fail | comp fail | total |
-| ------ | ------ | ------ | ------  | ------ | ------ | ------ |
-| ${mach} | ${compiler} | ${shhash} | ${cdat} | ${tcolor} ${tfail}, ${tunkn} | ${rcolor} ${rfail}, ${rothr} | [${ttotl}](${ofile}) |
-
-EOF
-if (-e ${branfile}.prev) cat ${branfile}.prev >> ${branfile}
-
-else
-  set oline = `grep -n "\*\*${bran}" ${branfile} | head -1 | cut -d : -f 1`
-  @ nline = ${oline} + 3
-  sed -i "$nline a | ${mach} | ${compiler} | ${shhash} | ${cdat} | ${tcolor} ${tfail}, ${tunkn} | ${rcolor} ${rfail}, ${rothr} | [${ttotl}](${ofile}) | " ${branfile}
-endif
-
 #foreach compiler
 end
 
@@ -400,8 +348,6 @@ git add ${tsubdir}/${shhash}.${mach}*.md
 git add ${tsubdir}/${ofile}.md
 git add ${tsubdir}/${hfile}.md
 git add ${tsubdir}/${mfile}.md
-git add ${tsubdir}/${vfile}.md
-git add ${tsubdir}/${bfile}.md
 git commit -a -m "update $hash $mach"
 git push origin master
 cd ../


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update zenodo json template and report_results script
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Ran quick suite on gordon and report_results seems fine.  hash #333a5a28ccd0b at https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks on Oct 18.
    Zenodo changes will have to be tested in the future.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

Zenodo json update based on feedback from zenodo folks. will test on next release.
Updated report_results to remove some of the reports and sync the icepack and CICE report_results script again.
Also updated .gitignore to ignore testsuite directories.