### PR TITLE
Fixes for uninitialized variables (snan testing)

### DIFF
--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -654,9 +654,7 @@
       enddo
       enddo
 
-#ifndef CICE_IN_NEMO
       sst   (:,:,:) = Tf(:,:,:)       ! sea surface temp (C)
-#endif
       qdp   (:,:,:) = c0              ! deep ocean heat flux (W/m^2)
       hmix  (:,:,:) = c20             ! ocean mixed layer depth (m)
       hwater(:,:,:) = bathymetry(:,:,:) ! ocean water depth (m)

--- a/cicecore/cicedynB/infrastructure/comm/mpi/ice_boundary.F90
+++ b/cicecore/cicedynB/infrastructure/comm/mpi/ice_boundary.F90
@@ -41,6 +41,7 @@
    type, public :: ice_halo
       integer (int_kind) ::  &
          communicator,     &! communicator to use for update messages
+         numLocalBlocks,   &! number of local blocks, needed for halo fill
          numMsgSend,       &! number of messages to send halo update
          numMsgRecv,       &! number of messages to recv halo update
          numLocalCopies,   &! num local copies for halo update
@@ -50,6 +51,7 @@
          tripoleTFlag       ! NS boundary is a tripole T-fold
 
       integer (int_kind), dimension(:), pointer :: &
+         blockGlobalID,    &! list of local block global IDs, needed for halo fill
          recvTask,         &! task from which to recv each msg
          sendTask,         &! task to   which to send each msg
          sizeSend,         &! size of each sent message
@@ -219,6 +221,13 @@ contains
    northMsgSize = nghost*blockSizeX
    cornerMsgSize = nghost*nghost
    tripoleRows = nghost+1
+
+   !*** store some block info to fill haloes properly
+   call ice_distributionGet(dist, numLocalBlocks=halo%numLocalBlocks)
+   if (halo%numLocalBlocks > 0) then
+      allocate(halo%blockGlobalID(halo%numLocalBlocks))
+      call ice_distributionGet(dist, blockGlobalID=halo%blockGlobalID)
+   endif
 
    if (nsBoundaryType == 'tripole' .or. nsBoundaryType == 'tripoleT') then
       tripoleTFlag = (nsBoundaryType == 'tripoleT')
@@ -1023,6 +1032,7 @@ contains
       communicator,                &! communicator for message passing
       numMsgSend, numMsgRecv,      &! number of messages for this halo
       numLocalCopies,              &! num local copies for halo update
+      numLocalBlocks,              &! num local blocks for halo fill
       tripoleRows,                 &! number of rows in tripole buffer
       lbufSizeSend,                &! buffer size for send messages
       lbufSizeRecv                  ! buffer size for recv messages
@@ -1043,6 +1053,7 @@ contains
       numMsgSend     = basehalo%numMsgSend
       numMsgRecv     = basehalo%numMsgRecv
       numLocalCopies = basehalo%numLocalCopies
+      numLocalBlocks = basehalo%numLocalBlocks
       lbufSizeSend   = size(basehalo%sendAddr,dim=2)
       lbufSizeRecv   = size(basehalo%recvAddr,dim=2)
 
@@ -1056,6 +1067,7 @@ contains
                halo%recvAddr(3,lbufSizeRecv,numMsgRecv), &
                halo%srcLocalAddr(3,numLocalCopies), &
                halo%dstLocalAddr(3,numLocalCopies), &
+               halo%blockGlobalID(numLocalBlocks), &
                stat = istat)
 
       if (istat > 0) then
@@ -1067,9 +1079,12 @@ contains
       halo%tripoleRows    = tripoleRows
       halo%tripoleTFlag   = tripoleTFlag
       halo%numLocalCopies = numLocalCopies
+      halo%numLocalBlocks = numLocalBlocks
 
       halo%srcLocalAddr   = basehalo%srcLocalAddr(:,1:numLocalCopies)
       halo%dstLocalAddr   = basehalo%dstLocalAddr(:,1:numLocalCopies)
+
+      halo%blockGlobalID  = basehalo%blockGlobalID
 
    numMsgSend = 0
    do nmsg=1,basehalo%numMsgSend
@@ -1176,7 +1191,8 @@ contains
 !-----------------------------------------------------------------------
 
    integer (int_kind) ::           &
