### PR TITLE
doc: conda: add note about csh/tcsh

### DIFF
--- a/doc/source/user_guide/ug_running.rst
+++ b/doc/source/user_guide/ug_running.rst
@@ -503,6 +503,17 @@ On GNU/Linux:
   # Follow the prompts
   
   # Close and reopen your shell
+
+Note: on some Linux distributions (including Ubuntu and its derivatives), the csh shell that comes with the system is not compatible with conda.
+You will need to install the tcsh shell (which is backwards compatible with csh), and configure your system to use tcsh as csh:
+ 
+.. code-block:: bash
+ 
+  # Install tcsh
+  sudo apt-get install tcsh
+  # Configure your system to use tcsh as csh
+  sudo update-alternatives --set csh /bin/tcsh
+ 
   
 
 .. _init_shell:


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Update documentation for the conda configuration, mentioning that the csh shell on some Linux distros is not compatible with conda, and provide a workaround.
- [x] Developer(s): 
    P. Blain
- [x] Suggest PR reviewers from list in the column to the right.
@apcraig 
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    No tests.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:

On Ubuntu and its derivatives, the csh shell at /bin/csh, which is used in the shebangs of the CICE scripts, is not compatible with conda.

Mention that in the documentation and explain how to install tcsh as an alternative, and configure the system such that /bin/csh points to /bin/tcsh.

I had to do that on my local machine a while ago at work for our in-house package manager to work in the env file, so I did not realize that is was necessary for the conda configuration also. I just realized when testing the Icepack procedure in CICE-Consortium/Icepack#296 on my personal Linux system.
