### PR TITLE
cicecore: fix some use of uninitialized variables

### DIFF
--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -654,9 +654,7 @@
       enddo
       enddo
 
-#ifndef CICE_IN_NEMO
       sst   (:,:,:) = Tf(:,:,:)       ! sea surface temp (C)
-#endif
       qdp   (:,:,:) = c0              ! deep ocean heat flux (W/m^2)
       hmix  (:,:,:) = c20             ! ocean mixed layer depth (m)
       hwater(:,:,:) = bathymetry(:,:,:) ! ocean water depth (m)

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -384,7 +384,7 @@
       ! T-grid cell and U-grid cell quantities
       !-----------------------------------------------------------------
 
-!     tarea(:,:,:) = c0
+      tarea(:,:,:) = c0
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -1636,7 +1636,7 @@
       !-----------------------------------------------------------------
 
       bm = c0
-!     uvm = c0
+      uvm = c0
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks

--- a/cicecore/drivers/standalone/cice/CICE_RunMod.F90
+++ b/cicecore/drivers/standalone/cice/CICE_RunMod.F90
@@ -627,11 +627,12 @@
       
       real (kind=dbl_kind)    :: &
           puny, &          !
+          Lsub, &          !
           rLsub            ! 1/Lsub
 
       character(len=*), parameter :: subname = '(sfcflux_to_ocn)'
 
-      call icepack_query_parameters(puny_out=puny)
+      call icepack_query_parameters(puny_out=puny, Lsub_out=Lsub)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
   cicecore: fix some use of uninitialized variables
- [x] Developer(s): 
    P.Blain
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
   **in progress**
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

This is the first one of a series of small PRs I'm preparing to upstream some changes I've had to make to CICE6 during my work on coupling with NEMO3.6.  This one deals with use of uninitialized values, which I've detected by compiling with `-init=snan,arrays` (Intel). I will start the base_suite right away and update the description with the test results once they are finished running.

See the [commit messages](https://github.com/CICE-Consortium/CICE/pull/560/commits) for complete details.