-      i,j,n,nmsg,                    &! dummy loop indices
+      i,j,n,nmsg,                &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       iSrc,jSrc,                 &! source addresses for message
@@ -1285,13 +1301,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:) = fill
-      array(1:nx_block,ny_block-j+1,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:) = fill
-      array(nx_block-i+1,1:ny_block,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,iblk) = fill
+         array(1:nx_block, jhi+j,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,iblk) = fill
+         array(ihi+i, 1:ny_block,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -1569,6 +1590,7 @@ contains
 
    integer (int_kind) ::           &
       i,j,n,nmsg,                &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       iSrc,jSrc,                 &! source addresses for message
@@ -1677,13 +1699,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:) = fill
-      array(1:nx_block,ny_block-j+1,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:) = fill
-      array(nx_block-i+1,1:ny_block,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,iblk) = fill
+         array(1:nx_block, jhi+j,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,iblk) = fill
+         array(ihi+i, 1:ny_block,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -1961,6 +1988,7 @@ contains
 
    integer (int_kind) ::           &
       i,j,n,nmsg,                &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       iSrc,jSrc,                 &! source addresses for message
@@ -2069,13 +2097,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:) = fill
-      array(1:nx_block,ny_block-j+1,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:) = fill
-      array(nx_block-i+1,1:ny_block,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,iblk) = fill
+         array(1:nx_block, jhi+j,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,iblk) = fill
+         array(ihi+i, 1:ny_block,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -2353,6 +2386,7 @@ contains
 
    integer (int_kind) ::           &
       i,j,k,n,nmsg,              &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       nz,                        &! size of array in 3rd dimension
@@ -2489,13 +2523,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,:,iblk) = fill
+         array(1:nx_block, jhi+j,:,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,:,iblk) = fill
+         array(ihi+i, 1:ny_block,:,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -2804,6 +2843,7 @@ contains
 
    integer (int_kind) ::           &
       i,j,k,n,nmsg,              &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       nz,                        &! size of array in 3rd dimension
@@ -2940,13 +2980,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,:,iblk) = fill
+         array(1:nx_block, jhi+j,:,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,:,iblk) = fill
+         array(ihi+i, 1:ny_block,:,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -3255,6 +3300,7 @@ contains
 
    integer (int_kind) ::           &
       i,j,k,n,nmsg,              &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       nz,                        &! size of array in 3rd dimension
@@ -3391,13 +3437,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,:,iblk) = fill
+         array(1:nx_block, jhi+j,:,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,:,iblk) = fill
+         array(ihi+i, 1:ny_block,:,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -3706,6 +3757,7 @@ contains
 
    integer (int_kind) ::           &
       i,j,k,l,n,nmsg,            &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       nz, nt,                    &! size of array in 3rd,4th dimensions
@@ -3846,13 +3898,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,:,:,iblk) = fill
+         array(1:nx_block, jhi+j,:,:,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,:,:,iblk) = fill
+         array(ihi+i, 1:ny_block,:,:,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -4181,6 +4238,7 @@ contains
 
    integer (int_kind) ::           &
       i,j,k,l,n,nmsg,            &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       nz, nt,                    &! size of array in 3rd,4th dimensions
@@ -4321,13 +4379,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,:,:,iblk) = fill
+         array(1:nx_block, jhi+j,:,:,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,:,:,iblk) = fill
+         array(ihi+i, 1:ny_block,:,:,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -4656,6 +4719,7 @@ contains
 
    integer (int_kind) ::           &
       i,j,k,l,n,nmsg,            &! dummy loop indices
+      iblk,ilo,ihi,jlo,jhi,      &! block sizes for fill
       ierr,                      &! error or status flag for MPI,alloc
       nxGlobal,                  &! global domain size in x (tripole)
       nz, nt,                    &! size of array in 3rd,4th dimensions
@@ -4796,13 +4860,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:,:) = fill
+   do iblk = 1, halo%numLocalBlocks
+      call get_block_parameter(halo%blockGlobalID(iblk), &
+                               ilo=ilo, ihi=ihi,   &
+                               jlo=jlo, jhi=jhi)
+      do j = 1,nghost
+         array(1:nx_block, jlo-j,:,:,iblk) = fill
+         array(1:nx_block, jhi+j,:,:,iblk) = fill
+      enddo
+      do i = 1,nghost
+         array(ilo-i, 1:ny_block,:,:,iblk) = fill
+         array(ihi+i, 1:ny_block,:,:,iblk) = fill
+      enddo
    enddo
 
 !-----------------------------------------------------------------------
@@ -5232,13 +5301,18 @@ contains
 !  the tripole zipper as needed for stresses.  if you zero
 !  it out, all halo values will be wiped out.
 !-----------------------------------------------------------------------
-!   do j = 1,nghost
-!      array1(1:nx_block,           j,:) = fill
-!      array1(1:nx_block,ny_block-j+1,:) = fill
-!   enddo
-!   do i = 1,nghost
-!      array1(i,           1:ny_block,:) = fill
-!      array1(nx_block-i+1,1:ny_block,:) = fill
+!   do iblk = 1, halo%numLocalBlocks
+!      call get_block_parameter(halo%blockGlobalID(iblk), &
+!                               ilo=ilo, ihi=ihi,   &
+!                               jlo=jlo, jhi=jhi)
+!      do j = 1,nghost
+!         array(1:nx_block, jlo-j,iblk) = fill
+!         array(1:nx_block, jhi+j,iblk) = fill
+!      enddo
+!      do i = 1,nghost
+!         array(ilo-i, 1:ny_block,iblk) = fill
+!         array(ihi+i, 1:ny_block,iblk) = fill
+!      enddo
 !   enddo
 
 !-----------------------------------------------------------------------
@@ -6715,20 +6789,20 @@ contains
    character(len=*), parameter :: subname = '(ice_HaloDestroy)'
 !-----------------------------------------------------------------------
 
-   deallocate(halo%sendTask, stat=istat)
-   deallocate(halo%recvTask, stat=istat)
-   deallocate(halo%sizeSend, stat=istat)
-   deallocate(halo%sizeRecv, stat=istat)
-   deallocate(halo%tripSend, stat=istat)
-   deallocate(halo%tripRecv, stat=istat)
-   deallocate(halo%srcLocalAddr, stat=istat)
-   deallocate(halo%dstLocalAddr, stat=istat)
-   deallocate(halo%sendAddr, stat=istat)
-   deallocate(halo%recvAddr, stat=istat)
+   deallocate(halo%sendTask, &
+              halo%recvTask, &
+              halo%sizeSend, &
+              halo%sizeRecv, &
+              halo%tripSend, &
+              halo%tripRecv, &
+              halo%srcLocalAddr, &
+              halo%dstLocalAddr, &
+              halo%sendAddr, &
+              halo%recvAddr, &
+              halo%blockGlobalID, stat=istat)
 
    if (istat > 0) then
-      call abort_ice( &
-         'ice_HaloDestroy: error deallocating')
+      call abort_ice(subname,' ERROR: deallocating')
       return
    endif
 end subroutine ice_HaloDestroy

