### PR TITLE
box2001: compute aiu with aice instead of aice_init

### DIFF
--- a/cicecore/cicedynB/general/ice_forcing.F90
+++ b/cicecore/cicedynB/general/ice_forcing.F90
@@ -5067,7 +5067,7 @@
       use ice_blocks, only: nx_block, ny_block, nghost
       use ice_flux, only: uocn, vocn, uatm, vatm, wind, rhoa, strax, stray
       use ice_grid, only: uvm, to_ugrid
-      use ice_state, only: aice_init
+      use ice_state, only: aice
 
       ! local parameters
 
@@ -5082,7 +5082,7 @@
       call icepack_query_parameters(pi_out=pi, pi2_out=pi2, puny_out=puny)
       call icepack_query_parameters(secday_out=secday)
 
-      call to_ugrid(aice_init, aiu)
+      call to_ugrid(aice, aiu)
 
       period = c4*secday
 


### PR DESCRIPTION

## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    Correcting my bug...because get_forcing_atmo is called after ice_step, aiu in get_forcing_atmo (for box2001) should be calculated with aice instead of aice_init (that way the aiu for aiu*tair and aiu*twater are at the same time level).

This does not change the result with the box2001 exp because the advection is turned off. It only matters when someone is running modified box2001 exp with advection turned on (like I am doing...). 

- [ ] Developer(s): 
    @JFLemieux73 
- [ ] Suggest PR reviewers from list in the column to the right.
@eclare108213 @TillRasmussen 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    249 measured results of 249 total results
249 of 249 tests PASSED
0 of 249 tests PENDING
0 of 249 tests MISSING data
0 of 249 tests FAILED
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [ ] Please provide any additional information or relevant details below:
