### PR TITLE
Add Code Coverage Capability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ install:
 
 script:
   # verify cice.setup --case and cice.setup --test don't error then run test suite
-  - "./cice.setup --case trcase --mach travisCI --env gnu --pes 2x2 -s diag1"
+  - "./cice.setup --case trcase --mach travisCI --env gnu --pes 2x2 -s diag1 && sleep 4"
   - "./cice.setup --test smoke --testid trtest --mach travisCI --env gnu 
-    --pes 2x2 -s diag1"
+    --pes 2x2 -s diag1 && sleep 4"
   - "./cice.setup --suite travis_suite --testid travisCItest
     --mach travisCI --env gnu;
     cd testsuite.travisCItest &&

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/CICE-Consortium/CICE.svg?branch=master)](https://travis-ci.org/CICE-Consortium/CICE)
 [![Documentation Status](https://readthedocs.org/projects/cice-consortium-cice/badge/?version=master)](http://cice-consortium-cice.readthedocs.io/en/master/?badge=master)
-[![codecov](https://codecov.io/gh/CICE-Consortium/CICE/branch/master/graph/badge.svg)](https://codecov.io/gh/CICE-Consortium/CICE)
+[![codecov](https://codecov.io/gh/apcraig/Test_CICE_Icepack/branch/master/graph/badge.svg)](https://codecov.io/gh/apcraig/Test_CICE_Icepack)
 
 ## The CICE Consortium sea-ice model
 CICE is a computationally efficient model for simulating the growth, melting, and movement of polar sea ice. Designed as one component of coupled atmosphere-ocean-land-ice global climate models, today’s CICE model is the outcome of more than two decades of community collaboration in building a sea ice model suitable for multiple uses including process studies, operational forecasting, and climate simulation.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/CICE-Consortium/CICE.svg?branch=master)](https://travis-ci.org/CICE-Consortium/CICE)
 [![Documentation Status](https://readthedocs.org/projects/cice-consortium-cice/badge/?version=master)](http://cice-consortium-cice.readthedocs.io/en/master/?badge=master)
+[![codecov](https://codecov.io/gh/CICE-Consortium/CICE/branch/master/graph/badge.svg)](https://codecov.io/gh/CICE-Consortium/CICE)
 
 ## The CICE Consortium sea-ice model
 CICE is a computationally efficient model for simulating the growth, melting, and movement of polar sea ice. Designed as one component of coupled atmosphere-ocean-land-ice global climate models, today’s CICE model is the outcome of more than two decades of community collaboration in building a sea ice model suitable for multiple uses including process studies, operational forecasting, and climate simulation.

--- a/cice.setup
+++ b/cice.setup
@@ -34,6 +34,8 @@ set stime = `date -u "+%H%M%S"`
 set docase = 0
 set dotest = 0
 set dosuite = 0
+set codecov = 0       # code coverage measurement and reporting
+set codecovflag = false
 set suitebuild  = true
 set suiterun    = false
 set suitesubmit = true
@@ -81,7 +83,7 @@ SYNOPSIS
 
     --suite SUITE[,SUITE2] -m MACH --testid ID 
         [-e ENV1,ENV2][--acct ACCT][--bdir DIR][--bgen DIR]
-        [--bcmp DIR][--tdir PATH][--report]
+        [--bcmp DIR][--tdir PATH][--report || --codecov]
         [--setup-only || --setup-build || --setup-build-run || --setup-build-submit]
 
 DESCRIPTION
@@ -108,6 +110,8 @@ DESCRIPTION
     --testid   : test ID, user-defined id for testing (REQUIRED with --test or --suite)
     --diff     : generate comparison against another case
     --report   : automatically post results when tests are complete
+    --codecov  : generate and report test coverage metrics when tests are complete,
+                 requires GNU compiler (--env gnu)
     --setup-only         : for suite, setup testcases, no build, no submission
     --setup-build        : for suite, setup and build testcases, no submission
     --setup-build-run    : for suite, setup, build, and run interactively
@@ -224,6 +228,11 @@ while (1)
     set report = 1
     shift argv
 
+  else if ("$option" == "--codecov") then
+    set codecov = 1
+    set codecovflag = true
+    shift argv
+
   else if ("$option" == "--setup-only") then
     set suitebuild  = false
     set suiterun    = false
@@ -252,11 +261,11 @@ while (1)
   else
     shift argv
     if ( $#argv < 1 ) then
-      echo "${0}: ERROR1 in $option"
+      echo "${0}: ERROR in $option, unsupported or missing an argument"
       exit -1
     endif
-    if ($argv[1] =~ $dash* ) then
-      echo "${0}: ERROR2 in $option"
+    if ("$argv[1]" =~ "$dash*" ) then
+      echo "${0}: ERROR in $option, possibly missing an argument"
       exit -1
     endif
 
@@ -321,7 +330,30 @@ if (${dosum} > 1) then
   exit -1
 endif
 
+if ($codecov == 1 && $report == 1) then
+  echo "${0}: ERROR in arguments, not recommmended to set both --codecov and --report"
+  exit -1
+endif
+
+if ($codecov == 1 && "$compilers" != "gnu") then
+  echo "${0}: ERROR in arguments, must use --env gnu with --codecov"
+  exit -1
+endif
+
+if ($codecov == 1 && `where curl` == "" && `where wget` == "") then
+  echo "${0}: ERROR 'curl' or 'wget' is required for --codecov"
+  exit -1
+endif
+
 if (${dosuite} == 0) then
+  if ($report == 1) then
+    echo "${0}: ERROR in arguments, must use --suite with --report"
+    exit -1
+  endif
+  if ($codecov == 1) then
+    echo "${0}: ERROR in arguments, must use --suite with --codecov"
+    exit -1
+  endif
   if ("$compilers" =~ "*,*") then
     echo "${0}: ERROR in arguments, cannot set multiple compilers without --suite"
     exit -1
@@ -449,6 +481,7 @@ echo "#hash = ${hash}" >> results.log
 echo "#hshs = ${shhash}" >> results.log
 echo "#hshu = ${hashuser}" >> results.log
 echo "#hshd = ${hashdate}" >> results.log
+echo "#suit = ${testsuite}" >> results.log
 echo "#date = ${cdate}" >> results.log
 echo "#time = ${ctime}" >> results.log
 echo "#mach = ${machine}" >> results.log
@@ -457,8 +490,19 @@ echo "#vers = ${vers}" >> results.log
 echo "#------- " >> results.log
 EOF0
 
+cat >! ${tsdir}/report_codecov.csh << EOF0
+#!/bin/csh -f
+
+setenv CODECOV_TOKEN "f3236008-0b92-4707-9ad5-ad906f5d2ba7"   # apcraig cice
+set report_name = "${shhash}:${branch}:${machine} ${testsuite}"
+
+set use_curl = 1
+
+EOF0
+
   chmod +x ${tsdir}/suite.submit
   chmod +x ${tsdir}/results.csh
+  chmod +x ${tsdir}/report_codecov.csh
 
 endif
 
@@ -734,6 +778,8 @@ EOF
       endif
     endif
 
+    set rundir = ${ICE_MACHINE_WKDIR}/${casename}
+
     #------------------------------------------------------------
     # Compute a default blocksize
 
@@ -755,6 +801,7 @@ EOF
     echo "ICE_CASEDIR  = ${casedir}"
     echo "ICE_MACHINE  = ${machine}"
     echo "ICE_COMPILER = ${compiler}"
+    echo "ICE_RUNDIR   = ${rundir}"
     echo "ICE_PES      = ${task}x${thrd}"
     echo "ICE_GRID     = ${grid} (${ICE_DECOMP_NXGLOB}x${ICE_DECOMP_NYGLOB}) blocksize=${ICE_DECOMP_BLCKX}x${ICE_DECOMP_BLCKY}x${ICE_DECOMP_MXBLCKS}"
     echo "ICE_DECOMP   = ${ICE_DECOMP_DECOMP} ${ICE_DECOMP_DSHAPE}"
@@ -809,7 +856,7 @@ setenv ICE_CASEDIR  ${casedir}
 setenv ICE_MACHINE  ${machine}
 setenv ICE_COMPILER ${compiler}
 setenv ICE_MACHCOMP ${machcomp}
-setenv ICE_RUNDIR   ${ICE_MACHINE_WKDIR}/${casename}
+setenv ICE_RUNDIR   ${rundir}
 setenv ICE_GRID     ${grid}
 #setenv ICE_NXGLOB   ${ICE_DECOMP_NXGLOB}  # moved to namelist
 #setenv ICE_NYGLOB   ${ICE_DECOMP_NYGLOB}  # moved to namelist
@@ -829,6 +876,7 @@ setenv ICE_TESTID   ${testid}
 setenv ICE_BFBCOMP  ${fbfbcomp}
 setenv ICE_ACCOUNT  ${acct}
 setenv ICE_QUEUE    ${queue}
+setenv ICE_CODECOV  ${codecovflag}
 EOF1
 
     if (${sets} != "") then
@@ -954,6 +1002,12 @@ EOF2
 cat ${testname_base}/test_output >> results.log
 EOF
 
+      cat >> ${tsdir}/report_codecov.csh << EOF
+mkdir ${testname_base}/codecov_output
+cp ${rundir}/compile/*.{gcno,gcda} ${testname_base}/codecov_output/
+
+EOF
+
       cat >> ${tsdir}/suite.submit << EOF
 
 echo "-------test--------------"
@@ -1059,6 +1113,18 @@ setenv ICE_MACHINE_QSTAT ${ICE_MACHINE_QSTAT}
 EOF0
   endif
 
+cat >> ${tsdir}/report_codecov.csh << EOF
+if ( \${use_curl} == 1 ) then
+  bash -c "bash <(curl -s https://codecov.io/bash) -n '\${report_name}' -y ./codecov.yml "
+else
+  bash -c "bash <(wget -O - https://codecov.io/bash) -n '\${report_name}' -y ./codecov.yml "
+endif
+
+sleep 10
+rm -r -f ./*/codecov_output
+
+EOF
+
   # build and submit tests
   cd ${tsdir}
   setenv SUITE_BUILD ${suitebuild}
@@ -1070,6 +1136,11 @@ EOF0
     ./poll_queue.csh
     ./results.csh
     ./report_results.csh
+  endif
+  if ($codecov == 1) then
+    echo "Generating codecov reports"
+    ./poll_queue.csh
+    ./report_codecov.csh
   endif
   cd ${ICE_SANDBOX}
 

--- a/cice.setup
+++ b/cice.setup
@@ -393,7 +393,9 @@ endif
 if ( ${tdir} != ${spval} ) then
   set tsdir = ${tdir}
 endif
-if (-e $tsfile) then
+if (-e ${tsfile}) then
+  ls -al ${tsfile}
+  echo "${0}: ERROR in tsfile, ${tsfile}"
   echo "${0}: ERROR in tsfile, this should never happen"
   exit -1
 endif

--- a/cice.setup
+++ b/cice.setup
@@ -37,6 +37,7 @@ set dosuite = 0
 set codecov = 0       # code coverage measurement and reporting
 set codecovflag = false
 set suitebuild  = true
+set suitereuse  = true
 set suiterun    = false
 set suitesubmit = true
 
@@ -231,28 +232,33 @@ while (1)
   else if ("$option" == "--codecov") then
     set codecov = 1
     set codecovflag = true
+    set suitereuse  = false
     shift argv
 
   else if ("$option" == "--setup-only") then
     set suitebuild  = false
+    set suitereuse  = true
     set suiterun    = false
     set suitesubmit = false
     shift argv
 
   else if ("$option" == "--setup-build") then
     set suitebuild  = true
+    set suitereuse  = true
     set suiterun    = false
     set suitesubmit = false
     shift argv
 
   else if ("$option" == "--setup-build-run") then
     set suitebuild  = true
+    set suitereuse  = true
     set suiterun    = true
     set suitesubmit = false
     shift argv
 
   else if ("$option" == "--setup-build-submit") then
     set suitebuild  = true
+    set suitereuse  = true
     set suiterun    = false
     set suitesubmit = true
     shift argv
@@ -448,10 +454,14 @@ else
 set nonomatch && rm -f ciceexe.* && unset nonomatch
 
 set dobuild  = true
+set doreuse  = true
 set dorun    = false
 set dosubmit = true
 if (\$?SUITE_BUILD) then
   set dobuild  = "\${SUITE_BUILD}"
+endif
+if (\$?SUITE_REUSEBUILD) then
+  set doreuse = "\${SUITE_REUSEBUILD}"
 endif
 if (\$?SUITE_RUN) then
   set dorun    = "\${SUITE_RUN}"
@@ -461,6 +471,7 @@ if (\$?SUITE_SUBMIT) then
 endif
 
 echo \${0}: dobuild  = \${dobuild}
+echo \${0}: doreuse  = \${doreuse}
 echo \${0}: dorun    = \${dorun}
 echo \${0}: dosubmit = \${dosubmit}
 
@@ -493,7 +504,9 @@ EOF0
 cat >! ${tsdir}/report_codecov.csh << EOF0
 #!/bin/csh -f
 
-setenv CODECOV_TOKEN "f3236008-0b92-4707-9ad5-ad906f5d2ba7"   # apcraig cice
+#setenv CODECOV_TOKEN "1d09241f-ed9e-47d8-847c-038bab024b53"   # consortium cice
+#setenv CODECOV_TOKEN "f3236008-0b92-4707-9ad5-ad906f5d2ba7"   # apcraig cice
+setenv CODECOV_TOKEN "0dcc6066-fdce-47b6-b84a-c55e2a0af4c0"   # apcraig test_cice_icepack
 set report_name = "${shhash}:${branch}:${machine} ${testsuite}"
 
 set use_curl = 1
@@ -1015,9 +1028,13 @@ echo "${testname_base}"
 cd ${testname_base}
 source ./cice.settings
 if (\${dobuild} == true) then
-   set ciceexe = "../ciceexe.\${ICE_COMPILER}.\${ICE_COMMDIR}.\${ICE_BLDDEBUG}.\${ICE_THREADED}.\${ICE_IOTYPE}"
-  ./cice.build --exe \${ciceexe}
-  if !(-e \${ciceexe}) cp -p \${ICE_RUNDIR}/cice \${ciceexe}
+   if (\${doreuse} == true) then
+     set ciceexe = "../ciceexe.\${ICE_COMPILER}.\${ICE_COMMDIR}.\${ICE_BLDDEBUG}.\${ICE_THREADED}.\${ICE_IOTYPE}"
+     ./cice.build --exe \${ciceexe}
+     if !(-e \${ciceexe}) cp -p \${ICE_RUNDIR}/cice \${ciceexe}
+   else
+     ./cice.build
+   endif
 endif
 if (\${dosubmit} == true) then
   ./cice.submit | tee -a ../suite.jobs
@@ -1114,6 +1131,8 @@ EOF0
   endif
 
 cat >> ${tsdir}/report_codecov.csh << EOF
+source ${ICE_SCRIPTS}/machines/env.${machcomp} 
+
 if ( \${use_curl} == 1 ) then
   bash -c "bash <(curl -s https://codecov.io/bash) -n '\${report_name}' -y ./codecov.yml "
 else
@@ -1128,6 +1147,7 @@ EOF
   # build and submit tests
   cd ${tsdir}
   setenv SUITE_BUILD ${suitebuild}
+  setenv SUITE_REUSEBUILD ${suitereuse}
   setenv SUITE_RUN ${suiterun}
   setenv SUITE_SUBMIT ${suitesubmit}
   ./suite.submit | tee suite.log

--- a/cice.setup
+++ b/cice.setup
@@ -394,8 +394,6 @@ if ( ${tdir} != ${spval} ) then
   set tsdir = ${tdir}
 endif
 if (-e ${tsfile}) then
-  ls -al ${tsfile}
-  echo "${0}: ERROR in tsfile, ${tsfile}"
   echo "${0}: ERROR in tsfile, this should never happen"
   exit -1
 endif

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  range: "20...100"
+  round: down
+  precision: 2
+
+comment: false

--- a/configuration/scripts/cice.build
+++ b/configuration/scripts/cice.build
@@ -1,7 +1,7 @@
 #! /bin/csh -f
 
 #====================================
-# If the cice binary is passed as an argument and the file exists,
+# If the cice binary is passed via the --exe argument and the file exists,
 # copy it into the run directory and don't build the model.
 
 set dohelp = 0

--- a/configuration/scripts/cice.settings
+++ b/configuration/scripts/cice.settings
@@ -40,4 +40,5 @@ if (${ICE_NTASKS} == 1) setenv ICE_COMMDIR serial
 
 ### Specialty code
 setenv ICE_BLDDEBUG  false  # build debug flags
+setenv ICE_CODECOV   false  # build debug flags
 

--- a/configuration/scripts/machines/Macros.gaffney_gnu
+++ b/configuration/scripts/machines/Macros.gaffney_gnu
@@ -4,7 +4,7 @@
 
 CPP        := ftn -E
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2
+CFLAGS     := -c
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-else
-  FFLAGS     += -O2
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+  CFLAGS   += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true)
+  FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
+  CFLAGS   += -O0 -g -coverage
+  LDFLAGS  += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true)
+ifneq ($(ICE_CODECOV), true)
+  FFLAGS   += -O2
+  CFLAGS   += -O2
+endif
 endif
 
 SCC   := gcc

--- a/configuration/scripts/machines/Macros.gordon_gnu
+++ b/configuration/scripts/machines/Macros.gordon_gnu
@@ -4,7 +4,7 @@
 
 CPP        := ftn -E
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2
+CFLAGS     := -c
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-else
-  FFLAGS     += -O2
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+  CFLAGS   += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true)
+  FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
+  CFLAGS   += -O0 -g -coverage
+  LDFLAGS  += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true)
+ifneq ($(ICE_CODECOV), true)
+  FFLAGS   += -O2
+  CFLAGS   += -O2
+endif
 endif
 
 SCC   := cc 

--- a/configuration/scripts/machines/Macros.izumi_gnu
+++ b/configuration/scripts/machines/Macros.izumi_gnu
@@ -17,9 +17,9 @@ ifeq ($(ICE_BLDDEBUG), true)
 endif
 
 ifeq ($(ICE_CODECOV), true)
-  FFLAGS  += -O0 -g -fprofile-arcs -ftest-coverage
-  CFLAGS  += -O0 -g -coverage
-  LDFLAGS += -g -ftest-coverage -fprofile-arcs
+  FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
+  CFLAGS   += -O0 -g -coverage
+  LDFLAGS  += -g -ftest-coverage -fprofile-arcs
 endif
 
 ifneq ($(ICE_BLDDEBUG), true) 

--- a/configuration/scripts/machines/Macros.izumi_gnu
+++ b/configuration/scripts/machines/Macros.izumi_gnu
@@ -4,7 +4,7 @@
 
 CPP        := /usr/bin/cpp
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2
+CFLAGS     := -c
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -13,8 +13,20 @@ FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
   FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-else
+  CFLAGS   += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true)
+  FFLAGS  += -O0 -g -fprofile-arcs -ftest-coverage
+  CFLAGS  += -O0 -g -coverage
+  LDFLAGS += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
   FFLAGS   += -O2
+  CFLAGS   += -O2
+endif
 endif
 
 SCC   := gcc 

--- a/configuration/scripts/machines/Macros.onyx_gnu
+++ b/configuration/scripts/machines/Macros.onyx_gnu
@@ -4,7 +4,7 @@
 
 CPP        := ftn -E
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2
+CFLAGS     := -c
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-else
-  FFLAGS     += -O2
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+  CFLAGS   += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true)
+  FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
+  CFLAGS   += -O0 -g -coverage
+  LDFLAGS  += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
+  FFLAGS   += -O2
+  CFLAGS   += -O2
+endif
 endif
 
 SCC   := cc 

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -4,7 +4,7 @@
 
 CPP        := cpp
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2
+CFLAGS     := -c
 
 FIXEDFLAGS := -ffixed-line-length-132
 FREEFLAGS  := -ffree-form
@@ -12,9 +12,21 @@ FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-else
-  FFLAGS     += -O2
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+  CFLAGS   += -O0
+endif
+
+ifeq ($(ICE_CODECOV), true)
+  FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
+  CFLAGS   += -O0 -g -coverage
+  LDFLAGS  += -g -ftest-coverage -fprofile-arcs
+endif
+
+ifneq ($(ICE_BLDDEBUG), true) 
+ifneq ($(ICE_CODECOV), true) 
+  FFLAGS   += -O2
+  CFLAGS   += -O2
+endif
 endif
 
 SCC   := gcc

--- a/configuration/scripts/tests/nothread_suite.ts
+++ b/configuration/scripts/tests/nothread_suite.ts
@@ -26,6 +26,12 @@ restart        gx3     20x1       alt02,debug,short
 restart        gx3     24x1       alt03,debug,short
 smoke          gx3     24x1       alt04,debug,short
 smoke          gx3     32x1       alt05,debug,short
+restart        gx3     16x1       isotope
+smoke          gx3     6x1        isotope,debug
+smoke          gx3     8x1        fsd1,diag24,run5day,debug
+smoke          gx3     16x1       fsd12,diag24,run5day,short
+restart        gx3     12x1       fsd12,debug,short
+smoke          gx3     20x1       fsd12ww3,diag24,run1day,medium
 
 restart        gbox128 8x1        short
 restart        gbox128 16x1       boxdyn,short
@@ -36,6 +42,12 @@ restart        gbox128 32x1       boxrestore,short
 smoke          gbox128 24x1       boxrestore,short,debug
 restart        gbox80  1x1        box2001
 smoke          gbox80  1x1        boxslotcyl
+
+smoke          gx3     16x1        jra55_gx3_2008,medium,run90day
+restart        gx3     12x1        jra55_gx3,short
+#tcraig, hangs nodes intermittently on izumi
+#smoke          gx1     24x1       jra55_gx1_2008,medium,run90day
+#restart        gx1     24x1       jra55_gx1,short
 
 smoke          gx3     16x1       bgcz
 smoke          gx3     16x1       bgcz,debug

--- a/configuration/scripts/tests/report_results.csh
+++ b/configuration/scripts/tests/report_results.csh
@@ -39,6 +39,7 @@ set hash = `grep "#hash = " results.log | cut -c 9-`
 set shhash   = `grep "#hshs = " results.log | cut -c 9-`
 set hashuser = `grep "#hshu = " results.log | cut -c 9-`
 set hashdate = `grep "#hshd = " results.log | cut -c 9-`
+set testsuites = `grep "#suit = " results.log | cut -c 9-`
 set cdat = `grep "#date = " results.log | cut -c 9-`
 set ctim = `grep "#time = " results.log | cut -c 9-`
 set user = `grep "#user = " results.log | cut -c 9-`
@@ -56,6 +57,7 @@ set compilers = `grep -v "#" results.log | grep ${mach}_ | cut -d "_" -f 2 | sor
 #echo "debug ${shhash}"
 #echo "debug ${hashuser}"
 #echo "debug ${hashdate}"
+#echo "debug ${testsuites}"
 #echo "debug ${cdat}"
 #echo "debug ${ctim}"
 #echo "debug ${user}"

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -689,15 +689,26 @@ be run on that repository.  A sample script to do that would be::
 
   ./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite -m gordon -e gnu --codecov --testid cc01
 
-To use, submit a full test suite using the latest Test_CICE_Icepack version
-and the gnu compiler with the ``--codecov`` argument to **cice.setup**.
+To use, submit a full test suite using an updated Test_CICE_Icepack version
+and the gnu compiler with the ``--codecov`` argument.
 The test suite will run and then a report will be generated and uploaded to 
 the `codecov.io site <https://codecov.io/gh/apcraig/Test_CICE_Icepack>`_ by the 
 **report_codecov.csh** script.  
 
 This is a special diagnostic test and does not constitute proper model testing.
 General use is not recommended, this is mainly used as a diagnostic to periodically 
-assess test coverage.  In addition, the interaction with codecov.io is not always robust.
+assess test coverage.  The interaction with codecov.io is not always robust and
+can be tricky to manage.  Some constraints are that the output generated at runtime
+is copied into the directory where compilation took place.  That means each
+test should be compiled separately.  Tests that invoke multiple runs
+(such as exact restart and the decomp test) will only save coverage information
+for the last run, so some coverage information may be lost.  The gcov tool can
+be a little slow to run on large test suites, and the codecov.io bash uploader
+(that runs gcov and uploads the data to codecov.io) is constantly evolving.
+Finally, gcov requires that the diagnostic output be copied into the git sandbox for
+analysis.  These constraints are handled by the current scripts, but may change
+in the future.
+
 
 .. _compliance:
 

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -380,6 +380,9 @@ following options are valid for suites,
 ``--report``
   This is only used by ``--suite`` and when set, invokes a script that sends the test results to the results page when all tests are complete.  Please see :ref:`testreporting` for more information.
 
+``--codecov``
+  When invoked, code coverage diagnostics are generated.  This will modify the build and reduce optimization.  The results will be uploaded to the **codecov.io** website via the **report_codecov.csh** script.  General use is not recommended, this is mainly used as a diagnostic to periodically assess test coverage.  Please see :ref:`codecoverage` for more information.
+
 ``--setup-only``
   This is only used by ``--suite`` and when set, just creates the suite testcases.  It does not build or submit them to run.  By default, the suites do ``--setup-build-submit``.
 
@@ -657,6 +660,44 @@ The reporting can also be automated in a test suite by adding ``--report`` to ``
 With ``--report``, the suite will create all the tests, build and submit them,
 wait for all runs to be complete, and run the results and report_results scripts.
 
+.. _codecoverage:
+
+Code Coverage Testing
+------------------------------
+
+The ``--codecov`` feature in **cice.setup** provides a method to diagnose code coverage.
+This argument turns on special compiler flags including reduced optimization and then
+invokes the gcov tool.
+This option is currently only available with the gnu compiler and on a few systems.
+
+Because codecov.io does not support git submodule analysis right now, a customized
+repository has to be created to test CICE with Icepack integrated directly.  The repository 
+https://github.com/apcraig/Test_CICE_Icepack serves as the current default test repository.
+In general, to setup the code coverage test in CICE, the current CICE master has
+to be copied into the Test_CICE_Icepack repository, then the code coverage tool can
+be run on that repository.  A sample script to do that would be::
+
+  git clone https://github.com/cice-consortium/cice cice.master --recursive
+
+  git clone https://github.com/apcraig/test_cice_icepack
+  cd test_cice_icepack
+  git rm -r *
+  cp -p -r ../cice.master/* .
+  git add .
+  git commit -m "update to current cice master"
+  git push origin master
+
+  ./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite -m gordon -e gnu --codecov --testid cc01
+
+To use, submit a full test suite using the latest Test_CICE_Icepack version
+and the gnu compiler with the ``--codecov`` argument to **cice.setup**.
+The test suite will run and then a report will be generated and uploaded to 
+the `codecov.io site <https://codecov.io/gh/apcraig/Test_CICE_Icepack>`_ by the 
+**report_codecov.csh** script.  
+
+This is a special diagnostic test and does not constitute proper model testing.
+General use is not recommended, this is mainly used as a diagnostic to periodically 
+assess test coverage.  In addition, the interaction with codecov.io is not always robust.
 
 .. _compliance:
 


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    add code coverage capability
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Full test suite on gordon passes
    https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#725a2c54dfe4a571c6aac47084e80da3e78e5ac9
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

For sample output, see https://codecov.io/gh/apcraig/Test_CICE_Icepack

Will need to verify process works once merged to master.

- Add codecov.yml (required filename) to set some codecov.io settings
- Update Macros files for gnu compiler on most machines to support --codecov option
- Add --codecov flag to icepack.setup.  Needed to create a flag in cice.setup that would turn off cice exe reuse.  For this to work, each run needs to be built separately.
- Update documentation
- Add badge to README.md (needs to be verified once merged)
- Add test suite output list to results.log (unrelated to codecov)