--- a/cicecore/cicedynB/infrastructure/ice_blocks.F90
+++ b/cicecore/cicedynB/infrastructure/ice_blocks.F90
@@ -252,8 +252,8 @@ contains
             !*** set last physical point if padded domain
 
             else if (j_global(j,n) == ny_global .and. &
-                     j > all_blocks(n)%jlo      .and. &
-                     j < all_blocks(n)%jhi) then
+                     j >= all_blocks(n)%jlo      .and. &
+                     j <  all_blocks(n)%jhi) then
                all_blocks(n)%jhi = j   ! last physical point in padded domain
             endif
          end do
@@ -300,8 +300,8 @@ contains
             !*** last physical point in padded domain
 
             else if (i_global(i,n) == nx_global .and. &
-                     i > all_blocks(n)%ilo      .and. &
-                     i < all_blocks(n)%ihi) then
+                     i >= all_blocks(n)%ilo      .and. &
+                     i <  all_blocks(n)%ihi) then
                all_blocks(n)%ihi = i
             endif
          end do

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -384,7 +384,7 @@
       ! T-grid cell and U-grid cell quantities
       !-----------------------------------------------------------------
 
-!     tarea(:,:,:) = c0
+      tarea(:,:,:) = c0
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -1636,7 +1636,7 @@
       !-----------------------------------------------------------------
 
       bm = c0
-!     uvm = c0
+      uvm = c0
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -2401,7 +2401,8 @@
          do iblk = 1, nblocks
             do j = 1, ny_block
             do i = 1, nx_block
-               k = min(nint(kmt(i,j,iblk)),nlevel)
+               k = nint(kmt(i,j,iblk))
+               if (k > nlevel) call abort_ice(subname//' kmt gt nlevel error')
                if (k > puny) bathymetry(i,j,iblk) = depth(k)
             enddo
             enddo
@@ -2492,8 +2493,8 @@
       do iblk = 1, nblocks
          do j = 1, ny_block
          do i = 1, nx_block
-            k = kmt(i,j,iblk)
-            if (k > nlevel) call abort_ice(subname//' kmt/nlevel error')
+            k = nint(kmt(i,j,iblk))
+            if (k > nlevel) call abort_ice(subname//' kmt gt nlevel error')
             if (k > 0) bathymetry(i,j,iblk) = depth(k)
          enddo
          enddo

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -384,9 +384,6 @@
       ! T-grid cell and U-grid cell quantities
       !-----------------------------------------------------------------
 
-! tcraig, tcx, this is temporary, see https://github.com/CICE-Consortium/CICE/issues/572
-      tarea(:,:,:) = c0
-
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
          this_block = get_block(blocks_ice(iblk),iblk)
@@ -1637,8 +1634,6 @@
       !-----------------------------------------------------------------
 
       bm = c0
-! tcraig, tcx, this is temporary, see https://github.com/CICE-Consortium/CICE/issues/572
-      uvm = c0
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
@@ -1673,11 +1668,11 @@
          jlo = this_block%jlo
          jhi = this_block%jhi
 
-         ! needs to cover halo OR need a halo update
-         do j = 1, ny_block
-         do i = 1, nx_block
-            tmask(i,j,iblk) = .false.
-            umask(i,j,iblk) = .false.
+         ! needs to cover halo (no halo update for logicals)
+         tmask(:,:,iblk) = .false.
+         umask(:,:,iblk) = .false.
+         do j = jlo-nghost, jhi+nghost
+         do i = ilo-nghost, ihi+nghost
             if ( hm(i,j,iblk) > p5) tmask(i,j,iblk) = .true.
             if (uvm(i,j,iblk) > p5) umask(i,j,iblk) = .true.
          enddo

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -1196,15 +1196,9 @@
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)
 
-      !$OMP PARALLEL DO PRIVATE(iblk,i,j)
-      do iblk = 1, nblocks
-         do j = 1, ny_block
-         do i = 1, nx_block
-            ANGLE(i,j,iblk) = c0              ! "square with the world"
-         enddo
-         enddo
-      enddo
-      !$OMP END PARALLEL DO
+      hm (:,:,:) = c0
+      kmt(:,:,:) = c0
+      angle(:,:,:) = c0   ! "square with the world"
 
       allocate(work_g1(nx_global,ny_global))
 

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -2403,7 +2403,7 @@
             do i = 1, nx_block
                k = nint(kmt(i,j,iblk))
                if (k > nlevel) call abort_ice(subname//' kmt gt nlevel error')
-               if (k > puny) bathymetry(i,j,iblk) = depth(k)
+               if (k > 0) bathymetry(i,j,iblk) = depth(k)
             enddo
             enddo
          enddo

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -26,7 +26,7 @@
       use ice_domain, only: blocks_ice, nblocks, halo_info, distrb_info, &
           ew_boundary_type, ns_boundary_type, init_domain_distribution
       use ice_fileunits, only: nu_diag, nu_grid, nu_kmt, &
-          get_fileunit, release_fileunit
+          get_fileunit, release_fileunit, flush_fileunit
       use ice_gather_scatter, only: gather_global, scatter_global
       use ice_read_write, only: ice_read, ice_read_nc, ice_read_global, &
           ice_read_global_nc, ice_open, ice_open_nc, ice_close_nc
@@ -384,11 +384,12 @@
       ! T-grid cell and U-grid cell quantities
       !-----------------------------------------------------------------
 
+! tcraig, tcx, this is temporary, see https://github.com/CICE-Consortium/CICE/issues/572
       tarea(:,:,:) = c0
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -486,7 +487,7 @@
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block, &
       !$OMP                     angle_0,angle_w,angle_s,angle_sw)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -642,7 +643,7 @@
       kmt(:,:,:) = c0
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -785,7 +786,7 @@
       kmt(:,:,:) = c0
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -1104,7 +1105,7 @@
 
      !$OMP PARALLEL DO PRIVATE(iblk,this_block,ilo,ihi,jlo,jhi,i,j)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -1396,7 +1397,7 @@
       kmt(:,:,:) = c0
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -1636,11 +1637,12 @@
       !-----------------------------------------------------------------
 
       bm = c0
+! tcraig, tcx, this is temporary, see https://github.com/CICE-Consortium/CICE/issues/572
       uvm = c0
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -1663,8 +1665,15 @@
                            field_loc_center, field_type_scalar)
       call ice_timer_stop(timer_bound)
 
-      !$OMP PARALLEL DO PRIVATE(iblk,i,j)
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
+         this_block = get_block(blocks_ice(iblk),iblk)
+         ilo = this_block%ilo
+         ihi = this_block%ihi
+         jlo = this_block%jlo
+         jhi = this_block%jhi
+
+         ! needs to cover halo OR need a halo update
          do j = 1, ny_block
          do i = 1, nx_block
             tmask(i,j,iblk) = .false.
@@ -1684,11 +1693,14 @@
          tarean(:,:,iblk) = c0
          tareas(:,:,iblk) = c0
 
-         do j = 1, ny_block
-         do i = 1, nx_block
+         do j = jlo,jhi
+         do i = ilo,ihi
 
-            if (ULAT(i,j,iblk) >= -puny) lmask_n(i,j,iblk) = .true. ! N. Hem.
-            if (ULAT(i,j,iblk) <  -puny) lmask_s(i,j,iblk) = .true. ! S. Hem.
+            if (ULAT(i,j,iblk) >= -puny) then
+               lmask_n(i,j,iblk) = .true. ! N. Hem.
+            else
+               lmask_s(i,j,iblk) = .true. ! S. Hem.
+            endif
 
             ! N hemisphere area mask (m^2)
             if (lmask_n(i,j,iblk)) tarean(i,j,iblk) = tarea(i,j,iblk) &
@@ -1743,7 +1755,7 @@
       !$OMP                     x1,y1,z1,x2,y2,z2,x3,y3,z3,x4,y4,z4, &
       !$OMP                     tx,ty,tz,da)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -1915,7 +1927,7 @@
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -2000,7 +2012,7 @@
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo
@@ -2073,7 +2085,7 @@
 
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
       do iblk = 1, nblocks
