### PR TITLE
Add `iceruf` to namelist

### DIFF
--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -126,7 +126,7 @@
         mu_rdg, hs0, dpscale, rfracmin, rfracmax, pndaspect, hs1, hp1, &
         a_rapid_mode, Rac_rapid_mode, aspect_rapid_mode, dSdt_slow_mode, &
         phi_c_slow_mode, phi_i_mushy, kalg, atmiter_conv, Pstar, Cstar, &
-        sw_frac, sw_dtemp, floediam, hfrazilmin
+        sw_frac, sw_dtemp, floediam, hfrazilmin, iceruf
 
       integer (kind=int_kind) :: ktherm, kstrength, krdg_partic, krdg_redist, natmiter, &
         kitd, kcatbound, ktransport
@@ -226,7 +226,7 @@
       namelist /forcing_nml/ &
         formdrag,       atmbndy,         calc_strair,   calc_Tsfc,      &
         highfreq,       natmiter,        atmiter_conv,                  &
-        ustar_min,      emissivity,                                     &
+        ustar_min,      emissivity,      iceruf,                        &
         fbot_xfer_type, update_ocn_f,    l_mpond_fresh, tfrz_option,    &
         oceanmixed_ice, restore_ice,     restore_ocn,   trestore,       &
         precip_units,   default_season,  wave_spec_type,nfreq,          &
@@ -376,6 +376,7 @@
       calc_Tsfc = .true.     ! calculate surface temperature
       update_ocn_f = .false. ! include fresh water and salt fluxes for frazil
       ustar_min = 0.005      ! minimum friction velocity for ocean heat flux (m/s)
+      iceruf = 0.0005_dbl_kind ! ice surface roughness at atmosphere interface (m)
       emissivity = 0.985     ! emissivity of snow and ice
       l_mpond_fresh = .false.     ! logical switch for including meltpond freshwater
                                   ! flux feedback to ocean model
@@ -732,6 +733,7 @@
       call broadcast_scalar(update_ocn_f,         master_task)
       call broadcast_scalar(l_mpond_fresh,        master_task)
       call broadcast_scalar(ustar_min,            master_task)
+      call broadcast_scalar(iceruf,               master_task)
       call broadcast_scalar(emissivity,           master_task)
       call broadcast_scalar(fbot_xfer_type,       master_task)
       call broadcast_scalar(precip_units,         master_task)
@@ -1479,6 +1481,7 @@
          write(nu_diag,1010) ' calc_strair      = ', calc_strair,' : calculate wind stress and speed'
          write(nu_diag,1010) ' rotate_wind      = ', rotate_wind,' : rotate wind/stress to computational grid'
          write(nu_diag,1010) ' formdrag         = ', formdrag,' : use form drag parameterization'
+         write(nu_diag,1000) ' iceruf           = ', iceruf, ' : ice surface roughness at atmosphere interface (m)'
          if (trim(atmbndy) == 'default') then
             tmpstr2 = ' : stability-based boundary layer'
             write(nu_diag,1010) ' highfreq         = ', highfreq,' : high-frequency atmospheric coupling'
@@ -1799,7 +1802,7 @@
          wave_spec_type_in = wave_spec_type, &
          wave_spec_in=wave_spec, nfreq_in=nfreq, &
          tfrz_option_in=tfrz_option, kalg_in=kalg, fbot_xfer_type_in=fbot_xfer_type, &
-         Pstar_in=Pstar, Cstar_in=Cstar, &
+         Pstar_in=Pstar, Cstar_in=Cstar, iceruf_in=iceruf, &
          sw_redist_in=sw_redist, sw_frac_in=sw_frac, sw_dtemp_in=sw_dtemp)
       call icepack_init_tracer_flags(tr_iage_in=tr_iage, tr_FY_in=tr_FY, &
          tr_lvl_in=tr_lvl, tr_iso_in=tr_iso, tr_aero_in=tr_aero, &

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -200,6 +200,7 @@
     natmiter        = 5
     atmiter_conv    = 0.0d0
     ustar_min       = 0.0005
+    iceruf          = 0.0005
     emissivity      = 0.985
     fbot_xfer_type  = 'constant'
     update_ocn_f    = .false.

--- a/doc/source/cice_index.rst
+++ b/doc/source/cice_index.rst
@@ -314,7 +314,7 @@ either Celsius or Kelvin units).
    "ice_stderr", "unit number for standard error output", ""
    "ice_ref_salinity", "reference salinity for ice–ocean exchanges", "4. ppt"
    "icells", "number of grid cells with specified property (for vectorization)", ""
-   "iceruf", "ice surface roughness", "5.\ :math:`\times`\ 10\ :math:`^{-4}` m"
+   "iceruf", ":math:`\bullet` ice surface roughness at atmosphere interface", "5.\ :math:`\times`\ 10\ :math:`^{-4}` m"
    "icetmask", "ice extent mask (T-cell)", "" 
    "iceumask", "ice extent mask (U-cell)", ""
    "idate", "the date at the end of the current time step (yyyymmdd)", ""

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -519,6 +519,7 @@ forcing_nml
    "``ice_data_type``", "``boxslotcyl``", "initialize ice concentration and velocity for :ref:`boxslotcyl` test (:cite:`Zalesak79`)", "``default``"
    "", "``box2001``", "initialize ice concentration for :ref:`box2001` test (:cite:`Hunke01`)", ""
    "", "``default``", "no special initialization", ""
+   "``iceruf``", "real", "ice surface roughness at atmosphere interface", "0.0005"
    "``l_mpond_fresh``", "``.false.``", "release pond water immediately to ocean", "``.false.``"
    "", "``true``", "retain (topo) pond water until ponds drain", ""
    "``natmiter``", "integer", "number of atmo boundary layer iterations", "5"


### PR DESCRIPTION

## PR checklist
- [x] Short (1 sentence) summary of your PR: 
   Allow setting the ice surface roughness at the atmosphere interface, `iceruf`, in the CICE namelist. This makes it easier to modify this value.

- [x] Developer(s): 
    Original-pach-by: probably F. Roy or F. Dupont, ECCC
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
~~~
184 measured results of 184 total results
184 of 184 tests PASSED
0 of 184 tests PENDING
0 of 184 tests MISSING data
0 of 184 tests FAILED
~~~
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:


This is a another small  step in bringing our in-house modifications back to the Consortium. More to come in the coming weeks / months.
