### PR TITLE
Add lcov code coverage tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.org/CICE-Consortium/CICE.svg?branch=master)](https://travis-ci.org/CICE-Consortium/CICE)
 [![Documentation Status](https://readthedocs.org/projects/cice-consortium-cice/badge/?version=master)](http://cice-consortium-cice.readthedocs.io/en/master/?badge=master)
-[![codecov](https://codecov.io/gh/apcraig/Test_CICE_Icepack/branch/master/graph/badge.svg)](https://codecov.io/gh/apcraig/Test_CICE_Icepack)
+..[![codecov](https://codecov.io/gh/apcraig/Test_CICE_Icepack/branch/master/graph/badge.svg)](https://codecov.io/gh/apcraig/Test_CICE_Icepack)
+[![lcov](https://img.shields.io/endpoint?url=https://apcraig.github.io/coverage.json)]
 
 ## The CICE Consortium sea-ice model
 CICE is a computationally efficient model for simulating the growth, melting, and movement of polar sea ice. Designed as one component of coupled atmosphere-ocean-land-ice global climate models, today’s CICE model is the outcome of more than two decades of community collaboration in building a sea ice model suitable for multiple uses including process studies, operational forecasting, and climate simulation.

--- a/cice.setup
+++ b/cice.setup
@@ -518,7 +518,7 @@ cat >! ${tsdir}/report_codecov.csh << EOF0
 
 source ${ICE_SCRIPTS}/machines/env.${machcomp}
 
-set rn0 = "${shhash}:${sdate}-${stime}:${testsuitecnt}:${testsuite}"
+set rn0 = "${sdate}-${stime}:${shhash}:${testsuitecnt}:${testsuite}"
 set rn1 = \`echo \${rn0} | sed -e 's/ //g'\`
 set report_name = \`echo \${rn1} | sed -e 's/_suite//g'\`
 

--- a/cice.setup
+++ b/cice.setup
@@ -112,7 +112,7 @@ DESCRIPTION
     --diff     : generate comparison against another case
     --report   : automatically post results when tests are complete
     --coverage : generate and report test coverage metrics when tests are complete,
-                 requires GNU compiler (--env gnu*)
+                 requires GNU env (--env gnu*)
     --setup-only         : for suite, setup testcases, no build, no submission
     --setup-build        : for suite, setup and build testcases, no submission
     --setup-build-run    : for suite, setup, build, and run interactively
@@ -369,22 +369,15 @@ if (${dosuite} == 0) then
   endif
 else
   if ($coverage == 1) then
-    if ("$compilers" =~ "*,*") then
-      echo "${0}: ERROR in arguments, cannot set multiple compilers with --coverage"
+    if ("$envnames" =~ "*,*") then
+      echo "${0}: ERROR in arguments, cannot set multiple envnamess with --coverage"
       exit -1
     else
-      set compiler = ${compilers}
-      set machcomp = ${machine}_${compiler}
+      set envname = ${envnames}
+      set machcomp = ${machine}_${envname}
     endif
   endif
 endif
-
-# tcraig, lets find another way to validate argument
-#if (${test} != ${spval} && ${test} != 'smoke' && ${test} != '10day' && ${test} != 'annual' \
-# && ${test} != 'restart') then
-#  echo "${0}: ERROR in arguments.  ${test} is not a valid test"
-#  exit -1
-#endif
 
 if ((${dosuite} == 1 || ${dotest} == 1) && ${testid} == ${spval}) then
   echo "${0}: ERROR in arguments.  --testid must be passed if using --suite or --test"

--- a/cice.setup
+++ b/cice.setup
@@ -34,8 +34,8 @@ set stime = `date -u "+%H%M%S"`
 set docase = 0
 set dotest = 0
 set dosuite = 0
-set codecov = 0       # code coverage measurement and reporting
-set codecovflag = false
+set coverage = 0       # code coverage measurement and reporting
+set coverageflag = false
 set suitebuild  = true
 set suitereuse  = true
 set suiterun    = false
@@ -84,7 +84,7 @@ SYNOPSIS
 
     --suite SUITE[,SUITE2] -m MACH --testid ID 
         [-e ENV1,ENV2][--acct ACCT][--bdir DIR][--bgen DIR]
-        [--bcmp DIR][--tdir PATH][--report || --codecov]
+        [--bcmp DIR][--tdir PATH][--report || --coverage]
         [--setup-only || --setup-build || --setup-build-run || --setup-build-submit]
 
 DESCRIPTION
@@ -111,8 +111,8 @@ DESCRIPTION
     --testid   : test ID, user-defined id for testing (REQUIRED with --test or --suite)
     --diff     : generate comparison against another case
     --report   : automatically post results when tests are complete
-    --codecov  : generate and report test coverage metrics when tests are complete,
-                 requires GNU compiler (--env gnu)
+    --coverage : generate and report test coverage metrics when tests are complete,
+                 requires GNU compiler (--env gnu*)
     --setup-only         : for suite, setup testcases, no build, no submission
     --setup-build        : for suite, setup and build testcases, no submission
     --setup-build-run    : for suite, setup, build, and run interactively
@@ -229,9 +229,9 @@ while (1)
     set report = 1
     shift argv
 
-  else if ("$option" == "--codecov") then
-    set codecov = 1
-    set codecovflag = true
+  else if ("$option" == "--coverage") then
+    set coverage = 1
+    set coverageflag = true
     set suitereuse  = false
     shift argv
 
@@ -336,18 +336,18 @@ if (${dosum} > 1) then
   exit -1
 endif
 
-if ($codecov == 1 && $report == 1) then
-  echo "${0}: ERROR in arguments, not recommmended to set both --codecov and --report"
+if ($coverage == 1 && $report == 1) then
+  echo "${0}: ERROR in arguments, not recommmended to set both --coverage and --report"
   exit -1
 endif
 
-if ($codecov == 1 && "$envnames" != "gnu") then
-  echo "${0}: ERROR in arguments, must use --env gnu with --codecov"
+if ($coverage == 1 && "$envnames" !~ "gnu*") then
+  echo "${0}: ERROR in arguments, must use --env gnu* with --coverage"
   exit -1
 endif
 
-if ($codecov == 1 && `where curl` == "" && `where wget` == "") then
-  echo "${0}: ERROR 'curl' or 'wget' is required for --codecov"
+if ($coverage == 1 && `where curl` == "" && `where wget` == "") then
+  echo "${0}: ERROR 'curl' or 'wget' is required for --coverage"
   exit -1
 endif
 
@@ -356,8 +356,8 @@ if (${dosuite} == 0) then
     echo "${0}: ERROR in arguments, must use --suite with --report"
     exit -1
   endif
-  if ($codecov == 1) then
-    echo "${0}: ERROR in arguments, must use --suite with --codecov"
+  if ($coverage == 1) then
+    echo "${0}: ERROR in arguments, must use --suite with --coverage"
     exit -1
   endif
   if ("$envnames" =~ "*,*") then
@@ -366,6 +366,16 @@ if (${dosuite} == 0) then
   else
     set envname = ${envnames}
     set machcomp = ${machine}_${envname}
+  endif
+else
+  if ($coverage == 1) then
+    if ("$compilers" =~ "*,*") then
+      echo "${0}: ERROR in arguments, cannot set multiple compilers with --coverage"
+      exit -1
+    else
+      set compiler = ${compilers}
+      set machcomp = ${machine}_${compiler}
+    endif
   endif
 endif
 
@@ -504,6 +514,13 @@ EOF0
 cat >! ${tsdir}/report_codecov.csh << EOF0
 #!/bin/csh -f
 
+source ${ICE_SCRIPTS}/machines/env.${machcomp}
+
+set rn0 = "${shhash}:${sdate}-${stime}:${testsuite}"
+set report_name = \`echo \${rn0} | sed -e 's/ //g'\`
+
+#for codecov
+set use_curl = 1
 # define CODECOV_TOKEN env variable
 if !(\$?CODECOV_TOKEN) then
   if (-e ~/.codecov_cice_token) then
@@ -515,14 +532,16 @@ if !(\$?CODECOV_TOKEN) then
   endif
 endif
 
-set report_name = "${shhash}:${branch}:${machine} ${testsuite}"
-set use_curl = 1
+#for lcov
+setenv PERL5LIB ~/usr/lib/perl5/site_perl/5.18.2/x86_64-linux-thread-multi/
+set lcovalist = ""
 
 EOF0
 
   chmod +x ${tsdir}/suite.submit
   chmod +x ${tsdir}/results.csh
   chmod +x ${tsdir}/report_codecov.csh
+  cp -p -f ${tsdir}/report_codecov.csh ${tsdir}/report_lcov.csh
 
 endif
 
@@ -763,7 +782,7 @@ EOF
         echo "${0}: ERROR, ${ICE_SCRIPTS}/$file not found"
         exit -1
       endif
-      cp -f -p ${ICE_SCRIPTS}/$file ${casedir}
+      cp -f -p ${ICE_SCRIPTS}/$file ${casedir}/
     end
 
     # from machines dir to case
@@ -772,16 +791,16 @@ EOF
         echo "${0}: ERROR, ${ICE_SCRIPTS}/machines/$file not found"
         exit -1
       endif
-      cp -f -p ${ICE_SCRIPTS}/machines/$file ${casedir}
+      cp -f -p ${ICE_SCRIPTS}/machines/$file ${casedir}/
     end
 
     # from basic script dir to casescr
-    foreach file (parse_namelist.sh parse_settings.sh parse_namelist_from_env.sh cice_decomp.csh cice.run.setup.csh cice.test.setup.csh)
+    foreach file (parse_namelist.sh parse_settings.sh parse_namelist_from_env.sh cice_decomp.csh cice.run.setup.csh cice.test.setup.csh cice.results.csh cice.codecov.csh cice.lcov.csh)
       if !(-e ${ICE_SCRIPTS}/$file) then
         echo "${0}: ERROR, ${ICE_SCRIPTS}/$file not found"
         exit -1
       endif
-      cp -f -p ${ICE_SCRIPTS}/$file ${casescr}
+      cp -f -p ${ICE_SCRIPTS}/$file ${casescr}/
     end
 
     cd ${casedir}
@@ -906,7 +925,7 @@ setenv ICE_TESTID   ${testid}
 setenv ICE_BFBCOMP  ${fbfbcomp}
 setenv ICE_ACCOUNT  ${acct}
 setenv ICE_QUEUE    ${queue}
-setenv ICE_CODECOV  ${codecovflag}
+setenv ICE_COVERAGE ${coverageflag}
 EOF1
 
     if (${sets} != "") then
@@ -1038,6 +1057,14 @@ cp ${rundir}/compile/*.{gcno,gcda} ${testname_base}/codecov_output/
 
 EOF
 
+      cat >> ${tsdir}/report_lcov.csh << EOF
+lcov --gcov-tool gcov -c -d ${rundir}/compile -o ${testname_base}/lcov.info
+if (-s ${testname_base}/lcov.info) then
+  set lcovalist = "\${lcovalist} -a ${testname_base}/lcov.info"
+endif
+
+EOF
+
       cat >> ${tsdir}/suite.submit << EOF
 
 echo "-------test--------------"
@@ -1086,60 +1113,7 @@ set nonomatch && rm -f ciceexe.* && unset nonomatch
 
 EOF0
 
-  # Add code to results.csh to count the number of failures
-  cat >> ${tsdir}/results.csh << EOF
-cat ./results.log | grep -iv "#machinfo" | grep -iv "#envinfo"
-set pends     = \`cat ./results.log | grep PEND | wc -l\`
-set misses    = \`cat ./results.log | grep MISS | wc -l\`
-set failures  = \`cat ./results.log | grep FAIL | wc -l\`
-set failbuild = \`cat ./results.log | grep FAIL | grep " build " | wc -l\`
-set failrun   = \`cat ./results.log | grep FAIL | grep " run " | wc -l\`
-set failtest  = \`cat ./results.log | grep FAIL | grep " test " | wc -l\`
-set failcomp  = \`cat ./results.log | grep FAIL | grep " compare " | wc -l\`
-set failbfbc  = \`cat ./results.log | grep FAIL | grep " bfbcomp " | wc -l\`
-set failgen   = \`cat ./results.log | grep FAIL | grep " generate " | wc -l\`
-set success   = \`cat ./results.log | grep 'PASS\|COPY' | wc -l\`
-set comments  = \`cat ./results.log | grep "#" | wc -l\`
-set alltotal  = \`cat ./results.log | wc -l\`
-@ total = \$alltotal - \$comments
-@ chkcnt = \$pends + \$misses + \$failures + \$success
-
-echo "#------- " >> results.log
-echo " " >> results.log
-echo "#totl = \$total total" >> results.log
-echo "#chkd = \$chkcnt checked" >> results.log
-echo "#pass = \$success" >> results.log
-echo "#pend = \$pends" >> results.log
-echo "#miss = \$misses" >> results.log
-echo "#fail = \$failures" >> results.log
-echo "    #failbuild = \$failbuild" >> results.log
-echo "    #failrun   = \$failrun" >> results.log
-echo "    #failtest  = \$failtest" >> results.log
-echo "    #failcomp  = \$failcomp" >> results.log
-echo "    #failbfbc  = \$failbfbc" >> results.log
-echo "    #failgen   = \$failgen" >> results.log
-
-echo ""
-echo "Descriptors:"
-echo " PASS - successful completion"
-echo " COPY - previously compiled code was copied for new test"
-echo " MISS - comparison data is missing"
-echo " PEND - status is undertermined; test may still be queued, running, or timed out"
-echo " FAIL - test failed"
-echo ""
-echo "\$chkcnt measured results of \$total total results"
-echo "\$success of \$chkcnt tests PASSED"
-echo "\$pends of \$chkcnt tests PENDING"
-echo "\$misses of \$chkcnt tests MISSING data"
-echo "\$failures of \$chkcnt tests FAILED"
-#echo "  \$failbuild of \$failures FAILED build"
-#echo "  \$failrun of \$failures FAILED run"
-#echo "  \$failtest of \$failures FAILED test"
-#echo "  \$failcomp of \$failures FAILED compare"
-#echo "  \$failbfbc of \$failures FAILED bfbcomp"
-#echo "  \$failgen of \$failures FAILED generate"
-exit \$failures
-EOF
+  # Add code to post processing scripts
 
   if ($?ICE_MACHINE_QSTAT) then
     cat >! ${tsdir}/poll_queue.env << EOF0
@@ -1147,19 +1121,11 @@ setenv ICE_MACHINE_QSTAT ${ICE_MACHINE_QSTAT}
 EOF0
   endif
 
-cat >> ${tsdir}/report_codecov.csh << EOF
-source ${ICE_SCRIPTS}/machines/env.${machcomp} 
+  cat ${casescr}/cice.results.csh >> ${tsdir}/results.csh 
 
-if ( \${use_curl} == 1 ) then
-  bash -c "bash <(curl -s https://codecov.io/bash) -n '\${report_name}' -y ./codecov.yml "
-else
-  bash -c "bash <(wget -O - https://codecov.io/bash) -n '\${report_name}' -y ./codecov.yml "
-endif
+  cat ${casescr}/cice.codecov.csh >> ${tsdir}/report_codecov.csh
 
-sleep 10
-rm -r -f ./*/codecov_output
-
-EOF
+  cat ${casescr}/cice.lcov.csh >> ${tsdir}/report_lcov.csh
 
   # build and submit tests
   cd ${tsdir}
@@ -1174,10 +1140,11 @@ EOF
     ./results.csh
     ./report_results.csh
   endif
-  if ($codecov == 1) then
-    echo "Generating codecov reports"
+  if ($coverage == 1) then
+    echo "Generating coverage reports"
     ./poll_queue.csh
-    ./report_codecov.csh
+    ./report_lcov.csh
+    #./report_codecov.csh
   endif
   cd ${ICE_SANDBOX}
 

--- a/cice.setup
+++ b/cice.setup
@@ -432,7 +432,9 @@ if ( ${dosuite} == 0 ) then
 
 else
   set tarrays = `echo ${testsuite} | sed 's/,/ /g' | fmt -1 | sort -u`
+  set testsuitecnt = 0
   foreach tarray ( ${tarrays} )
+    @ testsuitecnt = ${testsuitecnt} + 1
     if (-e ${tarray}) then
       cat ${tarray} >> $tsfile
     else if (-e ${tarray}.ts) then
@@ -516,8 +518,9 @@ cat >! ${tsdir}/report_codecov.csh << EOF0
 
 source ${ICE_SCRIPTS}/machines/env.${machcomp}
 
-set rn0 = "${shhash}:${sdate}-${stime}:${testsuite}"
-set report_name = \`echo \${rn0} | sed -e 's/ //g'\`
+set rn0 = "${shhash}:${sdate}-${stime}:${testsuitecnt}:${testsuite}"
+set rn1 = \`echo \${rn0} | sed -e 's/ //g'\`
+set report_name = \`echo \${rn1} | sed -e 's/_suite//g'\`
 
 #for codecov
 set use_curl = 1

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/bin/csh -f
 
 if ( $1 != "" ) then
   echo "running cice.batch.csh (creating ${1})"

--- a/configuration/scripts/cice.build
+++ b/configuration/scripts/cice.build
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/bin/csh -f
 
 #====================================
 # If the cice binary is passed via the --exe argument and the file exists,

--- a/configuration/scripts/cice.codecov.csh
+++ b/configuration/scripts/cice.codecov.csh
@@ -1,0 +1,20 @@
+
+#--- cice.codecov.csh ---
+
+#if ( ${use_curl} == 1 ) then
+#  bash -c "bash <(curl -s https://codecov.io/bash) -n '${report_name}' -y ./codecov.yml "
+#else
+#  bash -c "bash <(wget -O - https://codecov.io/bash) -n '${report_name}' -y ./codecov.yml "
+#endif
+
+if ( ${use_curl} == 1 ) then
+  curl https://codecov.io/bash -o codecov.bash
+else
+  wget https://codecov.io/bash -O codecov.bash
+endif
+chmod +x codecov.bash
+sed -i.sedbak 's|mktemp /tmp/|mktemp ./|g' codecov.bash
+bash -c "bash ./codecov.bash -n '${report_name}' -y ./codecov.yml"
+
+sleep 10
+rm -r -f ./*/codecov_output

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/bin/csh -f
 
 #echo ${0}
 echo "running cice.launch.csh"

--- a/configuration/scripts/cice.lcov.csh
+++ b/configuration/scripts/cice.lcov.csh
@@ -1,0 +1,45 @@
+
+#--- cice.lcov.csh ---
+
+echo ${lcovalist}
+lcov ${lcovalist} -o total.info
+
+set lcovrepo = apcraig.github.io
+set lcovhtmldir = lcov_cice_${report_name}
+genhtml -o ./${lcovhtmldir} --precision 2 -t "${report_name}" total.info
+
+git clone https://github.com/apcraig/${lcovrepo}
+cp -p -r ${lcovhtmldir} ${lcovrepo}/
+
+cd ${lcovrepo}
+set oline = `grep -n "add_cice_entry_here" index.html | head -1 | cut -d : -f 1`
+@ nline = ${oline}
+sed -i "$nline a    <li><a href="${lcovhtmldir}/index.html">${lcovhtmldir}</a></li> " index.html
+
+set covp0 = `grep message coverage.json | cut -d : -f 2 | cut -d \" -f 2 | cut -d % -f 1`
+set covp  = `grep -i headerCovTableEntryLo ${lcovhtmldir}/index.html | head -1 | cut -d \> -f 2 | cut -d % -f 1`
+set covpi = `echo $covp | cut -d . -f 1`
+
+set covpcolor = red
+if (${covpi} > 50) set covpcolor = orange
+if (${covpi} > 60) set covpcolor = yellow
+if (${covpi} > 70) set covpcolor = yellowgreen
+if (${covpi} > 80) set covpcolor = green
+if (${covpi} > 90) set covpcolor = brightgreen
+
+cp coverage.json coverage.json.old
+cat >! coverage.json <<EOF
+
+  {
+  "schemaVersion": 1,
+  "label": "lcov",
+  "message": "${covp}%",
+  "color": "${covpcolor}"
+  }
+
+EOF
+
+git add .
+git commit -m "add ${lcovhtmldir}"
+git push origin master
+

--- a/configuration/scripts/cice.lcov.csh
+++ b/configuration/scripts/cice.lcov.csh
@@ -12,13 +12,14 @@ git clone https://github.com/apcraig/${lcovrepo}
 cp -p -r ${lcovhtmldir} ${lcovrepo}/
 
 cd ${lcovrepo}
-set oline = `grep -n "add_cice_entry_here" index.html | head -1 | cut -d : -f 1`
-@ nline = ${oline}
-sed -i "$nline a    <li><a href="${lcovhtmldir}/index.html">${lcovhtmldir}</a></li> " index.html
-
 set covp0 = `grep message coverage.json | cut -d : -f 2 | cut -d \" -f 2 | cut -d % -f 1`
 set covp  = `grep -i headerCovTableEntryLo ${lcovhtmldir}/index.html | head -1 | cut -d \> -f 2 | cut -d % -f 1`
 set covpi = `echo $covp | cut -d . -f 1`
+
+set lcovhtmlname = "${covpi}%:${report_name}"
+set oline = `grep -n "add_cice_entry_here" index.html | head -1 | cut -d : -f 1`
+@ nline = ${oline}
+sed -i "$nline a    <li><a href="${lcovhtmldir}/index.html">${lcovhtmlname}</a></li> " index.html
 
 set covpcolor = red
 if (${covpi} > 50) set covpcolor = orange

--- a/configuration/scripts/cice.results.csh
+++ b/configuration/scripts/cice.results.csh
@@ -1,7 +1,7 @@
 
 #--- cice.results.csh --- 
 
-cat ./results.log
+cat ./results.log | grep -iv "#machinfo" | grep -iv "#envinfo"
 set pends     = `cat ./results.log | grep PEND | wc -l`
 set misses    = `cat ./results.log | grep MISS | wc -l`
 set failures  = `cat ./results.log | grep FAIL | wc -l`

--- a/configuration/scripts/cice.results.csh
+++ b/configuration/scripts/cice.results.csh
@@ -1,0 +1,54 @@
+
+#--- cice.results.csh --- 
+
+cat ./results.log
+set pends     = `cat ./results.log | grep PEND | wc -l`
+set misses    = `cat ./results.log | grep MISS | wc -l`
+set failures  = `cat ./results.log | grep FAIL | wc -l`
+set failbuild = `cat ./results.log | grep FAIL | grep " build " | wc -l`
+set failrun   = `cat ./results.log | grep FAIL | grep " run " | wc -l`
+set failtest  = `cat ./results.log | grep FAIL | grep " test " | wc -l`
+set failcomp  = `cat ./results.log | grep FAIL | grep " compare " | wc -l`
+set failbfbc  = `cat ./results.log | grep FAIL | grep " bfbcomp " | wc -l`
+set failgen   = `cat ./results.log | grep FAIL | grep " generate " | wc -l`
+set success   = `cat ./results.log | grep 'PASS\|COPY' | wc -l`
+set comments  = `cat ./results.log | grep "#" | wc -l`
+set alltotal  = `cat ./results.log | wc -l`
+@ total = $alltotal - $comments
+@ chkcnt = $pends + $misses + $failures + $success
+
+echo "#------- " >> results.log
+echo " " >> results.log
+echo "#totl = $total total" >> results.log
+echo "#chkd = $chkcnt checked" >> results.log
+echo "#pass = $success" >> results.log
+echo "#pend = $pends" >> results.log
+echo "#miss = $misses" >> results.log
+echo "#fail = $failures" >> results.log
+echo "    #failbuild = $failbuild" >> results.log
+echo "    #failrun   = $failrun" >> results.log
+echo "    #failtest  = $failtest" >> results.log
+echo "    #failcomp  = $failcomp" >> results.log
+echo "    #failbfbc  = $failbfbc" >> results.log
+echo "    #failgen   = $failgen" >> results.log
+
+echo ""
+echo "Descriptors:"
+echo " PASS - successful completion"
+echo " COPY - previously compiled code was copied for new test"
+echo " MISS - comparison data is missing"
+echo " PEND - status is undertermined; test may still be queued, running, or timed out"
+echo " FAIL - test failed"
+echo ""
+echo "$chkcnt measured results of $total total results"
+echo "$success of $chkcnt tests PASSED"
+echo "$pends of $chkcnt tests PENDING"
+echo "$misses of $chkcnt tests MISSING data"
+echo "$failures of $chkcnt tests FAILED"
+#echo "  $failbuild of $failures FAILED build"
+#echo "  $failrun of $failures FAILED run"
+#echo "  $failtest of $failures FAILED test"
+#echo "  $failcomp of $failures FAILED compare"
+#echo "  $failbfbc of $failures FAILED bfbcomp"
+#echo "  $failgen of $failures FAILED generate"
+exit $failures

--- a/configuration/scripts/cice.run.setup.csh
+++ b/configuration/scripts/cice.run.setup.csh
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/bin/csh -f
 
 #echo ${0}
 echo "running cice.run.setup.csh"

--- a/configuration/scripts/cice.settings
+++ b/configuration/scripts/cice.settings
@@ -41,5 +41,5 @@ if (${ICE_NTASKS} == 1) setenv ICE_COMMDIR serial
 
 ### Specialty code
 setenv ICE_BLDDEBUG  false  # build debug flags
-setenv ICE_CODECOV   false  # build debug flags
+setenv ICE_COVERAGE  false  # build debug flags
 

--- a/configuration/scripts/cice.settings
+++ b/configuration/scripts/cice.settings
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/bin/csh -f
 
 setenv ICE_CASENAME   undefined
 setenv ICE_SANDBOX    undefined

--- a/configuration/scripts/cice.test.setup.csh
+++ b/configuration/scripts/cice.test.setup.csh
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/bin/csh -f
 
 #source ./cice.settings
 #source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} || exit 2

--- a/configuration/scripts/machines/Macros.cheyenne_gnu
+++ b/configuration/scripts/machines/Macros.cheyenne_gnu
@@ -16,14 +16,14 @@ ifeq ($(ICE_BLDDEBUG), true)
   CFLAGS   += -O0
 endif
 
-ifeq ($(ICE_CODECOV), true)
+ifeq ($(ICE_COVERAGE), true)
   FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
   CFLAGS   += -O0 -g -coverage
   LDFLAGS  += -g -ftest-coverage -fprofile-arcs
 endif
 
 ifneq ($(ICE_BLDDEBUG), true)
-ifneq ($(ICE_CODECOV), true)
+ifneq ($(ICE_COVERAGE), true)
   FFLAGS   += -O2
   CFLAGS   += -O2
 endif

--- a/configuration/scripts/machines/Macros.gaffney_gnu
+++ b/configuration/scripts/machines/Macros.gaffney_gnu
@@ -16,14 +16,14 @@ ifeq ($(ICE_BLDDEBUG), true)
   CFLAGS   += -O0
 endif
 
-ifeq ($(ICE_CODECOV), true)
+ifeq ($(ICE_COVERAGE), true)
   FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
   CFLAGS   += -O0 -g -coverage
   LDFLAGS  += -g -ftest-coverage -fprofile-arcs
 endif
 
 ifneq ($(ICE_BLDDEBUG), true)
-ifneq ($(ICE_CODECOV), true)
+ifneq ($(ICE_COVERAGE), true)
   FFLAGS   += -O2
   CFLAGS   += -O2
 endif

--- a/configuration/scripts/machines/Macros.gordon_gnu
+++ b/configuration/scripts/machines/Macros.gordon_gnu
@@ -16,14 +16,14 @@ ifeq ($(ICE_BLDDEBUG), true)
   CFLAGS   += -O0
 endif
 
-ifeq ($(ICE_CODECOV), true)
+ifeq ($(ICE_COVERAGE), true)
   FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
   CFLAGS   += -O0 -g -coverage
   LDFLAGS  += -g -ftest-coverage -fprofile-arcs
 endif
 
 ifneq ($(ICE_BLDDEBUG), true)
-ifneq ($(ICE_CODECOV), true)
+ifneq ($(ICE_COVERAGE), true)
   FFLAGS   += -O2
   CFLAGS   += -O2
 endif

--- a/configuration/scripts/machines/Macros.izumi_gnu
+++ b/configuration/scripts/machines/Macros.izumi_gnu
@@ -16,14 +16,14 @@ ifeq ($(ICE_BLDDEBUG), true)
   CFLAGS   += -O0
 endif
 
-ifeq ($(ICE_CODECOV), true)
+ifeq ($(ICE_COVERAGE), true)
   FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
   CFLAGS   += -O0 -g -coverage
   LDFLAGS  += -g -ftest-coverage -fprofile-arcs
 endif
 
 ifneq ($(ICE_BLDDEBUG), true) 
-ifneq ($(ICE_CODECOV), true) 
+ifneq ($(ICE_COVERAGE), true)
   FFLAGS   += -O2
   CFLAGS   += -O2
 endif

--- a/configuration/scripts/machines/Macros.onyx_gnu
+++ b/configuration/scripts/machines/Macros.onyx_gnu
@@ -16,14 +16,14 @@ ifeq ($(ICE_BLDDEBUG), true)
   CFLAGS   += -O0
 endif
 
-ifeq ($(ICE_CODECOV), true)
+ifeq ($(ICE_COVERAGE), true)
   FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
   CFLAGS   += -O0 -g -coverage
   LDFLAGS  += -g -ftest-coverage -fprofile-arcs
 endif
 
 ifneq ($(ICE_BLDDEBUG), true) 
-ifneq ($(ICE_CODECOV), true) 
+ifneq ($(ICE_COVERAGE), true)
   FFLAGS   += -O2
   CFLAGS   += -O2
 endif

--- a/configuration/scripts/machines/Macros.travisCI_gnu
+++ b/configuration/scripts/machines/Macros.travisCI_gnu
@@ -16,14 +16,14 @@ ifeq ($(ICE_BLDDEBUG), true)
   CFLAGS   += -O0
 endif
 
-ifeq ($(ICE_CODECOV), true)
+ifeq ($(ICE_COVERAGE), true)
   FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
   CFLAGS   += -O0 -g -coverage
   LDFLAGS  += -g -ftest-coverage -fprofile-arcs
 endif
 
 ifneq ($(ICE_BLDDEBUG), true) 
-ifneq ($(ICE_CODECOV), true) 
+ifneq ($(ICE_COVERAGE), true) 
   FFLAGS   += -O2
   CFLAGS   += -O2
 endif

--- a/configuration/scripts/machines/env.cheyenne_gnu
+++ b/configuration/scripts/machines/env.cheyenne_gnu
@@ -16,6 +16,7 @@ module load mpt/2.19
 module load ncarcompilers/0.5.0
 module load netcdf/4.6.3
 
+if ($?ICE_IOTYPE) then
 if ($ICE_IOTYPE =~ pio*) then
   module unload netcdf
   module load netcdf-mpi/4.6.3
@@ -25,6 +26,7 @@ if ($ICE_IOTYPE =~ pio*) then
   else
     module load pio/2.4.4
   endif
+endif
 endif
 
 endif

--- a/configuration/scripts/machines/env.cheyenne_intel
+++ b/configuration/scripts/machines/env.cheyenne_intel
@@ -16,6 +16,7 @@ module load mpt/2.19
 module load ncarcompilers/0.5.0
 module load netcdf/4.6.3
 
+if ($?ICE_IOTYPE) then
 if ($ICE_IOTYPE =~ pio*) then
   module unload netcdf
   module load netcdf-mpi/4.6.3
@@ -25,6 +26,7 @@ if ($ICE_IOTYPE =~ pio*) then
   else
     module load pio/2.4.4
   endif
+endif
 endif
 
 endif

--- a/configuration/scripts/machines/env.cheyenne_pgi
+++ b/configuration/scripts/machines/env.cheyenne_pgi
@@ -16,6 +16,7 @@ module load mpt/2.21
 module load ncarcompilers/0.5.0
 module load netcdf/4.7.3
 
+if ($?ICE_IOTYPE) then
 if ($ICE_IOTYPE =~ pio*) then
   module unload netcdf
   module load netcdf-mpi/4.7.3
@@ -25,6 +26,7 @@ if ($ICE_IOTYPE =~ pio*) then
   else
     module load pio/2.4.4
   endif
+endif
 endif
 
 endif

--- a/configuration/scripts/set_version_number.csh
+++ b/configuration/scripts/set_version_number.csh
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/bin/csh -f
 
 if ( $#argv < 1 ) then
   echo "$0 requires one argument, none passed"

--- a/configuration/scripts/setup_run_dirs.csh
+++ b/configuration/scripts/setup_run_dirs.csh
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/bin/csh -f
 
 source ./cice.settings
 source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} -nomodules || exit 2

--- a/configuration/scripts/tests/cice_test_codecov.csh
+++ b/configuration/scripts/tests/cice_test_codecov.csh
@@ -1,8 +1,7 @@
 #!/bin/csh 
 
 # This was a script on gordon
-# This script should only be run on hardware with the gnu compiler with a
-#   modified Macros file to turn on the codecov flags
+# This script should only be run on hardware with the gnu compiler
 # This should be run interactively because git push will require login information
 
 #PBS -N cice_test
@@ -69,7 +68,7 @@ git push origin master
 # Run test suite
 echo " "
 echo "*** run test suite ***"
-./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite -m gordon -e gnu --testid T${date} --codecov --queue standard
+./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,io_suite,quick_suite -m gordon -e gnu --testid T${date} --coverage --queue standard
 
-# The test suite will wait until all jobs are complete then run report_codecov.csh
-# If that fails, you can run report_codecov.csh manually after all jobs are done
+# The test suite will wait until all jobs are complete then run report_codecov.csh or report_lcov.csh
+# If that fails, you can run report_codecov.csh or report_lcov.csh manually after all jobs are done

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -71,7 +71,7 @@ can be modified as needed.
    "ICE_QUEUE", "string", "batch queue name", "set by cice.setup or by default"
    "ICE_THREADED", "true, false", "force threading in compile, will always compile threaded if ICE_NTHRDS :math:`> 1`", "false"
    "ICE_BLDDEBUG", "true, false", "turn on compile debug flags", "false"
-   "ICE_CODECOV", "true,false", "turn on code coverage flags", "false"
+   "ICE_COVERAGE", "true, false", "turn on code coverage flags", "false"
 
 
 .. _tabnamelist:

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -381,7 +381,7 @@ following options are valid for suites,
   This is only used by ``--suite`` and when set, invokes a script that sends the test results to the results page when all tests are complete.  Please see :ref:`testreporting` for more information.
 
 ``--coverage``
-  When invoked, code coverage diagnostics are generated.  This will modify the build and reduce optimization.  The results can then be processed by **report_codecov.csh** or **report_lcov.csh**.  General use is not recommended, this is mainly used as a diagnostic to periodically assess test coverage.  Please see :ref:`codecoverage` for more information.
+  When invoked, code coverage diagnostics are generated.  This will modify the build and reduce optimization and generate coverage reports using lcov or codecov tools.  General use is not recommended, this is mainly used as a diagnostic to periodically assess test coverage.  Please see :ref:`codecoverage` for more information.
 
 ``--setup-only``
   This is only used by ``--suite`` and when set, just creates the suite testcases.  It does not build or submit them to run.  By default, the suites do ``--setup-build-submit``.
@@ -667,40 +667,63 @@ Code Coverage Testing
 
 The ``--coverage`` feature in **cice.setup** provides a method to diagnose code coverage.
 This argument turns on special compiler flags including reduced optimization and then
-invokes the gcov tool.
+invokes the gcov tool.  Once runs are complete, either lcov or codecov can be used
+to analyze the results.
 This option is currently only available with the gnu compiler and on a few systems
 with modified Macros files.
 
-Because codecov.io does not support git submodule analysis right now, a customized
-repository has to be created to test CICE with Icepack integrated directly.  The repository 
-https://github.com/apcraig/Test_CICE_Icepack serves as the current default test repository.
-In general, to setup the code coverage test in CICE, the current CICE master has
-to be copied into the Test_CICE_Icepack repository, then the full test suite
-can be run with the gnu compiler with the ``--coverage`` argument.
+At the present time, the ``--coverage`` flag invokes the lcov analysis automatically
+by running the **report_lcov.csh** script in the test suite directory.  The output 
+will show up at the `CICE lcov website <https://apcraig.github.io>`__.  To
+use the tool, you should have write permission for that repository.  The lcov tool
+should be run on a full multi-suite test suite, and it can 
+take several hours to process the data once the test runs are complete.  A typical
+instantiation would be
+::
 
-The test suite will run and then a report will be generated and uploaded to 
-the `codecov.io site <https://codecov.io/gh/apcraig/Test_CICE_Icepack>`_ by the 
-**report_codecov.csh** script.  The env variable CODECOV_TOKEN needs to be defined
-either in the environment or in a file named **~/.codecov_cice_token**.  That
-token provides write permission to the Test_CICE_Icepack codecov.io site and is available
-by contacting the Consortium team directly.
+  ./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,io_suite,quick_suite --mach cheyenne --env gnu --testid cc01 --coverage
 
-A script that carries out the end-to-end testing can be found in 
-**configuration/scripts/tests/cice_test_codecov.csh**
+Alternatively, codecov analysis can be carried out by manually running the **report_codecov.csh**
+script from the test suite directory, but there are several ongoing problems with this approach and
+it is not generally recommended.  A script that summarizes the end-to-end process for codecov
+analysis can be found in ..**configuration/scripts/tests/cice_test_codecov.csh**.  The codecov
+analysis is largely identical to the analysis performed by lcov, codecov just provides a nicer 
+web experience to view the output.
 
-This is a special diagnostic test and does not constitute proper model testing.
-General use is not recommended, this is mainly used as a diagnostic to periodically 
-assess test coverage.  The interaction with codecov.io is not always robust and
-can be tricky to manage.  Some constraints are that the output generated at runtime
-is copied into the directory where compilation took place.  That means each
-test should be compiled separately.  Tests that invoke multiple runs
-(such as exact restart and the decomp test) will only save coverage information
-for the last run, so some coverage information may be lost.  The gcov tool can
-be a little slow to run on large test suites, and the codecov.io bash uploader
-(that runs gcov and uploads the data to codecov.io) is constantly evolving.
-Finally, gcov requires that the diagnostic output be copied into the git sandbox for
-analysis.  These constraints are handled by the current scripts, but may change
-in the future.
+This is a special diagnostic test and is not part of the standard model testing.
+General use is not recommended, this is mainly used as a diagnostic to periodically
+assess test coverage.  
+
+..Because codecov.io does not support git submodule analysis right now, a customized
+..repository has to be created to test CICE with Icepack integrated directly.  The repository 
+..https://github.com/apcraig/Test_CICE_Icepack serves as the current default test repository.
+..In general, to setup the code coverage test in CICE, the current CICE master has
+..to be copied into the Test_CICE_Icepack repository, then the full test suite
+..can be run with the gnu compiler with the ``--coverage`` argument.
+
+..The test suite will run and then a report will be generated and uploaded to 
+..the `codecov.io site <https://codecov.io/gh/apcraig/Test_CICE_Icepack>`_ by the 
+..**report_codecov.csh** script.  The env variable CODECOV_TOKEN needs to be defined
+..either in the environment or in a file named **~/.codecov_cice_token**.  That
+..token provides write permission to the Test_CICE_Icepack codecov.io site and is available
+..by contacting the Consortium team directly.
+
+..A script that carries out the end-to-end testing can be found in 
+..**configuration/scripts/tests/cice_test_codecov.csh**
+
+..This is a special diagnostic test and does not constitute proper model testing.
+..General use is not recommended, this is mainly used as a diagnostic to periodically 
+..assess test coverage.  The interaction with codecov.io is not always robust and
+..can be tricky to manage.  Some constraints are that the output generated at runtime
+..is copied into the directory where compilation took place.  That means each
+..test should be compiled separately.  Tests that invoke multiple runs
+..(such as exact restart and the decomp test) will only save coverage information
+..for the last run, so some coverage information may be lost.  The gcov tool can
+..be a little slow to run on large test suites, and the codecov.io bash uploader
+..(that runs gcov and uploads the data to codecov.io) is constantly evolving.
+..Finally, gcov requires that the diagnostic output be copied into the git sandbox for
+..analysis.  These constraints are handled by the current scripts, but may change
+..in the future.
 
 
 .. _compliance:

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -380,8 +380,8 @@ following options are valid for suites,
 ``--report``
   This is only used by ``--suite`` and when set, invokes a script that sends the test results to the results page when all tests are complete.  Please see :ref:`testreporting` for more information.
 
-``--codecov``
-  When invoked, code coverage diagnostics are generated.  This will modify the build and reduce optimization.  The results will be uploaded to the **codecov.io** website via the **report_codecov.csh** script.  General use is not recommended, this is mainly used as a diagnostic to periodically assess test coverage.  Please see :ref:`codecoverage` for more information.
+``--coverage``
+  When invoked, code coverage diagnostics are generated.  This will modify the build and reduce optimization.  The results can then be processed by **report_codecov.csh** or **report_lcov.csh**.  General use is not recommended, this is mainly used as a diagnostic to periodically assess test coverage.  Please see :ref:`codecoverage` for more information.
 
 ``--setup-only``
   This is only used by ``--suite`` and when set, just creates the suite testcases.  It does not build or submit them to run.  By default, the suites do ``--setup-build-submit``.
@@ -665,7 +665,7 @@ wait for all runs to be complete, and run the results and report_results scripts
 Code Coverage Testing
 ------------------------------
 
-The ``--codecov`` feature in **cice.setup** provides a method to diagnose code coverage.
+The ``--coverage`` feature in **cice.setup** provides a method to diagnose code coverage.
 This argument turns on special compiler flags including reduced optimization and then
 invokes the gcov tool.
 This option is currently only available with the gnu compiler and on a few systems
@@ -676,7 +676,7 @@ repository has to be created to test CICE with Icepack integrated directly.  The
 https://github.com/apcraig/Test_CICE_Icepack serves as the current default test repository.
 In general, to setup the code coverage test in CICE, the current CICE master has
 to be copied into the Test_CICE_Icepack repository, then the full test suite
-can be run with the gnu compiler with the ``--codecov`` argument.
+can be run with the gnu compiler with the ``--coverage`` argument.
 
 The test suite will run and then a report will be generated and uploaded to 
 the `codecov.io site <https://codecov.io/gh/apcraig/Test_CICE_Icepack>`_ by the 


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Add lcov code coverage tool and minor refactor of coverage scripts
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    ran several tests with coverage turned on, verifies it updates the following website, https://apcraig.github.io/
    no source code was changed, ran a quick suite on cheyenne with 3 compilers to confirm things are working, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#ea01b978fcc788fa021d9ea789dc440cc724993b
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

- Updates the scripts implementation and adds lcov tool.
- "--coverage" turns on lcov analysis, prior to this PR it activated the codecov analysis tool.  The codecov tool is still available and can be run manually.
- need to have write permissions to github.com/apcraig/apcraig.github.io to write results to the web site.  This site could/should be moved into the Consortium once there's general agreement it should live there.  I am also happy to provide write access to several people and for it to continue to live under apcraig.
- Adds a badge for the lcov results, will need to check it's working OK once merged.
- Cleans up the /bin/csh implementation, removing a space.