-         this_block = get_block(blocks_ice(iblk),iblk)         
+         this_block = get_block(blocks_ice(iblk),iblk)
          ilo = this_block%ilo
          ihi = this_block%ihi
          jlo = this_block%jlo

--- a/cicecore/cicedynB/infrastructure/ice_restoring.F90
+++ b/cicecore/cicedynB/infrastructure/ice_restoring.F90
@@ -98,6 +98,11 @@
              vsnon_rest(nx_block,ny_block,ncat,max_blocks), &
              trcrn_rest(nx_block,ny_block,ntrcr,ncat,max_blocks))
 
+   aicen_rest(:,:,:,:) = c0
+   vicen_rest(:,:,:,:) = c0
+   vsnon_rest(:,:,:,:) = c0
+   trcrn_rest(:,:,:,:,:) = c0
+
 !-----------------------------------------------------------------------
 ! initialize
 ! halo cells have to be filled manually at this stage

--- a/cicecore/drivers/standalone/cice/CICE_RunMod.F90
+++ b/cicecore/drivers/standalone/cice/CICE_RunMod.F90
@@ -628,11 +628,12 @@
       
       real (kind=dbl_kind)    :: &
           puny, &          !
+          Lsub, &          !
           rLsub            ! 1/Lsub
 
       character(len=*), parameter :: subname = '(sfcflux_to_ocn)'
 
-      call icepack_query_parameters(puny_out=puny)
+      call icepack_query_parameters(puny_out=puny, Lsub_out=Lsub)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)

--- a/cicecore/shared/ice_init_column.F90
+++ b/cicecore/shared/ice_init_column.F90
@@ -408,7 +408,7 @@
          do i = ilo, ihi
 
                if (aicen(i,j,n,iblk) > puny) then
-                  
+
                   alvdf(i,j,iblk) = alvdf(i,j,iblk) &
                        + alvdfn(i,j,n,iblk)*aicen(i,j,n,iblk)
                   alidf(i,j,iblk) = alidf(i,j,iblk) &
@@ -417,7 +417,7 @@
                        + alvdrn(i,j,n,iblk)*aicen(i,j,n,iblk)
                   alidr(i,j,iblk) = alidr(i,j,iblk) &
                        + alidrn(i,j,n,iblk)*aicen(i,j,n,iblk)
-                  
+
                   netsw = swvdr(i,j,iblk) + swidr(i,j,iblk) &
                         + swvdf(i,j,iblk) + swidf(i,j,iblk)
                   if (netsw > puny) then ! sun above horizon
@@ -428,12 +428,12 @@
                      albpnd(i,j,iblk) = albpnd(i,j,iblk) &
                           + albpndn(i,j,n,iblk)*aicen(i,j,n,iblk)
                   endif
-                  
+
                   apeff_ai(i,j,iblk) = apeff_ai(i,j,iblk) &
                        + apeffn(i,j,n,iblk)*aicen(i,j,n,iblk)
                   snowfrac(i,j,iblk) = snowfrac(i,j,iblk) &
                        + snowfracn(i,j,n,iblk)*aicen(i,j,n,iblk)
-               
+
                endif ! aicen > puny
 
          enddo ! i

--- a/cicecore/shared/ice_spacecurve.F90
+++ b/cicecore/shared/ice_spacecurve.F90
@@ -1245,10 +1245,10 @@ contains
       integer (int_kind) :: i
       character(len=*),parameter :: subname='(PrintFactor)'
 
