### PR TITLE
Use JRA55 for tx1 grid

### DIFF
--- a/cicecore/cicedynB/general/ice_forcing.F90
+++ b/cicecore/cicedynB/general/ice_forcing.F90
@@ -116,7 +116,7 @@
          ocn_data_format, & ! 'bin'=binary or 'nc'=netcdf
          atm_data_type, & ! 'default', 'monthly', 'ncar', 
                           ! 'LYq' or 'hadgem' or 'oned' or
-                          ! 'JRA55_gx1' or 'JRA55_gx3'
+                          ! 'JRA55_gx1' or 'JRA55_gx3' or 'JRA55_tx1'
          bgc_data_type, & ! 'default', 'clim'
          ocn_data_type, & ! 'default', 'clim', 'ncar', 'oned',
                           ! 'hadgem_sst' or 'hadgem_sst_uvocn'
@@ -241,6 +241,7 @@
 
       if (use_leap_years .and. (trim(atm_data_type) /= 'JRA55_gx1' .and. &
                                 trim(atm_data_type) /= 'JRA55_gx3' .and. &
+                                trim(atm_data_type) /= 'JRA55_tx1' .and. &
                                 trim(atm_data_type) /= 'hycom' .and. &
                                 trim(atm_data_type) /= 'box2001')) then
          write(nu_diag,*) 'use_leap_years option is currently only supported for'
@@ -261,6 +262,8 @@
          call JRA55_gx1_files(fyear)
       elseif (trim(atm_data_type) == 'JRA55_gx3') then
          call JRA55_gx3_files(fyear)
+      elseif (trim(atm_data_type) == 'JRA55_tx1') then
+         call JRA55_tx1_files(fyear)
       elseif (trim(atm_data_type) == 'hadgem') then
          call hadgem_files(fyear)
       elseif (trim(atm_data_type) == 'monthly') then
@@ -559,6 +562,8 @@
       elseif (trim(atm_data_type) == 'JRA55_gx1') then
          call JRA55_data(fyear)
       elseif (trim(atm_data_type) == 'JRA55_gx3') then
+         call JRA55_data(fyear)
+      elseif (trim(atm_data_type) == 'JRA55_tx1') then
          call JRA55_data(fyear)
       elseif (trim(atm_data_type) == 'hadgem') then
          call hadgem_data
@@ -1405,6 +1410,10 @@
          i = index(data_file,'.nc') - 5
          tmpname = data_file
          write(data_file,'(a,i4.4,a)') tmpname(1:i), yr, '.nc'
+      elseif (trim(atm_data_type) == 'JRA55_tx1') then ! netcdf
+         i = index(data_file,'.nc') - 5
+         tmpname = data_file
+         write(data_file,'(a,i4.4,a)') tmpname(1:i), yr, '.nc'
       else                                     ! LANL/NCAR naming convention
          i = index(data_file,'.dat') - 5
          tmpname = data_file
@@ -2047,6 +2056,22 @@
          write (nu_diag,*) trim(uwind_file)
     endif
       end subroutine JRA55_gx1_files
+      subroutine JRA55_tx1_files(yr)
+!
+      integer (kind=int_kind), intent(in) :: &
+           yr                   ! current forcing year
+
+      character(len=*), parameter :: subname = '(JRA55_tx1_files)'
+
+      uwind_file = &
+           trim(atm_data_dir)//'/8XDAILY/JRA55_03hr_forcing_tx1_2005.nc'
+      call file_year(uwind_file,yr)
+  if (my_task == master_task) then
+         write (nu_diag,*) ' '
+         write (nu_diag,*) 'Atmospheric data files:'
+         write (nu_diag,*) trim(uwind_file)
+    endif
+      end subroutine JRA55_tx1_files
       subroutine JRA55_gx3_files(yr)
 !
       integer (kind=int_kind), intent(in) :: &

--- a/configuration/scripts/options/set_nml.tx1
+++ b/configuration/scripts/options/set_nml.tx1
@@ -5,8 +5,8 @@ grid_format = 'bin'
 grid_type   = 'tripole'
 grid_file   = 'ICE_MACHINE_INPUTDATA/CICE_data/grid/tx1/grid_tx1.bin'
 kmt_file    = 'ICE_MACHINE_INPUTDATA/CICE_data/grid/tx1/kmt_tx1.bin'
-fyear_init      = 1997
-atm_data_format = 'bin'
-atm_data_type   = 'clim'
-atm_data_dir    = 'none'
-
+atm_data_dir    = 'ICE_MACHINE_INPUTDATA/CICE_data/forcing/tx1/JRA55'
+atm_data_format = 'nc'
+atm_data_type   = 'JRA55_tx1'
+year_init      = 2005
+fyear_init      = 2005

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -356,6 +356,7 @@ Table of namelist options
    "","", "``LYq``", "COREII Large-Yeager (AOMIP) forcing data", ":cite:`Large09`"
    "","", "``JRA55_gx1``", "JRA55 forcing data for gx1 grid :cite:`Tsujino18`", ""
    "","", "``JRA55_gx3``", "JRA55 forcing data for gx3 grid :cite:`Tsujino18`", ""
+   "","", "``JRA55_tx1``", "JRA55 forcing data for tx1 grid :cite:`Tsujino18`", ""
    "","", "``monthly``", "monthly forcing data", ""
    "","", "``ncar``", "NCAR bulk forcing data", ""
    "","", "``box2001``", "forcing data for :cite:`Hunke01` box problem", ""


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Change the default forcing for the tx1 grid to JRA55. This should finally address issue #186 
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
I have run a one-year simulation using this forcing on izumi. Needs to be run on other machines.
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial 
This will change answers for the tx1 tests.
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:
You will need to set up the tx1 JRA55 forcing manually for testing. Once it is fine, then we can put it in Zenodo. The path and files are as follows:

ICE_MACHINE_INPUTDATA/CICE_data/forcing/tx1/JRA55/8XDAILY/
JRA55_03hr_forcing_tx1_2005.nc
JRA55_03hr_forcing_tx1_2006.nc
JRA55_03hr_forcing_tx1_2007.nc
JRA55_03hr_forcing_tx1_2008.nc
JRA55_03hr_forcing_tx1_2009.nc

This is triggered now by -s tx1.
