### PR TITLE
Moved calculation of sicen and trcrn_bgc to the loop where they are used

### DIFF
--- a/cicecore/shared/ice_init_column.F90
+++ b/cicecore/shared/ice_init_column.F90
@@ -877,7 +877,7 @@
 
       endif     ! .not. restart
 
-      !$OMP PARALLEL DO PRIVATE(iblk,i,j,k,n,ilo,ihi,jlo,jhi,this_block,sicen,trcrn_bgc)
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j,n,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
 
          this_block = get_block(blocks_ice(iblk),iblk)         
@@ -888,15 +888,6 @@
 
          do j = jlo, jhi
          do i = ilo, ihi  
-
-            do n = 1, ncat
-            do k = 1, nilyr
-               sicen(k,n) = trcrn(i,j,nt_sice+k-1,n,iblk)
-            enddo
-            do k = ntrcr_o+1, ntrcr
-               trcrn_bgc(k-ntrcr_o,n) = trcrn(i,j,k,n,iblk)
-            enddo
-            enddo
 
             call icepack_load_ocean_bio_array(max_nbtrcr=icepack_max_nbtrcr,     &
                          max_algae=icepack_max_algae, max_don=icepack_max_don,   &
@@ -919,7 +910,7 @@
          file=__FILE__, line=__LINE__)
 
       if (.not. restart_bgc) then       
-         !$OMP PARALLEL DO PRIVATE(iblk,i,j,n,ilo,ihi,jlo,jhi,this_block)
+         !$OMP PARALLEL DO PRIVATE(iblk,i,j,k,n,ilo,ihi,jlo,jhi,this_block,sicen,trcrn_bgc)
          do iblk = 1, nblocks
 
             this_block = get_block(blocks_ice(iblk),iblk)         
@@ -930,7 +921,14 @@
 
             do j = jlo, jhi
             do i = ilo, ihi  
-
+                do n = 1, ncat
+                do k = 1, nilyr
+                   sicen(k,n) = trcrn(i,j,nt_sice+k-1,n,iblk)
+                enddo
+                do k = ntrcr_o+1, ntrcr
+                   trcrn_bgc(k-ntrcr_o,n) = trcrn(i,j,k,n,iblk)
+                enddo
+                enddo
             call icepack_init_bgc(ncat=ncat, nblyr=nblyr, nilyr=nilyr, ntrcr_o=ntrcr_o,  &
                          cgrid=cgrid, igrid=igrid, ntrcr=ntrcr, nbtrcr=nbtrcr,           &
                          sicen=sicen(:,:), trcrn=trcrn_bgc(:,:), sss=sss(i,j, iblk), &


### PR DESCRIPTION
Moved calculation of sicen and trcrn_bgc to the loop where they are used. The current construction did not use the calculated values as they were defined private and overwritten at each i/j


For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    Resolve warning 
- [ ] Developer(s): 
tar
- [ ] Suggest PR reviewers from list in the column to the right.
@apcraig @dabail10 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
   This is a bug fix of the init_bgc. I have not been running a test with bgc but the code compiles on gfortran, intel and cray. It will change the initialization of bgc.
 I hope that @dabail10 will review that the code work as intended. I have one concern this is that the initial calculation was imbedded in a "if (.not. restart_bgc)" clause. This is not the case anymore, however it is only used here.
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [x ] more substantial (anticipated)
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [ x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [ x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [ ] Please provide any additional information or relevant details below:
