### PR TITLE
Add DMI Cray XC50 hpc (freya) to machines. Based on Banting

### DIFF
--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -185,7 +185,15 @@ cat >> ${jobfile} << EOFB
 #SBATCH --qos=standby
 EOFB
 
-else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting* || ${ICE_MACHINE} =~ freya* ) then
+else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting*) then
+cat >> ${jobfile} << EOFB
+#PBS -N ${ICE_CASENAME}
+#PBS -j oe
+#PBS -l select=${nnodes}:ncpus=${corespernode}:mpiprocs=${taskpernodelimit}:ompthreads=${nthrds}
+#PBS -l walltime=${batchtime}
+EOFB
+
+else if (${ICE_MACHINE} =~ freya* ) then
 cat >> ${jobfile} << EOFB
 #PBS -N ${ICE_CASENAME}
 #PBS -j oe

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -185,7 +185,7 @@ cat >> ${jobfile} << EOFB
 #SBATCH --qos=standby
 EOFB
 
-else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting*) then
+else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting* || ${ICE_MACHINE} =~ freya* ) then
 cat >> ${jobfile} << EOFB
 #PBS -N ${ICE_CASENAME}
 #PBS -j oe

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -130,7 +130,7 @@ EOFR
 endif
 
 #=======
-else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting*) then
+else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting* || ${ICE_MACHINE} =~ freya*) then
 if (${ICE_COMMDIR} =~ serial*) then
 cat >> ${jobfile} << EOFR
 ./cice >&! \$ICE_RUNLOG_FILE

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -130,10 +130,22 @@ EOFR
 endif
 
 #=======
-else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting* || ${ICE_MACHINE} =~ freya*) then
+else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting*) then
 if (${ICE_COMMDIR} =~ serial*) then
 cat >> ${jobfile} << EOFR
 ./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+else
+cat >> ${jobfile} << EOFR
+aprun -n ${ntasks} -N ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+endif
+
+#=======
+else if (${ICE_MACHINE} =~ freya*) then
+if (${ICE_COMMDIR} =~ serial*) then
+cat >> ${jobfile} << EOFR
+aprun -n 1 -N 1 -d 1 ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
 else
 cat >> ${jobfile} << EOFR

--- a/configuration/scripts/machines/Macros.freya_gnu
+++ b/configuration/scripts/machines/Macros.freya_gnu
@@ -1,0 +1,40 @@
+#==============================================================================
+# Makefile macros for DMI freya
+#==============================================================================
+# For use with GNU compiler
+#==============================================================================
+
+#INCLDIR := -I. -I/usr/include
+#SLIBS   :=
+
+#--- Compiler/preprocessor ---
+FC         := ftn 
+CC         := cc
+CXX        := CC
+CPP        := /usr/bin/cpp
+CPPFLAGS   := -P -traditional  # ALLOW fortran double backslash "\\"
+SCC   := gcc
+SFC   := ftn
+
+CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
+CFLAGS     := -c -O2 
+#-xHost
+
+FREEFLAGS  := -ffree-form
+FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
+#-xHost
+
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow 
+else
+  FFLAGS     += -O2 #FROM BANTING
+  #FFLAGS     := -O2 -ffloat-store -march=native -ffree-line-length-non # DMI BUILD
+endif
+LD:= $(FC)
+LDFLAGS    := $(FFLAGS) -v
+
+ifeq ($(ICE_THREADED), true) 
+   LDFLAGS += -fopenmp 
+   CFLAGS += -fopenmp 
+   FFLAGS += -fopenmp 
+endif

--- a/configuration/scripts/machines/Macros.freya_intel
+++ b/configuration/scripts/machines/Macros.freya_intel
@@ -1,0 +1,75 @@
+#==============================================================================
+# Makefile macros for DMI Freya based on ECCC banting
+#==============================================================================
+# For use with intel compiler
+#==============================================================================
+
+#INCLDIR := -I. -I/usr/include
+#SLIBS   :=
+
+#--- Compiler/preprocessor ---
+FC         := ftn 
+CC         := cc
+CXX        := CC
+CPP        := /usr/bin/cpp
+CPPFLAGS   := -P -traditional  # ALLOW fortran double backslash "\\"
+SCC   := gcc
+SFC   := ftn
+
+CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
+CFLAGS     := -c -O2 -fp-model precise
+
+# Additional flags
+FIXEDFLAGS := -132
+FREEFLAGS  := -FR
+FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceback -no-wrap-margin
+#-xHost
+
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created
+# -heap-arrays 1024 
+else
+  FFLAGS     += -O2
+endif
+LD         := $(FC)
+LDFLAGS    := $(FFLAGS) -v
+#ifeq ($(ICE_BLDDEBUG), true)
+#FFLAGS     := -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#FFLAGS     := -g -O0 -traceback -fp-model precise -fp-stack-check -fpe0
+#else
+#FFLAGS     := -r8 -i4 -O2 -align all -w -ftz -assume byterecl
+# FFLAGS     := -O2 -fp-model precise -assume byterecl -ftz -traceback -xHost
+#endif
+# Preprocessor flags
+#CPPDEFS    := -DLINUX $(ICE_CPPDEFS)
+
+# Linker flags
+
+# Additional flags
+
+ifeq ($(DITTO), yes)
+   CPPDEFS :=  $(CPPDEFS) -DREPRODUCIBLE
+endif
+
+
+ifeq ($(ICE_THREADED), true) 
+   LDFLAGS += -qopenmp 
+   CFLAGS += -qopenmp 
+   FFLAGS += -qopenmp 
+endif
+
+#--- NetCDF ---
+#ifeq ($(IO_TYPE), netcdf)
+#   
+#endif
+#
+#ifeq ($(IO_TYPE), netcdf_bin)
+#   CPPDEFS :=  $(CPPDEFS) -Dncdf
+#endif
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first!
+#ifeq ($(ICE_IOTYPE), pio)
+#   PIO_PATH:=/usr/projects/climate/SHARED_CLIMATE/software/conejo/pio/1.7.2/intel-13.0.1/openmpi-1.6.3/netcdf-3.6.3-parallel-netcdf-1.3.1/include
+#   INCLDIR += -I$(PIO_PATH)
+#   SLIBS   := $(SLIBS) -L$(PIO_PATH) -lpio
+#endif

--- a/configuration/scripts/machines/Macros.freya_intel
+++ b/configuration/scripts/machines/Macros.freya_intel
@@ -18,7 +18,6 @@ SFC   := ftn
 
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
 CFLAGS     := -c -O2 -fp-model precise
-
 # Additional flags
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
@@ -46,11 +45,6 @@ LDFLAGS    := $(FFLAGS) -v
 # Linker flags
 
 # Additional flags
-
-ifeq ($(DITTO), yes)
-   CPPDEFS :=  $(CPPDEFS) -DREPRODUCIBLE
-endif
-
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -qopenmp 

--- a/configuration/scripts/machines/env.freya_gnu
+++ b/configuration/scripts/machines/env.freya_gnu
@@ -8,29 +8,30 @@ endif
 if ("$inp" != "-nomodules") then
 
 source /opt/modules/default/init/csh # Initialize modules for csh
-# Clear environment
+ Clear environment
 module rm PrgEnv-intel
 module rm PrgEnv-cray
 module rm PrgEnv-gnu
-module add PrgEnv-intel
+module add PrgEnv-gnu
 #module load PrgEnv-intel # Intel compiler
 #module load cray-mpich # MPI (Cray MPICH)
 module add cray-netcdf # NetCDF
 module add cray-hdf5 # HDF5
 #setenv HDF5_USE_FILE_LOCKING FALSE # necessary since data is on an NFS filesystem
+setenv HDF5_USE_FILE_LOCKING FALSE # necessary since data is on an NFS filesystem
 
 endif
 
 setenv ICE_MACHINE_MACHNAME freya
-setenv ICE_MACHINE_MACHINFO "Cray XC50, Intel Xeon Gold 6148 (Skylake) NOT SURE-TILL"
-setenv ICE_MACHINE_ENVNAME intel
-setenv ICE_MACHINE_ENVINFO "Intel 18.0.0.128, cray-mpich/7.7.0, cray-netcdf/4.4.1.1.6"
+setenv ICE_MACHINE_MACHINFO "Cray XC50, GNU Xeon Gold 6148 (Skylake) NOT SURE-TILL"
+setenv ICE_MACHINE_ENVNAME gnu
+setenv ICE_MACHINE_ENVINFO "gcc/7.2.0, cray-mpich/7.7.0, cray-netcdf/4.4.1.1.6"
 setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR /data/${USER}/cice_original/run/ 
 setenv ICE_MACHINE_INPUTDATA /data/${USER}/cice_original/
 setenv ICE_MACHINE_BASELINE /data/${USER}/cice_original/dbaselines/
 setenv ICE_MACHINE_SUBMIT "qsub"
-setenv ICE_MACHINE_TPNODE 36     # tasks per node
+setenv ICE_MACHINE_TPNODE 36    # tasks per node
 #setenv ICE_MACHINE_MAXRUNLENGTH 9
 setenv ICE_MACHINE_ACCT P0000000
 setenv ICE_MACHINE_QUEUE "development"

--- a/configuration/scripts/machines/env.freya_intel
+++ b/configuration/scripts/machines/env.freya_intel
@@ -1,0 +1,37 @@
+#!/bin/csh -f
+
+set inp = "undefined"
+if ($#argv == 1) then
+  set inp = $1
+endif
+
+if ("$inp" != "-nomodules") then
+
+source /opt/modules/default/init/csh # Initialize modules for csh
+module rm PrgEnv-intel
+module rm PrgEnv-cray
+module rm PrgEnv-gnu
+module add PrgEnv-intel
+#module load PrgEnv-intel # Intel compiler
+#module load cray-mpich # MPI (Cray MPICH)
+module add cray-netcdf # NetCDF
+module add cray-hdf5 # HDF5
+#setenv HDF5_USE_FILE_LOCKING FALSE # necessary since data is on an NFS filesystem
+
+endif
+
+setenv ICE_MACHINE_MACHNAME freya
+setenv ICE_MACHINE_MACHINFO "Cray XC50, Intel Xeon Gold 6148 (Skylake) NOT SURE-TILL"
+setenv ICE_MACHINE_ENVNAME intel
+setenv ICE_MACHINE_ENVINFO "Intel 18.0.0.128, cray-mpich/7.7.0, cray-netcdf/4.4.1.1.6"
+setenv ICE_MACHINE_MAKE make
+setenv ICE_MACHINE_WKDIR /data/${USER}/cice_original/run/ 
+setenv ICE_MACHINE_INPUTDATA /data/${USER}/cice_original/
+setenv ICE_MACHINE_BASELINE /data/${USER}/cice_original/dbaselines/
+setenv ICE_MACHINE_SUBMIT "qsub"
+setenv ICE_MACHINE_TPNODE 40
+setenv ICE_MACHINE_MAXRUNLENGTH 3
+setenv ICE_MACHINE_ACCT P0000000
+setenv ICE_MACHINE_QUEUE "development"
+setenv ICE_MACHINE_BLDTHRDS 18
+setenv ICE_MACHINE_QSTAT "qstat "


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    This adds environment and Macros for DMI Cray XC50 computer to machines. Based on Banting XC50.
- [ ] Developer(s): 
    tar
- [ ] Suggest PR reviewers from list in the column to the right.
@phil-blain @apcraig 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    Do not change the code itself 
- How much do the PR code changes differ from the unmodified code? 
    - [x ] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [ x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [ x] Please provide any additional information or relevant details below:
For DMI runs big endian flag should be removed.
Big endian flag only in Macro to use test examples from CICE consortium.
Only implemented for intel compiler

