### PR TITLE
machines: add '-no-wrap-margin' for ECCC machines

### DIFF
--- a/configuration/scripts/machines/Macros.banting_intel
+++ b/configuration/scripts/machines/Macros.banting_intel
@@ -9,7 +9,7 @@ CFLAGS     := -c -O2 -fp-model precise
 #-xHost
 
 FREEFLAGS  := -FR
-FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback
+FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback -no-wrap-margin
 #-xHost
 
 ifeq ($(ICE_BLDDEBUG), true)

--- a/configuration/scripts/machines/Macros.cesium_intel
+++ b/configuration/scripts/machines/Macros.cesium_intel
@@ -11,7 +11,7 @@ CFLAGS     := -c -O2 -fp-model precise
 
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
-FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback
+FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback -no-wrap-margin
 #-xHost
 FFLAGS_NOOPT:= -O0
 

--- a/configuration/scripts/machines/Macros.daley_intel
+++ b/configuration/scripts/machines/Macros.daley_intel
@@ -9,7 +9,7 @@ CFLAGS     := -c -O2 -fp-model precise
 #-xHost
 
 FREEFLAGS  := -FR
-FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback
+FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback -no-wrap-margin
 #-xHost
 
 ifeq ($(ICE_BLDDEBUG), true)

--- a/configuration/scripts/machines/Macros.fram_intel
+++ b/configuration/scripts/machines/Macros.fram_intel
@@ -11,7 +11,7 @@ CFLAGS     := -c -O2 -fp-model precise
 
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
-FFLAGS     := -O2 -fp-model precise -convert big_endian -assume byterecl -ftz -traceback
+FFLAGS     := -O2 -fp-model precise -convert big_endian -assume byterecl -ftz -traceback -no-wrap-margin
 #-xHost
 FFLAGS_NOOPT:= -O0
 

--- a/configuration/scripts/machines/Macros.millikan_intel
+++ b/configuration/scripts/machines/Macros.millikan_intel
@@ -11,7 +11,7 @@ CFLAGS     := -c -O2 -fp-model precise
 
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
-FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback
+FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback -no-wrap-margin
 #-xHost
 FFLAGS_NOOPT:= -O0
 


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    add '-no-wrap-margin' compiler option for Intel compiler on ECCC machines
- [X] Developer(s): 
    P. Blain
- [X] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
     NO code changes  - no tests 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:
Add this option instructing the Intel compiler not to wrap
output at 80 characters.

Reference:
https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/compiler-option-details/language-options/wrap-margin.html