### PR TITLE
Fix 1x1 and 2x2 blocksize error

### DIFF
--- a/cicecore/cicedynB/analysis/ice_diagnostics.F90
+++ b/cicecore/cicedynB/analysis/ice_diagnostics.F90
@@ -825,6 +825,7 @@
                      enddo
                   endif
                endif
+               psalt(n) = c0
                if (vice(i,j,iblk) /= c0) psalt(n) = work2(i,j,iblk)/vice(i,j,iblk)
                pTsfc(n) = trcr(i,j,nt_Tsfc,iblk)   ! ice/snow sfc temperature
                pevap(n) = evap(i,j,iblk)*dt/rhoi   ! sublimation/condensation

--- a/cicecore/cicedynB/infrastructure/comm/mpi/ice_gather_scatter.F90
+++ b/cicecore/cicedynB/infrastructure/comm/mpi/ice_gather_scatter.F90
@@ -636,6 +636,7 @@
    else
       special_value = spval_dbl
    endif
+   ARRAY_G = special_value
 
    nx = nx_global + 2*nghost
    ny = ny_global + 2*nghost
@@ -744,92 +745,7 @@
             endif
          endif
 
-       !*** fill land blocks with special values
-
-       else if (src_dist%blockLocation(n) == 0) then
-
-         this_block = get_block(n,n)
-
-         ! interior
-         do j=this_block%jlo,this_block%jhi
-         do i=this_block%ilo,this_block%ihi
-           ARRAY_G(this_block%i_glob(i)+nghost, &
-                   this_block%j_glob(j)+nghost) = special_value
-         end do
-         end do
-
-#ifdef CICE_IN_NEMO
-!echmod: this code is temporarily wrapped for nemo pending further testing elsewhere
-         ! fill ghost cells
-         if (this_block%jblock == 1) then
-            ! south block
-            do j=1, nghost
-            do i=this_block%ilo,this_block%ihi
-              ARRAY_G(this_block%i_glob(i)+nghost,j) = special_value
-            end do
-            end do
-            if (this_block%iblock == 1) then
-               ! southwest corner
-               do j=1, nghost
-               do i=1, nghost
-                 ARRAY_G(i,j) = special_value
-               end do
-               end do
-            endif
-         endif
-         if (this_block%jblock == nblocks_y) then
-            ! north block
-            do j=1, nghost
-            do i=this_block%ilo,this_block%ihi
-              ARRAY_G(this_block%i_glob(i)+nghost, &
-                      ny_global + nghost + j) = special_value
-            end do
-            end do
-            if (this_block%iblock == nblocks_x) then
-               ! northeast corner
-               do j=1, nghost
-               do i=1, nghost
-                 ARRAY_G(nx-i+1, ny-j+1) = special_value
-               end do
-               end do
-            endif
-         endif
-         if (this_block%iblock == 1) then
-            ! west block
-            do j=this_block%jlo,this_block%jhi
-            do i=1, nghost
-              ARRAY_G(i,this_block%j_glob(j)+nghost) = special_value
-            end do
-            end do
-            if (this_block%jblock == nblocks_y) then
-               ! northwest corner
-               do j=1, nghost
-               do i=1, nghost
-                 ARRAY_G(i,                   ny-j+1) = special_value
-               end do
-               end do
-            endif
-         endif
-         if (this_block%iblock == nblocks_x) then
-            ! east block
-            do j=this_block%jlo,this_block%jhi
-            do i=1, nghost
-              ARRAY_G(nx_global + nghost + i, &
-                      this_block%j_glob(j)+nghost) = special_value
-            end do
-            end do
-            if (this_block%jblock == 1) then
-               ! southeast corner
-               do j=1, nghost
-               do i=1, nghost
-                 ARRAY_G(                   nx-i+1,j) = special_value
-               end do
-               end do
-            endif
-         endif
-#endif
-
-       endif
+       endif  ! src_dist%blockLocation
 
      end do
 
@@ -939,7 +855,7 @@
 !
 !-----------------------------------------------------------------------
 
-   else
+   else  ! master task
 
      allocate(snd_request(nblocks_tot), &
               snd_status (MPI_STATUS_SIZE, nblocks_tot))
@@ -960,7 +876,7 @@
        call MPI_WAITALL(nsends, snd_request, snd_status, ierr)
      deallocate(snd_request, snd_status)
 
-   endif
+   endif  ! master task
 
    if (add_mpi_barriers) then
      call ice_barrier()
@@ -1028,8 +944,9 @@
    if (present(spc_val)) then
       special_value = spc_val
    else
-      special_value = 0   !MHRI NOTE: 0,1,-999,???
+      special_value = -9999
    endif
+   ARRAY_G = special_value
 
    nx = nx_global + 2*nghost
    ny = ny_global + 2*nghost
@@ -1138,21 +1055,7 @@
             endif
          endif
 
-       !*** fill land blocks with special values
-
-       else if (src_dist%blockLocation(n) == 0) then
-
-         this_block = get_block(n,n)
-
-         ! interior
-         do j=this_block%jlo,this_block%jhi
-         do i=this_block%ilo,this_block%ihi
-           ARRAY_G(this_block%i_glob(i)+nghost, &
-                   this_block%j_glob(j)+nghost) = special_value
-         end do
-         end do
-
-       endif
+       endif  ! src_dist%blockLocation
 
      end do
 
@@ -1262,7 +1165,7 @@
 !
 !-----------------------------------------------------------------------
 
-   else
+   else  ! master task
 
      allocate(snd_request(nblocks_tot), &
               snd_status (MPI_STATUS_SIZE, nblocks_tot))
@@ -1283,7 +1186,7 @@
        call MPI_WAITALL(nsends, snd_request, snd_status, ierr)
      deallocate(snd_request, snd_status)
 
-   endif
+   endif  ! master task
 
    if (add_mpi_barriers) then
      call ice_barrier()
@@ -1353,6 +1256,7 @@
    else
       special_value = .false.   !MHRI NOTE: .true./.false.  ???
    endif
+   ARRAY_G = special_value
 
    nx = nx_global + 2*nghost
    ny = ny_global + 2*nghost
@@ -1461,21 +1365,7 @@
             endif
          endif
 
-       !*** fill land blocks with special values
-
-       else if (src_dist%blockLocation(n) == 0) then
-
-         this_block = get_block(n,n)
-
-         ! interior
-         do j=this_block%jlo,this_block%jhi
-         do i=this_block%ilo,this_block%ihi
-           ARRAY_G(this_block%i_glob(i)+nghost, &
-                   this_block%j_glob(j)+nghost) = special_value
-         end do
-         end do
-
-       endif
+       endif  ! src_dist%blockLocation
 
      end do
 
@@ -1585,7 +1475,7 @@
 !
 !-----------------------------------------------------------------------
 
-   else
+   else  ! master task
 
      allocate(snd_request(nblocks_tot), &
               snd_status (MPI_STATUS_SIZE, nblocks_tot))
@@ -1606,7 +1496,7 @@
        call MPI_WAITALL(nsends, snd_request, snd_status, ierr)
      deallocate(snd_request, snd_status)
 
-   endif
+   endif  ! master task
 
    if (add_mpi_barriers) then
      call ice_barrier()

--- a/cicecore/cicedynB/infrastructure/comm/serial/ice_gather_scatter.F90
+++ b/cicecore/cicedynB/infrastructure/comm/serial/ice_gather_scatter.F90
@@ -373,6 +373,7 @@
    else
       special_value = spval_dbl
    endif
+   ARRAY_G = special_value
 
    nx = nx_global + 2*nghost
    ny = ny_global + 2*nghost
@@ -477,16 +478,7 @@
             endif
          endif
 
-      else !*** fill land blocks with special values
-
-         do j=this_block%jlo,this_block%jhi
-         do i=this_block%ilo,this_block%ihi
-            ARRAY_G(this_block%i_glob(i)+nghost, &
-                    this_block%j_glob(j)+nghost) = special_value
-         end do
-         end do
-
-      endif
+      endif  ! src_dist%blockLocation
 
    end do
 
@@ -537,8 +529,9 @@
    if (present(spc_val)) then
       special_value = spc_val
    else
-      special_value = 0 !MHRI:  0,1,999,-999 ??
+      special_value = -9999
    endif
+   ARRAY_G = special_value
 
    nx = nx_global + 2*nghost
    ny = ny_global + 2*nghost
@@ -643,16 +636,7 @@
             endif
          endif
 
-      else !*** fill land blocks with special values
-
-         do j=this_block%jlo,this_block%jhi
-         do i=this_block%ilo,this_block%ihi
-            ARRAY_G(this_block%i_glob(i)+nghost, &
-                    this_block%j_glob(j)+nghost) = special_value
-         end do
-         end do
-
-      endif
+      endif  ! src_dist%blockLocation
 
    end do
 
@@ -705,6 +689,7 @@
    else
       special_value = .false. !MHRI:  true/false
    endif
+   ARRAY_G = special_value
 
    nx = nx_global + 2*nghost
    ny = ny_global + 2*nghost
@@ -809,16 +794,7 @@
             endif
          endif
 
-      else !*** fill land blocks with special values
-
-         do j=this_block%jlo,this_block%jhi
-         do i=this_block%ilo,this_block%ihi
-            ARRAY_G(this_block%i_glob(i)+nghost, &
-                    this_block%j_glob(j)+nghost) = special_value
-         end do
-         end do
-
-      endif
+      endif  ! src_dist%blockLocation
 
    end do
 

--- a/cicecore/cicedynB/infrastructure/ice_domain.F90
+++ b/cicecore/cicedynB/infrastructure/ice_domain.F90
@@ -441,7 +441,7 @@
 !----------------------------------------------------------------------
 
    if (distribution_wght == 'latitude') then
-       flat = NINT(abs(ULATG*rad_to_deg), int_kind)  ! linear function
+       flat = max(NINT(abs(ULATG*rad_to_deg), int_kind),1)  ! linear function
    else
        flat = 1
    endif

--- a/configuration/scripts/tests/reprosum_suite.ts
+++ b/configuration/scripts/tests/reprosum_suite.ts
@@ -8,4 +8,5 @@ logbfb        gx3     1x20x5x29x80  dsectrobin,diag1,short,reprosum            l
 logbfb        gx3     8x2x8x10x20   droundrobin,diag1,reprosum                 logbfb_gx3_4x2x25x29x4_diag1_dslenderX2_reprosum
 logbfb        gx3     6x2x50x58x1   droundrobin,diag1,reprosum                 logbfb_gx3_4x2x25x29x4_diag1_dslenderX2_reprosum
 logbfb        gx3     6x2x4x29x18   dspacecurve,diag1,maskhalo,reprosum        logbfb_gx3_4x2x25x29x4_diag1_dslenderX2_reprosum
+logbfb        gx3     17x2x1x1x800  droundrobin,diag1,maskhalo,reprosum        logbfb_gx3_4x2x25x29x4_diag1_dslenderX2_reprosum
 #logbfb        gx3     8x2x8x10x20   droundrobin,diag1                          logbfb_gx3_4x2x25x29x4_diag1_dslenderX2


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix 1x1 and 2x2 blocksize error, update initialization of ARRAY_G in global_gather_ext
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Full test suite run on cheyenne with gnu.  All results are bit-for-bit except 1x1 and 2x2 results which don't change answers but do change restart files slightly due to the fix in missing blocks.  See cheyenne gnu results https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#85531cf8f8ae93f628344df6ecfa4be12e9629d8
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [X] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

- Fix 1x1 and 2x2 non-bit-for-bit results.  It turns out the 1x1 and 2x2 blocks were
  bit-for-bit physically, just not technically.  The problem was that a set 
  of blocks were "land block eliminated"
  near the equator incorrectly.  These blocks never have sea ice, so it's not a problem
  scientifically, but it changes the masking and restart files.  The fix is a one line change
  in ice_domain.F90 which that sets the minimum "flat" value to 1.  At the equator, flat 
  was set to zero and this eliminated those gridcells incorrectly.  This error could only
  happen in cases where the gridcells were within 0.5 degrees of the equator, and a set of
  conditions were required where an active gridcell was set to inactive which then resulted
  in the entire block being eliminated.  This could really only happen with the smallest blocks
  which is why it only showed up with 1x1 and 2x2.  
- Update the initialization of ARRAY_G in the gather_global_ext interfaces.  Get rid of
  older, more complex approach which left some blocks uninitialized.
- Set psalt(n) to zero by default.  Was uninitialized in cases where vice=0.
- Add a test to check bit-for-bit in log files for 1x1 blocks with bfbflag set to reprosum.