-      write(*,*) subname,' '
-      write(*,*) subname,'msg = ',trim(msg)
-      write(*,*) subname,(fac%factors(i),i=1,fac%numfact)
-      write(*,*) subname,(fac%used(i),i=1,fac%numfact)
+      write(nu_diag,*) subname,' '
+      write(nu_diag,*) subname,'msg = ',trim(msg)
+      write(nu_diag,*) subname,(fac%factors(i),i=1,fac%numfact)
+      write(nu_diag,*) subname,(fac%used(i),i=1,fac%numfact)
 
 
    end subroutine PrintFactor
@@ -1448,6 +1448,9 @@ contains
    maxdim=d
    vcnt=0
 
+   ! tcx, if l is 0, then fact has no factors, just return
+   if (l == 0) return
+
    type = fact%factors(l)
    ierr = GenCurve(l,type,0,1,0,1)
 
@@ -1492,113 +1495,113 @@ contains
 
      gridsize = SIZE(Mesh,dim=1)
 
-     write(*,*) subname,":"
+     write(nu_diag,*) subname,":"
 
      if(gridsize == 2) then
-        write (*,*) "A Level 1 Hilbert Curve:"
-        write (*,*) "------------------------"
+        write (nu_diag,*) "A Level 1 Hilbert Curve:"
+        write (nu_diag,*) "------------------------"
         do i=1,gridsize
-           write(*,2) Mesh(1,i),Mesh(2,i)
+           write(nu_diag,2) Mesh(1,i),Mesh(2,i)
         enddo
      else if(gridsize == 3) then
-        write (*,*) "A Level 1 Peano Meandering Curve:"
-        write (*,*) "---------------------------------"
+        write (nu_diag,*) "A Level 1 Peano Meandering Curve:"
+        write (nu_diag,*) "---------------------------------"
         do i=1,gridsize
-           write(*,3) Mesh(1,i),Mesh(2,i),Mesh(3,i)
+           write(nu_diag,3) Mesh(1,i),Mesh(2,i),Mesh(3,i)
         enddo
      else if(gridsize == 4) then
-        write (*,*) "A Level 2 Hilbert Curve:"
-        write (*,*) "------------------------"
+        write (nu_diag,*) "A Level 2 Hilbert Curve:"
+        write (nu_diag,*) "------------------------"
         do i=1,gridsize
-           write(*,4) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i)
+           write(nu_diag,4) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i)
         enddo
      else if(gridsize == 5) then
-        write (*,*) "A Level 1 Cinco Curve:"
-        write (*,*) "------------------------"
+        write (nu_diag,*) "A Level 1 Cinco Curve:"
+        write (nu_diag,*) "------------------------"
         do i=1,gridsize
-           write(*,5) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i),Mesh(5,i)
+           write(nu_diag,5) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i),Mesh(5,i)
         enddo
      else if(gridsize == 6) then
-        write (*,*) "A Level 1 Hilbert and Level 1 Peano Curve:"
-        write (*,*) "------------------------------------------"
+        write (nu_diag,*) "A Level 1 Hilbert and Level 1 Peano Curve:"
+        write (nu_diag,*) "------------------------------------------"
         do i=1,gridsize
-           write(*,6) Mesh(1,i),Mesh(2,i),Mesh(3,i), &
+           write(nu_diag,6) Mesh(1,i),Mesh(2,i),Mesh(3,i), &
                       Mesh(4,i),Mesh(5,i),Mesh(6,i)
         enddo
      else if(gridsize == 8) then
-        write (*,*) "A Level 3 Hilbert Curve:"
-        write (*,*) "------------------------"
+        write (nu_diag,*) "A Level 3 Hilbert Curve:"
+        write (nu_diag,*) "------------------------"
         do i=1,gridsize
-           write(*,8) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
+           write(nu_diag,8) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
                       Mesh(5,i),Mesh(6,i),Mesh(7,i),Mesh(8,i)
          enddo
      else if(gridsize == 9) then
-        write (*,*) "A Level 2 Peano Meandering Curve:"
-        write (*,*) "---------------------------------"
+        write (nu_diag,*) "A Level 2 Peano Meandering Curve:"
+        write (nu_diag,*) "---------------------------------"
         do i=1,gridsize
-           write(*,9) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
+           write(nu_diag,9) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
                       Mesh(5,i),Mesh(6,i),Mesh(7,i),Mesh(8,i), &
                       Mesh(9,i)
          enddo
      else if(gridsize == 10) then
-        write (*,*) "A Level 1 Hilbert and Level 1 Cinco Curve:"
-        write (*,*) "---------------------------------"
+        write (nu_diag,*) "A Level 1 Hilbert and Level 1 Cinco Curve:"
+        write (nu_diag,*) "---------------------------------"
         do i=1,gridsize
-           write(*,10) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
+           write(nu_diag,10) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
                       Mesh(5,i),Mesh(6,i),Mesh(7,i),Mesh(8,i), &
                       Mesh(9,i),Mesh(10,i)
          enddo
      else if(gridsize == 12) then
-        write (*,*) "A Level 2 Hilbert and Level 1 Peano Curve:"
-        write (*,*) "------------------------------------------"
+        write (nu_diag,*) "A Level 2 Hilbert and Level 1 Peano Curve:"
+        write (nu_diag,*) "------------------------------------------"
         do i=1,gridsize
-           write(*,12) Mesh(1,i),Mesh(2,i), Mesh(3,i), Mesh(4,i), &
+           write(nu_diag,12) Mesh(1,i),Mesh(2,i), Mesh(3,i), Mesh(4,i), &
                        Mesh(5,i),Mesh(6,i), Mesh(7,i), Mesh(8,i), &
                        Mesh(9,i),Mesh(10,i),Mesh(11,i),Mesh(12,i)
         enddo
      else if(gridsize == 15) then
-        write (*,*) "A Level 1 Peano and Level 1 Cinco Curve:"
-        write (*,*) "------------------------"
+        write (nu_diag,*) "A Level 1 Peano and Level 1 Cinco Curve:"
+        write (nu_diag,*) "------------------------"
         do i=1,gridsize
-           write(*,15) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
+           write(nu_diag,15) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
                        Mesh(5,i),Mesh(6,i),Mesh(7,i),Mesh(8,i), &
                        Mesh(9,i),Mesh(10,i),Mesh(11,i),Mesh(12,i), &
                        Mesh(13,i),Mesh(14,i),Mesh(15,i)
         enddo
      else if(gridsize == 16) then
-        write (*,*) "A Level 4 Hilbert Curve:"
-        write (*,*) "------------------------"
+        write (nu_diag,*) "A Level 4 Hilbert Curve:"
+        write (nu_diag,*) "------------------------"
         do i=1,gridsize
-           write(*,16) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
+           write(nu_diag,16) Mesh(1,i),Mesh(2,i),Mesh(3,i),Mesh(4,i), &
                        Mesh(5,i),Mesh(6,i),Mesh(7,i),Mesh(8,i), &
                        Mesh(9,i),Mesh(10,i),Mesh(11,i),Mesh(12,i), &
                        Mesh(13,i),Mesh(14,i),Mesh(15,i),Mesh(16,i)
         enddo
      else if(gridsize == 18) then
-        write (*,*) "A Level 1 Hilbert and Level 2 Peano Curve:"
-        write (*,*) "------------------------------------------"
+        write (nu_diag,*) "A Level 1 Hilbert and Level 2 Peano Curve:"
+        write (nu_diag,*) "------------------------------------------"
         do i=1,gridsize
-           write(*,18) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
+           write(nu_diag,18) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
                        Mesh(5,i), Mesh(6,i), Mesh(7,i), Mesh(8,i), &
                        Mesh(9,i), Mesh(10,i),Mesh(11,i),Mesh(12,i), &
                        Mesh(13,i),Mesh(14,i),Mesh(15,i),Mesh(16,i), &
                        Mesh(17,i),Mesh(18,i)
         enddo
      else if(gridsize == 20) then
-        write (*,*) "A Level 2 Hilbert and Level 1 Cinco Curve:"
-        write (*,*) "------------------------------------------"
+        write (nu_diag,*) "A Level 2 Hilbert and Level 1 Cinco Curve:"
+        write (nu_diag,*) "------------------------------------------"
         do i=1,gridsize
-           write(*,20) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
+           write(nu_diag,20) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
                        Mesh(5,i), Mesh(6,i), Mesh(7,i), Mesh(8,i), &
                        Mesh(9,i), Mesh(10,i),Mesh(11,i),Mesh(12,i), &
                        Mesh(13,i),Mesh(14,i),Mesh(15,i),Mesh(16,i), &
                        Mesh(17,i),Mesh(18,i),Mesh(19,i),Mesh(20,i)
         enddo
      else if(gridsize == 24) then
-        write (*,*) "A Level 3 Hilbert and Level 1 Peano Curve:"
-        write (*,*) "------------------------------------------"
+        write (nu_diag,*) "A Level 3 Hilbert and Level 1 Peano Curve:"
+        write (nu_diag,*) "------------------------------------------"
         do i=1,gridsize
-           write(*,24) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
+           write(nu_diag,24) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
                        Mesh(5,i), Mesh(6,i), Mesh(7,i), Mesh(8,i), &
                        Mesh(9,i), Mesh(10,i),Mesh(11,i),Mesh(12,i), &
                        Mesh(13,i),Mesh(14,i),Mesh(15,i),Mesh(16,i), &
@@ -1606,10 +1609,10 @@ contains
                        Mesh(21,i),Mesh(22,i),Mesh(23,i),Mesh(24,i)
         enddo
      else if(gridsize == 25) then
-        write (*,*) "A Level 2 Cinco Curve:"
-        write (*,*) "------------------------------------------"
+        write (nu_diag,*) "A Level 2 Cinco Curve:"
+        write (nu_diag,*) "------------------------------------------"
         do i=1,gridsize
-           write(*,25) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
+           write(nu_diag,25) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
                        Mesh(5,i), Mesh(6,i), Mesh(7,i), Mesh(8,i), &
                        Mesh(9,i), Mesh(10,i),Mesh(11,i),Mesh(12,i), &
                        Mesh(13,i),Mesh(14,i),Mesh(15,i),Mesh(16,i), &
@@ -1618,10 +1621,10 @@ contains
                        Mesh(25,i)
         enddo
      else if(gridsize == 27) then
-        write (*,*) "A Level 3 Peano Meandering Curve:"
-        write (*,*) "---------------------------------"
+        write (nu_diag,*) "A Level 3 Peano Meandering Curve:"
+        write (nu_diag,*) "---------------------------------"
         do i=1,gridsize
-           write(*,27) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
+           write(nu_diag,27) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i), &
                        Mesh(5,i), Mesh(6,i), Mesh(7,i), Mesh(8,i), &
                        Mesh(9,i), Mesh(10,i),Mesh(11,i),Mesh(12,i), &
                        Mesh(13,i),Mesh(14,i),Mesh(15,i),Mesh(16,i), &
@@ -1630,10 +1633,10 @@ contains
                        Mesh(25,i),Mesh(26,i),Mesh(27,i)
         enddo
      else if(gridsize == 32) then
-        write (*,*) "A Level 5 Hilbert Curve:"
-        write (*,*) "------------------------"
+        write (nu_diag,*) "A Level 5 Hilbert Curve:"
+        write (nu_diag,*) "------------------------"
         do i=1,gridsize
-           write(*,32) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i),  &
+           write(nu_diag,32) Mesh(1,i), Mesh(2,i), Mesh(3,i), Mesh(4,i),  &
                        Mesh(5,i), Mesh(6,i), Mesh(7,i), Mesh(8,i),  &
                        Mesh(9,i), Mesh(10,i),Mesh(11,i),Mesh(12,i), &
                        Mesh(13,i),Mesh(14,i),Mesh(15,i),Mesh(16,i), &
@@ -1711,7 +1714,13 @@ contains
    fact     = factor(gridsize)
    level    = fact%numfact
 
-   if(verbose) print *,'GenSpacecurve: level is ',level
+   if (verbose) then
+      write(nu_diag,*) subname,'chk1',dim,gridsize
+      write(nu_diag,*) subname,'chk2',level
+      call printfactor(subname//' chk3 ',fact)
+      call flush_fileunit(nu_diag)
+   endif
+
    allocate(ordered(gridsize,gridsize))
 
    !--------------------------------------------

--- a/configuration/scripts/machines/Macros.banting_intel
+++ b/configuration/scripts/machines/Macros.banting_intel
@@ -13,7 +13,7 @@ FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceb
 #-xHost
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created
+  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 # -heap-arrays 1024 
 else
   FFLAGS     += -O2

--- a/configuration/scripts/machines/Macros.cheyenne_gnu
+++ b/configuration/scripts/machines/Macros.cheyenne_gnu
@@ -12,7 +12,8 @@ FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+#  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+  FFLAGS   += -O0 -g -fcheck=all -finit-real=snan -fimplicit-none -ffpe-trap=invalid,zero,overflow
   CFLAGS   += -O0
 endif
 

--- a/configuration/scripts/machines/Macros.cheyenne_gnu
+++ b/configuration/scripts/machines/Macros.cheyenne_gnu
@@ -12,8 +12,8 @@ FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-#  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-  FFLAGS   += -O0 -g -fcheck=all -finit-real=snan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+#  FFLAGS   += -O0 -g -fcheck=all -finit-real=snan -fimplicit-none -ffpe-trap=invalid,zero,overflow
   CFLAGS   += -O0
 endif
 

--- a/configuration/scripts/machines/Macros.cheyenne_intel
+++ b/configuration/scripts/machines/Macros.cheyenne_intel
@@ -12,7 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
+  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays -link_mpi=dbg
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.cheyenne_intel
+++ b/configuration/scripts/machines/Macros.cheyenne_intel
@@ -13,7 +13,8 @@ FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
 #  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
-  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays -link_mpi=dbg
+  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -link_mpi=dbg
+#  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays -link_mpi=dbg
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.daley_intel
+++ b/configuration/scripts/machines/Macros.daley_intel
@@ -13,7 +13,7 @@ FFLAGS     := -fp-model source -convert big_endian -assume byterecl -ftz -traceb
 #-xHost
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created
+  FFLAGS     += -O0 -g -check -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 # -heap-arrays 1024 
 else
   FFLAGS     += -O2

--- a/configuration/scripts/machines/Macros.gaffney_intel
+++ b/configuration/scripts/machines/Macros.gaffney_intel
@@ -12,8 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.gaffney_intel
+++ b/configuration/scripts/machines/Macros.gaffney_intel
@@ -12,8 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -init=snan,arrays
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.koehr_intel
+++ b/configuration/scripts/machines/Macros.koehr_intel
@@ -12,8 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.koehr_intel
+++ b/configuration/scripts/machines/Macros.koehr_intel
@@ -12,8 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -init=snan,arrays
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.mustang_intel18
+++ b/configuration/scripts/machines/Macros.mustang_intel18
@@ -12,8 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.mustang_intel18
+++ b/configuration/scripts/machines/Macros.mustang_intel18
@@ -12,7 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.mustang_intel19
+++ b/configuration/scripts/machines/Macros.mustang_intel19
@@ -12,8 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-else
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrayselse
   FFLAGS     += -O2
 endif
 

--- a/configuration/scripts/machines/Macros.mustang_intel19
+++ b/configuration/scripts/machines/Macros.mustang_intel19
@@ -12,8 +12,9 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrayselse
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
+else
   FFLAGS     += -O2
 endif
 

--- a/configuration/scripts/machines/Macros.mustang_intel20
+++ b/configuration/scripts/machines/Macros.mustang_intel20
@@ -12,8 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-else
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrayselse
   FFLAGS     += -O2
 endif
 

--- a/configuration/scripts/machines/Macros.mustang_intel20
+++ b/configuration/scripts/machines/Macros.mustang_intel20
@@ -12,8 +12,9 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
-  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrayselse
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
+else
   FFLAGS     += -O2
 endif
 

--- a/configuration/scripts/machines/Macros.onyx_intel
+++ b/configuration/scripts/machines/Macros.onyx_intel
@@ -12,7 +12,7 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.onyx_intel
+++ b/configuration/scripts/machines/Macros.onyx_intel
@@ -12,7 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/env.cheyenne_gnu
+++ b/configuration/scripts/machines/env.cheyenne_gnu
@@ -31,6 +31,9 @@ endif
 
 endif
 
+limit coredumpsize unlimited
+limit stacksize unlimited
+
 setenv ICE_MACHINE_MACHNAME cheyenne
 setenv ICE_MACHINE_MACHINFO "SGI ICE XA Xeon E5-2697V4 Broadwell"
 setenv ICE_MACHINE_ENVNAME gnu

--- a/configuration/scripts/machines/env.cheyenne_intel
+++ b/configuration/scripts/machines/env.cheyenne_intel
@@ -31,6 +31,9 @@ endif
 
 endif
 
+limit coredumpsize unlimited
+limit stacksize unlimited
+
 setenv ICE_MACHINE_MACHNAME cheyenne
 setenv ICE_MACHINE_MACHINFO "SGI ICE XA Xeon E5-2697V4 Broadwell"
 setenv ICE_MACHINE_ENVNAME intel

--- a/configuration/scripts/machines/env.cheyenne_pgi
+++ b/configuration/scripts/machines/env.cheyenne_pgi
@@ -31,6 +31,9 @@ endif
 
 endif
 
+limit coredumpsize unlimited
+limit stacksize unlimited
+
 setenv ICE_MACHINE_MACHNAME cheyenne
 setenv ICE_MACHINE_MACHINFO "SGI ICE XA Xeon E5-2697V4 Broadwell"
 setenv ICE_MACHINE_ENVNAME pgi

--- a/configuration/scripts/tests/decomp_suite.ts
+++ b/configuration/scripts/tests/decomp_suite.ts
@@ -15,6 +15,9 @@ restart        gx3     8x2x8x10x20   droundrobin,maskhalo   restart_gx3_4x2x25x2
 restart        gx3     1x4x25x29x16  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     1x8x30x20x32  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     1x1x120x125x1 droundrobin,thread restart_gx3_4x2x25x29x4_dslenderX2
+restart        gx3     16x2x1x1x800  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
+restart        gx3     16x2x2x2x200  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
+restart        gx3     16x2x3x3x100  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
 
 smoke        gx3     4x2x25x29x4   debug,run2day,dslenderX2
 smoke        gx3     1x1x25x58x8   debug,run2day,droundrobin,thread smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
@@ -30,4 +33,7 @@ smoke        gx3     8x2x8x10x20   debug,run2day,droundrobin,maskhalo   smoke_gx
 smoke        gx3     1x6x25x29x16  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     1x8x30x20x32  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     1x1x120x125x1 debug,run2day,droundrobin,thread smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     16x2x1x1x800  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     16x2x2x2x200  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     16x2x3x3x100  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 

--- a/configuration/scripts/tests/decomp_suite.ts
+++ b/configuration/scripts/tests/decomp_suite.ts
@@ -7,11 +7,14 @@ restart        gx3     4x1x25x116x1  dslenderX1,thread  restart_gx3_4x2x25x29x4_
 restart        gx3     6x2x4x29x18   dspacecurve        restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     8x2x8x10x20   droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     6x2x50x58x1   droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
+restart        gx3     5x2x33x23x4   droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     4x2x19x19x10  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     1x20x5x29x80  dsectrobin,short   restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     16x2x5x10x20  drakeX2            restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     8x2x8x10x20   droundrobin,maskhalo   restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     1x4x25x29x16  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
+restart        gx3     1x8x30x20x32  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
+restart        gx3     1x1x120x125x1 droundrobin,thread restart_gx3_4x2x25x29x4_dslenderX2
 
 smoke        gx3     4x2x25x29x4   debug,run2day,dslenderX2
 smoke        gx3     1x1x25x58x8   debug,run2day,droundrobin,thread smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
@@ -19,9 +22,12 @@ smoke        gx3     20x1x5x116x1  debug,run2day,dslenderX1,thread  smoke_gx3_4x
 smoke        gx3     6x2x4x29x18   debug,run2day,dspacecurve        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     8x2x10x12x16  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     6x2x50x58x1   debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     5x2x33x23x4   debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     4x2x19x19x10  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     1x20x5x29x80  debug,run2day,dsectrobin,short   smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     16x2x5x10x20  debug,run2day,drakeX2            smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     8x2x8x10x20   debug,run2day,droundrobin,maskhalo   smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 smoke        gx3     1x6x25x29x16  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     1x8x30x20x32  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     1x1x120x125x1 debug,run2day,droundrobin,thread smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
 

--- a/configuration/scripts/tests/decomp_suite.ts
+++ b/configuration/scripts/tests/decomp_suite.ts
@@ -13,3 +13,15 @@ restart        gx3     16x2x5x10x20  drakeX2            restart_gx3_4x2x25x29x4_
 restart        gx3     8x2x8x10x20   droundrobin,maskhalo   restart_gx3_4x2x25x29x4_dslenderX2
 restart        gx3     1x4x25x29x16  droundrobin        restart_gx3_4x2x25x29x4_dslenderX2
 
+smoke        gx3     4x2x25x29x4   debug,run2day,dslenderX2
+smoke        gx3     1x1x25x58x8   debug,run2day,droundrobin,thread smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     20x1x5x116x1  debug,run2day,dslenderX1,thread  smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     6x2x4x29x18   debug,run2day,dspacecurve        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     8x2x10x12x16  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     6x2x50x58x1   debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     4x2x19x19x10  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     1x20x5x29x80  debug,run2day,dsectrobin,short   smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     16x2x5x10x20  debug,run2day,drakeX2            smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     8x2x8x10x20   debug,run2day,droundrobin,maskhalo   smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+smoke        gx3     1x6x25x29x16  debug,run2day,droundrobin        smoke_gx3_4x2x25x29x4_debug_dslenderX2_run2day
+


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    This fixes a handful of issues trapped by snan debug testing.  See #572, #560
- [X] Developer(s): 
    phil-blain, apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    bit-for-bit full test suite on cheyenne 3 compilers, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#eec256efb85e5206cd6e7745188e2c44a093c028
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [X] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

This replaces #560.

See also #572, #247 

This fixes several issues found by turning on snan debug tests with the intel/gnu compilers.  There are still outstanding issues, so snan is not out by default.  This fixes

- adds several tests including decomp tests with debug on, padded decomp with 1 active gridcell width in i and j directions, a 1x1 decomp test, and some serial decomp tests.
- fixes fill of halo in haloupdate.  was not working corrected for padded blocks.  required storing some additional information in the halo datatype at initialization.
- fixes issues with uvm and tarea, fixed by haloupdate fill.
- pulls in fixes from #560 (sst initiallization, Lsub initialization)
- fixes a bug in the size 1 padded grid cell decomp (ice_blocks)
- fixes a spacecurve issue
- adds snan debug options for several machines, but many still commented out due to outstanding issues.