### PR TITLE
Bug fix for box2001: aiu now multiplies the air stress components

### DIFF
--- a/cicecore/cicedynB/general/ice_forcing.F90
+++ b/cicecore/cicedynB/general/ice_forcing.F90
@@ -5059,22 +5059,30 @@
       subroutine box2001_data
 
 ! wind and current fields as in Hunke, JCP 2001
+! these are defined at the u point
 ! authors: Elizabeth Hunke, LANL
 
       use ice_domain, only: nblocks
+      use ice_domain_size, only: max_blocks
       use ice_blocks, only: nx_block, ny_block, nghost
       use ice_flux, only: uocn, vocn, uatm, vatm, wind, rhoa, strax, stray
-      use ice_grid, only: uvm
+      use ice_grid, only: uvm, to_ugrid
+      use ice_state, only: aice_init
 
       ! local parameters
 
       integer (kind=int_kind) :: &
          iblk, i,j           ! loop indices
 
+      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
+         aiu                 ! ice fraction on u-grid 
+
       real (kind=dbl_kind) :: &
           secday, pi , puny, period, pi2, tau
       call icepack_query_parameters(pi_out=pi, pi2_out=pi2, puny_out=puny)
       call icepack_query_parameters(secday_out=secday)
+
+      call to_ugrid(aice_init, aiu)
 
       period = c4*secday
 
@@ -5106,8 +5114,8 @@
          ! wind stress
          wind(i,j,iblk) = sqrt(uatm(i,j,iblk)**2 + vatm(i,j,iblk)**2)
          tau = rhoa(i,j,iblk) * 0.0012_dbl_kind * wind(i,j,iblk)
-         strax(i,j,iblk) = tau * uatm(i,j,iblk)
-         stray(i,j,iblk) = tau * vatm(i,j,iblk)
+         strax(i,j,iblk) = aiu(i,j,iblk) * tau * uatm(i,j,iblk)
+         stray(i,j,iblk) = aiu(i,j,iblk) * tau * vatm(i,j,iblk)
 
 ! initialization test
        ! Diagonal wind vectors 1


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    air stress components are now correctly multiplied by ice concentration at the u point (aiu) for box2001 experiment.
- [ ] Developer(s): 
    @JFLemieux73 
- [ ] Suggest PR reviewers from list in the column to the right. @eclare108213 @TillRasmussen 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    All the tests are bfb except (or course) box2001.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit (except for box2001)
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [ ] Please provide any additional information or relevant details below:
