### PR TITLE
solve_zsal bug fix and update zsal test option

### DIFF
--- a/cicecore/cicedynB/analysis/ice_diagnostics.F90
+++ b/cicecore/cicedynB/analysis/ice_diagnostics.F90
@@ -1561,11 +1561,11 @@
 
       real (kind=dbl_kind) :: &
            eidebug, esdebug, &
-           qi, qs, Tsnow, &
+           qi, qs, Tsnow, si, &
            rad_to_deg, puny, rhoi, lfresh, rhos, cp_ice
 
       integer (kind=int_kind) :: n, k, nt_Tsfc, nt_qice, nt_qsno, nt_fsd, &
-           nt_isosno, nt_isoice
+           nt_isosno, nt_isoice, nt_sice
 
       logical (kind=log_kind) :: tr_fsd, tr_iso
 
@@ -1576,7 +1576,7 @@
 
       call icepack_query_tracer_flags(tr_fsd_out=tr_fsd, tr_iso_out=tr_iso)
       call icepack_query_tracer_indices(nt_Tsfc_out=nt_Tsfc, nt_qice_out=nt_qice, &
-           nt_qsno_out=nt_qsno, nt_fsd_out=nt_fsd, &
+           nt_qsno_out=nt_qsno, nt_sice_out=nt_sice, nt_fsd_out=nt_fsd, &
            nt_isosno_out=nt_isosno, nt_isoice_out=nt_isoice)
       call icepack_query_parameters( &
            rad_to_deg_out=rad_to_deg, puny_out=puny, rhoi_out=rhoi, lfresh_out=lfresh, &
@@ -1621,7 +1621,6 @@
 
       enddo                     ! n
 
-
       eidebug = c0
       do n = 1,ncat
          do k = 1,nilyr
@@ -1652,6 +1651,14 @@
          endif
       enddo
       write(nu_diag,*) 'qsnow(i,j)',esdebug
+      write(nu_diag,*) ' '
+
+      do n = 1,ncat
+         do k = 1,nilyr
+            si = trcrn(i,j,nt_sice+k-1,n,iblk)
+            write(nu_diag,*) 'sice, cat ',n,' layer ',k, si
+         enddo
+      enddo
       write(nu_diag,*) ' '
 
       write(nu_diag,*) 'uvel(i,j)',uvel(i,j,iblk)

--- a/cicecore/cicedynB/general/ice_step_mod.F90
+++ b/cicecore/cicedynB/general/ice_step_mod.F90
@@ -550,22 +550,23 @@
 
       logical (kind=log_kind) :: &
          tr_fsd,          & ! floe size distribution tracers
-         z_tracers
+         z_tracers,       & ! vertical biogeochemistry
+         solve_zsal         ! zsalinity
 
       type (block) :: &
          this_block         ! block information for current block
 
       character(len=*), parameter :: subname = '(step_therm2)'
 
-      call icepack_query_parameters(z_tracers_out=z_tracers)
+      call icepack_query_parameters(z_tracers_out=z_tracers,solve_zsal_out=solve_zsal)
       call icepack_query_tracer_sizes(ntrcr_out=ntrcr, nbtrcr_out=nbtrcr)
       call icepack_query_tracer_flags(tr_fsd_out=tr_fsd)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)
 
-      ! tcraig, nltrcr used to be the number of zbgc tracers, but it's used as a zbgc flag in icepack
-      if (z_tracers) then
+      ! nltrcr is only used as a zbgc flag in icepack (number of zbgc tracers > 0)
+      if (z_tracers .or. solve_zsal) then
          nltrcr = 1
       else
          nltrcr = 0

--- a/cicecore/drivers/standalone/cice/CICE_RunMod.F90
+++ b/cicecore/drivers/standalone/cice/CICE_RunMod.F90
@@ -548,7 +548,7 @@
                             Tref     (:,:,iblk), Qref    (:,:,iblk), &
                             fresh    (:,:,iblk), fsalt   (:,:,iblk), &
                             fhocn    (:,:,iblk),                     &
-                            fswthru (:,:,iblk),                      &
+                            fswthru  (:,:,iblk),                     &
                             fswthru_vdr (:,:,iblk),                  &
                             fswthru_vdf (:,:,iblk),                  &
                             fswthru_idr (:,:,iblk),                  &

--- a/cicecore/drivers/standalone/cice/CICE_RunMod.F90_debug
+++ b/cicecore/drivers/standalone/cice/CICE_RunMod.F90_debug
@@ -247,7 +247,7 @@
                plabeld = 'post step_therm2'
                call debug_ice (iblk, plabeld)
 
-            endif
+            endif ! ktherm > 0
 
          enddo ! iblk
          !$OMP END PARALLEL DO
@@ -394,8 +394,8 @@
           albpnd, albcnt, apeff_ai, fpond, fresh, l_mpond_fresh, &
           alvdf_ai, alidf_ai, alvdr_ai, alidr_ai, fhocn_ai, &
           fresh_ai, fsalt_ai, fsalt, &
-          fswthru_ai, fhocn, fswthru, scale_factor, snowfrac, &
-          fswthru_vdr, fswthru_vdf, fswthru_idr, fswthru_idf, &
+          fswthru_ai, fhocn, scale_factor, snowfrac, &
+          fswthru, fswthru_vdr, fswthru_vdf, fswthru_idr, fswthru_idf, &
           swvdr, swidr, swvdf, swidf, Tf, Tair, Qa, strairxT, strairyT, &
           fsens, flat, fswabs, flwout, evap, Tref, Qref, &
           scale_fluxes, frzmlt_init, frzmlt
@@ -589,11 +589,12 @@
                             evap     (:,:,iblk),                     &
                             Tref     (:,:,iblk), Qref    (:,:,iblk), &
                             fresh    (:,:,iblk), fsalt   (:,:,iblk), &
-                            fhocn    (:,:,iblk), fswthru (:,:,iblk), &
-                            fswthru_vdr(:,:,iblk),                   &
-                            fswthru_vdf(:,:,iblk),                   &
-                            fswthru_idr(:,:,iblk),                   &
-                            fswthru_idf(:,:,iblk),                   &
+                            fhocn    (:,:,iblk),                     &
+                            fswthru  (:,:,iblk),                     &
+                            fswthru_vdr (:,:,iblk),                  &
+                            fswthru_vdf (:,:,iblk),                  &
+                            fswthru_idr (:,:,iblk),                  &
+                            fswthru_idf (:,:,iblk),                  &
                             faero_ocn(:,:,:,iblk),                   &
                             alvdr    (:,:,iblk), alidr   (:,:,iblk), &
                             alvdf    (:,:,iblk), alidf   (:,:,iblk), &

--- a/configuration/scripts/options/set_nml.zsal
+++ b/configuration/scripts/options/set_nml.zsal
@@ -3,7 +3,6 @@ sw_redist       = .true.
 tfrz_option     = 'linear_salt'
 tr_brine        = .true.
 solve_zsal      = .true.
-z_tracers       = .true.
 ice_ic          = 'default'
 restart         = .false.
 


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 

1. activate nltrcr when solve_zsal=T
2. set z_tracers=F in zsal test
3. add salinity profile to print_state for debugging
4. clean up and sync the regular and debug RunMod modules

- [x] Developer(s): 
@eclare108213 
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.

see comments below

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No, but it modifies the zsal option
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

The bug fix is simply to set nltrcr=1 when solve_zsal=T.
The z_tracers flag turns on vertical biogeochemistry, which is not needed to test the zsalinity capability.
Testing is underway.

Icepack [PR#346](https://github.com/CICE-Consortium/Icepack/pull/346) is related but independent of these changes.