### PR TITLE
machines: conda: fix linux env to be in line with the doc

### DIFF
--- a/configuration/scripts/machines/env.conda_linux
+++ b/configuration/scripts/machines/env.conda_linux
@@ -27,7 +27,7 @@ endif
 endif
 
 setenv ICE_MACHINE_ENVNAME conda
-setenv ICE_MACHINE_COMPILER conda
+setenv ICE_MACHINE_COMPILER linux
 setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR  $HOME/cice-dirs/runs
 setenv ICE_MACHINE_INPUTDATA $HOME/cice-dirs/input


### PR DESCRIPTION

## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Fix `ICE_MACHINE_COMPILER` in `env.conda_linux`
- [X] Developer(s): 
    P. Blain
- [x] Suggest PR reviewers from list in the column to the right.
@apcraig 
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    No tests.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

The `ICE_MACHINE_COMPILER` variable is incorrectly set to "conda"
instead of "linux" in `env.conda_linux`.

Fix that to reflect the documentation.
