### PR TITLE
report_results.csh: add html anchors to hashes and machines

### DIFF
--- a/configuration/scripts/tests/report_results.csh
+++ b/configuration/scripts/tests/report_results.csh
@@ -295,10 +295,11 @@ end
 #=====================
 
 set chk = 0
-if (-e ${hashfile}) set chk = `grep "\*\*${hash}" ${hashfile} | wc -l`
+if (-e ${hashfile}) set chk = `grep "#### ${hash}" ${hashfile} | wc -l`
 if ($chk == 0) then
+# Note: the line '#### ${hash}' is not a comment since it's in the here doc
 cat >! ${hashfile} << EOF
-**${hash}** :
+#### ${hash}
 
 | machine | compiler | version | date | test fail | comp fail | total |
 | ------ | ------ | ------ | ------  | ------ | ------ | ------ |
@@ -308,7 +309,7 @@ EOF
 if (-e ${hashfile}.prev) cat ${hashfile}.prev >> ${hashfile}
 
 else
-  set oline = `grep -n "\*\*${hash}" ${hashfile} | head -1 | cut -d : -f 1`
+  set oline = `grep -n "#### ${hash}" ${hashfile} | head -1 | cut -d : -f 1`
   @ nline = ${oline} + 3
   sed -i "$nline a | ${mach} | ${compiler} | ${vers} | ${cdat} | ${tcolor} ${tfail}, ${tunkn} | ${rcolor} ${rfail}, ${rothr} | [${ttotl}](${ofile}) | " ${hashfile}
 endif
@@ -318,10 +319,11 @@ endif
 #=====================
 
 set chk = 0
-if (-e ${machfile}) set chk = `grep "\*\*${mach}" ${machfile} | wc -l`
+if (-e ${machfile}) set chk = `grep "#### ${mach}" ${machfile} | wc -l`
 if ($chk == 0) then
+# Note: the line '#### ${mach}' is not a comment since it's in the here doc
 cat >! ${machfile} << EOF
-**${mach}** :
+#### ${mach}
 
 | version | hash | compiler | date | test fail | comp fail | total |
 | ------ | ------ | ------ | ------ | ------  | ------ | ------ |
@@ -331,7 +333,7 @@ EOF
 if (-e ${machfile}.prev) cat ${machfile}.prev >> ${machfile}
 
 else
-  set oline = `grep -n "\*\*${mach}" ${machfile} | head -1 | cut -d : -f 1`
+  set oline = `grep -n "#### ${mach}" ${machfile} | head -1 | cut -d : -f 1`
   @ nline = ${oline} + 3
   sed -i "$nline a | ${vers} | ${shhash} | ${compiler} | ${cdat} | ${tcolor} ${tfail}, ${tunkn} | ${rcolor} ${rfail}, ${rothr} | [${ttotl}](${ofile}) | " ${machfile}
 endif


### PR DESCRIPTION
# PR checklist
- [x] Short (1 sentence) summary of your PR  
 Add html anchors to hashes and machines in the Test-Results wiki
- [x] Developer(s :  
   Philippe Blain
- [x] Suggest PR reviewers from list in the column to the right @apcraig
- [x] Please copy the PR test results link or provide a summary of testing completed below.
 No tests ;)
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:

The hashes and machine names inserted by the script in the different pages
of the Test-Results wiki are formatted as bold (`** ${hash} **:`).

Change this to level 4 HTML titles (\<h4\>) so that an HTML anchor is
automatically created, which makes it easier to link directly to specific
hash from a pull request.
