### PR TITLE
Fix maskhalo bug in dynamics

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
@@ -365,6 +365,11 @@
       call ice_timer_start(timer_bound)
       call ice_HaloUpdate (strength,           halo_info, &
                            field_loc_center,   field_type_scalar)
+      ! velocities may have changed in dyn_prep2
+      call stack_velocity_field(uvel, vvel, fld2)
+      call ice_HaloUpdate (fld2,               halo_info, &
+                           field_loc_NEcorner, field_type_vector)
+      call unstack_velocity_field(fld2, uvel, vvel)
       call ice_timer_stop(timer_bound)
 
       if (maskhalo_dyn) then
@@ -376,19 +381,6 @@
          call ice_timer_stop(timer_bound)
          call ice_HaloMask(halo_info_mask, halo_info, halomask)
       endif
-
-      ! velocities may have changed in dyn_prep2
-      call stack_velocity_field(uvel, vvel, fld2)
-      call ice_timer_start(timer_bound)
-      if (maskhalo_dyn) then
-         call ice_HaloUpdate (fld2,               halo_info_mask, &
-                              field_loc_NEcorner, field_type_vector)
-      else
-         call ice_HaloUpdate (fld2,               halo_info, &
-                              field_loc_NEcorner, field_type_vector)
-      endif
-      call ice_timer_stop(timer_bound)
-      call unstack_velocity_field(fld2, uvel, vvel)
 
       !-----------------------------------------------------------------
       ! basal stress coefficients (landfast ice)

--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -307,6 +307,11 @@
       call ice_timer_start(timer_bound)
       call ice_HaloUpdate (strength,           halo_info, &
                            field_loc_center,   field_type_scalar)
+      ! velocities may have changed in dyn_prep2
+      call stack_velocity_field(uvel, vvel, fld2)
+      call ice_HaloUpdate (fld2,               halo_info, &
+                           field_loc_NEcorner, field_type_vector)
+      call unstack_velocity_field(fld2, uvel, vvel)
       call ice_timer_stop(timer_bound)
 
       if (maskhalo_dyn) then
@@ -318,19 +323,6 @@
          call ice_timer_stop(timer_bound)
          call ice_HaloMask(halo_info_mask, halo_info, halomask)
       endif
-
-      ! velocities may have changed in dyn_prep2
-      call stack_velocity_field(uvel, vvel, fld2)
-      call ice_timer_start(timer_bound)
-      if (maskhalo_dyn) then
-         call ice_HaloUpdate (fld2,               halo_info_mask, &
-                              field_loc_NEcorner, field_type_vector)
-      else
-         call ice_HaloUpdate (fld2,               halo_info, &
-                              field_loc_NEcorner, field_type_vector)
-      endif
-      call ice_timer_stop(timer_bound)
-      call unstack_velocity_field(fld2, uvel, vvel)
 
       !-----------------------------------------------------------------
       ! basal stress coefficients (landfast ice)

--- a/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
@@ -418,6 +418,11 @@
       call ice_timer_start(timer_bound)
       call ice_HaloUpdate (strength,           halo_info, &
                            field_loc_center,   field_type_scalar)
+      ! velocities may have changed in dyn_prep2
+      call stack_velocity_field(uvel, vvel, fld2)
+      call ice_HaloUpdate (fld2,               halo_info, &
+                           field_loc_NEcorner, field_type_vector)
+      call unstack_velocity_field(fld2, uvel, vvel)
       call ice_timer_stop(timer_bound)
 
       if (maskhalo_dyn) then
@@ -429,19 +434,6 @@
          call ice_timer_stop(timer_bound)
          call ice_HaloMask(halo_info_mask, halo_info, halomask)
       endif
-
-      ! velocities may have changed in dyn_prep2
-      call stack_velocity_field(uvel, vvel, fld2)
-      call ice_timer_start(timer_bound)
-      if (maskhalo_dyn) then
-         call ice_HaloUpdate (fld2,               halo_info_mask, &
-                              field_loc_NEcorner, field_type_vector)
-      else
-         call ice_HaloUpdate (fld2,               halo_info, &
-                              field_loc_NEcorner, field_type_vector)
-      endif
-      call ice_timer_stop(timer_bound)
-      call unstack_velocity_field(fld2, uvel, vvel)
 
       !-----------------------------------------------------------------
       ! basal stress coefficients (landfast ice)


### PR DESCRIPTION
PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix maskhalo bug in dynamics introduced in #491
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Full test suite passed on cheyenne, this fixes issue with "restart gx3 8x2x8x10x20 droundrobin maskhalo" on the current trunk.  https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#b1b1f9d49b3a228cff3fc9b07ac4a22d13f2da39
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

Fix maskhalo bug in dynamics, only appears when running padded decompositions.  In #491, an unmasked halo update was changed to a masked halo update.  This affects only padded decompositions with maskhalo_dyn=true and was picked up by an exact restart failure.


