### PR TITLE
OMP loop removal of unused private variables and added 1d evp teest

### DIFF
--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -1663,7 +1663,7 @@
                            field_loc_center, field_type_scalar)
       call ice_timer_stop(timer_bound)
 
-      !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j)
       do iblk = 1, nblocks
          do j = 1, ny_block
          do i = 1, nx_block

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -185,7 +185,7 @@ cat >> ${jobfile} << EOFB
 #SBATCH --qos=standby
 EOFB
 
-else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting*) then
+else if (${ICE_MACHINE} =~ daley* || ${ICE_MACHINE} =~ banting* ) then
 cat >> ${jobfile} << EOFB
 #PBS -N ${ICE_CASENAME}
 #PBS -j oe

--- a/configuration/scripts/machines/Macros.freya_intel
+++ b/configuration/scripts/machines/Macros.freya_intel
@@ -18,6 +18,7 @@ SFC   := ftn
 
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
 CFLAGS     := -c -O2 -fp-model precise
+
 # Additional flags
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
@@ -45,6 +46,11 @@ LDFLAGS    := $(FFLAGS) -v
 # Linker flags
 
 # Additional flags
+
+ifeq ($(DITTO), yes)
+   CPPDEFS :=  $(CPPDEFS) -DREPRODUCIBLE
+endif
+
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -qopenmp 

--- a/configuration/scripts/machines/Macros.freya_intel
+++ b/configuration/scripts/machines/Macros.freya_intel
@@ -18,7 +18,6 @@ SFC   := ftn
 
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
 CFLAGS     := -c -O2 -fp-model precise
-
 # Additional flags
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
@@ -46,11 +45,6 @@ LDFLAGS    := $(FFLAGS) -v
 # Linker flags
 
 # Additional flags
-
-ifeq ($(DITTO), yes)
-   CPPDEFS :=  $(CPPDEFS) -DREPRODUCIBLE
-endif
-
 
 ifeq ($(ICE_THREADED), true) 
    LDFLAGS += -qopenmp 

--- a/configuration/scripts/options/set_nml.kevp102
+++ b/configuration/scripts/options/set_nml.kevp102
@@ -1,0 +1,1 @@
+kevp_kernel = 102


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
  Remove private variables from OMP loop. They are not used (ilo, jlo, ihi, jhi), added flag to test 1d evp
- [x] Developer(s): 
   tar
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ENTER INFORMATION HERE 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

Cleanup of OMP loop. 