### PR TITLE
Fix albedo initialization order of operations and update icepack

### DIFF
--- a/cicecore/shared/ice_init_column.F90
+++ b/cicecore/shared/ice_init_column.F90
@@ -254,8 +254,6 @@
 
       allocate(ztrcr_sw(nbtrcr_sw, ncat))
 
-      !!$OMP PARALLEL DO PRIVATE(iblk,i,j,n,ilo,ihi,jlo,jhi,this_block, &
-      !!$OMP                     l_print_point,debug,ipoint)
       do iblk=1,nblocks
 
          ! Initialize
@@ -387,12 +385,18 @@
               enddo
             endif
 
+         enddo ! i
+         enddo ! j
+
       !-----------------------------------------------------------------
       ! Aggregate albedos 
+      ! Match loop order in coupling_prep for same order of operations
       !-----------------------------------------------------------------
 
-            do n = 1, ncat
-               
+         do n = 1, ncat
+         do j = jlo, jhi
+         do i = ilo, ihi
+
                if (aicen(i,j,n,iblk) > puny) then
                   
                   alvdf(i,j,iblk) = alvdf(i,j,iblk) &
@@ -422,7 +426,12 @@
                
                endif ! aicen > puny
 
-            enddo  ! ncat
+         enddo ! i
+         enddo ! j
+         enddo ! ncat
+
+         do j = 1, ny_block
+         do i = 1, nx_block
 
       !----------------------------------------------------------------
       ! Store grid box mean albedos and fluxes before scaling by aice
@@ -432,14 +441,14 @@
             alidf_ai  (i,j,iblk) = alidf  (i,j,iblk)
             alvdr_ai  (i,j,iblk) = alvdr  (i,j,iblk)
             alidr_ai  (i,j,iblk) = alidr  (i,j,iblk)
-            
+
             ! for history averaging
 !echmod?            cszn = c0
 !echmod            if (coszen(i,j,iblk) > puny) cszn = c1
 !echmod            do n = 1, nstreams
 !echmod               albcnt(i,j,iblk,n) = albcnt(i,j,iblk,n) + cszn
 !echmod            enddo
-            
+
       !----------------------------------------------------------------
       ! Save net shortwave for scaling factor in scale_factor
       !----------------------------------------------------------------


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix albedo initialization order of operations and update icepack
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Ran full test suite on conrad, 4 compilers, all bit-for-bit, [results](https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#abc7b5a6153765617e6bd36c432aad4df68d8221)
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

This issue never results in a restart problem in CICE, but the same problem did in Icepack, so we're fixing it here as well.  This also includes the latest version of Icepack, which does not change the columnphysics but also includes this fix in the icepack driver.