### PR TITLE
move Ktens out of basalstress conditional in diagnostic output

### DIFF
--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -1174,8 +1174,8 @@
                write(nu_diag,1007) ' k2               = ', k2, ' free parameter for landfast ice'
                write(nu_diag,1007) ' alphab           = ', alphab, ' factor for landfast ice'
                write(nu_diag,1007) ' threshold_hw     = ', threshold_hw, ' max water depth for grounding ice'
-               write(nu_diag,1007) ' Ktens            = ', Ktens, ' tensile strength factor'
             endif
+            write(nu_diag,1007) ' Ktens            = ', Ktens, ' tensile strength factor'
          endif ! kdyn enabled
 
          write(nu_diag,*) ' '


### PR DESCRIPTION

- [x] Short (1 sentence) summary of your PR: 
    small correction to diagnostic output PR #468, so that Ktens prints even with basalstress = F
- [x] Developer(s): 
    E. Hunke
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    not tested (will do it if anyone thinks it's necessary)
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit (but diagnostic output of namelist values will change in some cases)
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:
Relocated a single line of code to print diagnostic output outside of an if-block.