### PR TITLE
conda: Macros: add '-L' argument to the linker command

### DIFF
--- a/configuration/scripts/machines/Macros.conda_linux
+++ b/configuration/scripts/machines/Macros.conda_linux
@@ -40,7 +40,7 @@ LD:= $(FC)
 MODDIR  += -I$(CONDA_PREFIX)/include
 
 # Libraries to be passed to the linker
-SLIBS   := -lnetcdf -lnetcdff
+SLIBS   := -L$(CONDA_PREFIX)/lib -lnetcdf -lnetcdff
 
 # Necessary flag to compile with OpenMP support
 ifeq ($(ICE_THREADED), true)

--- a/configuration/scripts/machines/Macros.conda_macos
+++ b/configuration/scripts/machines/Macros.conda_macos
@@ -43,7 +43,7 @@ MODDIR  += -I$(CONDA_PREFIX)/include
 CFLAGS_HOST = -isysroot$(shell xcrun --show-sdk-path)
 
 # Libraries to be passed to the linker
-SLIBS   := -lnetcdf -lnetcdff
+SLIBS   := -L$(CONDA_PREFIX)/lib -lnetcdf -lnetcdff
 
 # Necessary flag to compile with OpenMP support
 ifeq ($(ICE_THREADED), true)


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
  add '-L' argument to the linker command under conda
- [X] Developer(s): 
    P. Blain
- [x] Suggest PR reviewers from list in the column to the right. @apcraig 
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    No test suite run. Tested this on my Ubuntu 17.04 system.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

On Linux, compiling CICE in serial mode under the conda environment
currently fails as the linker does not find the NetCDF libraries.

Compiling in parallel mode does work as the MPI compilation wrappers
seem to pass the necessary flag to the linker under the hood.

Explicitely tell the linker the location of the libraries using the
`SLIBS` variable in the Macros file. To be on the safe side, also do it
on macOS.