### PR TITLE
Fix history single/double precision issues

### DIFF
--- a/cicecore/cicedynB/analysis/ice_history.F90
+++ b/cicecore/cicedynB/analysis/ice_history.F90
@@ -32,7 +32,7 @@
       use ice_kinds_mod
       use ice_communicate, only: my_task, master_task
       use ice_constants, only: c0, c1, c2, c100, c360, c180, &
-          p001, p25, p5, mps_to_cmpdy, kg_to_g, spval
+          p001, p25, p5, mps_to_cmpdy, kg_to_g, spval_dbl
       use ice_fileunits, only: nu_nml, nml_filename, nu_diag, &
           get_fileunit, release_fileunit, flush_fileunit
       use ice_exit, only: abort_ice
@@ -3118,7 +3118,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a2D(i,j,n,iblk) = spval
+                    a2D(i,j,n,iblk) = spval_dbl
                  else                            ! convert units
                     a2D(i,j,n,iblk) = avail_hist_fields(n)%cona*a2D(i,j,n,iblk) &
                                    * ravgct + avail_hist_fields(n)%conb
@@ -3135,7 +3135,7 @@
                              a2D(i,j,n_sithick(ns),iblk) = &
                              a2D(i,j,n_sithick(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sithick(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sithick(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3148,7 +3148,7 @@
                              a2D(i,j,n_siage(ns),iblk) = &
                              a2D(i,j,n_siage(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siage(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siage(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3161,7 +3161,7 @@
                              a2D(i,j,n_sisnthick(ns),iblk) = &
                              a2D(i,j,n_sisnthick(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sisnthick(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sisnthick(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3174,7 +3174,7 @@
                              a2D(i,j,n_sitemptop(ns),iblk) = &
                              a2D(i,j,n_sitemptop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sitemptop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sitemptop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3187,7 +3187,7 @@
                              a2D(i,j,n_sitempsnic(ns),iblk) = &
                              a2D(i,j,n_sitempsnic(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sitempsnic(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sitempsnic(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3200,7 +3200,7 @@
                              a2D(i,j,n_sitempbot(ns),iblk) = &
                              a2D(i,j,n_sitempbot(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sitempbot(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sitempbot(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3213,7 +3213,7 @@
                              a2D(i,j,n_siu(ns),iblk) = &
                              a2D(i,j,n_siu(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siu(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siu(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3226,7 +3226,7 @@
                              a2D(i,j,n_siv(ns),iblk) = &
                              a2D(i,j,n_siv(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siv(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siv(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3239,7 +3239,7 @@
                              a2D(i,j,n_sistrxdtop(ns),iblk) = &
                              a2D(i,j,n_sistrxdtop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sistrxdtop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sistrxdtop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3252,7 +3252,7 @@
                              a2D(i,j,n_sistrydtop(ns),iblk) = &
                              a2D(i,j,n_sistrydtop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sistrydtop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sistrydtop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3265,7 +3265,7 @@
                              a2D(i,j,n_sistrxubot(ns),iblk) = &
                              a2D(i,j,n_sistrxubot(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sistrxubot(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sistrxubot(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3278,7 +3278,7 @@
                              a2D(i,j,n_sistryubot(ns),iblk) = &
                              a2D(i,j,n_sistryubot(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sistryubot(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sistryubot(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3291,7 +3291,7 @@
                              a2D(i,j,n_sicompstren(ns),iblk) = &
                              a2D(i,j,n_sicompstren(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sicompstren(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sicompstren(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3304,7 +3304,7 @@
                              a2D(i,j,n_sispeed(ns),iblk) = &
                              a2D(i,j,n_sispeed(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sispeed(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sispeed(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3317,8 +3317,8 @@
                              a2D(i,j,n_sialb(ns),iblk) = &
                              a2D(i,j,n_sialb(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sialb(ns),iblk) = spval
-                       if (albcnt(i,j,iblk,ns) <= puny) a2D(i,j,n_sialb(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sialb(ns),iblk) = spval_dbl
+                       if (albcnt(i,j,iblk,ns) <= puny) a2D(i,j,n_sialb(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3331,7 +3331,7 @@
                              a2D(i,j,n_siflswdtop(ns),iblk) = &
                              a2D(i,j,n_siflswdtop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflswdtop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflswdtop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3344,7 +3344,7 @@
                              a2D(i,j,n_siflswutop(ns),iblk) = &
                              a2D(i,j,n_siflswutop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflswutop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflswutop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3357,7 +3357,7 @@
                              a2D(i,j,n_siflswdbot(ns),iblk) = &
                              a2D(i,j,n_siflswdbot(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflswdbot(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflswdbot(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3370,7 +3370,7 @@
                              a2D(i,j,n_sifllwdtop(ns),iblk) = &
                              a2D(i,j,n_sifllwdtop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sifllwdtop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sifllwdtop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3383,7 +3383,7 @@
                              a2D(i,j,n_sifllwutop(ns),iblk) = &
                              a2D(i,j,n_sifllwutop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sifllwutop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sifllwutop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3396,7 +3396,7 @@
                              a2D(i,j,n_siflsenstop(ns),iblk) = &
                              a2D(i,j,n_siflsenstop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflsenstop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflsenstop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3409,7 +3409,7 @@
                              a2D(i,j,n_siflsensupbot(ns),iblk) = &
                              a2D(i,j,n_siflsensupbot(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflsensupbot(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflsensupbot(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3422,7 +3422,7 @@
                              a2D(i,j,n_sifllatstop(ns),iblk) = &
                              a2D(i,j,n_sifllatstop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sifllatstop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sifllatstop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3435,7 +3435,7 @@
                              a2D(i,j,n_sipr(ns),iblk) = &
                              a2D(i,j,n_sipr(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sipr(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sipr(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3448,7 +3448,7 @@
                              a2D(i,j,n_sifb(ns),iblk) = &
                              a2D(i,j,n_sifb(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sifb(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sifb(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3461,7 +3461,7 @@
                              a2D(i,j,n_siflcondtop(ns),iblk) = &
                              a2D(i,j,n_siflcondtop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflcondtop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflcondtop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3474,7 +3474,7 @@
                              a2D(i,j,n_siflcondbot(ns),iblk) = &
                              a2D(i,j,n_siflcondbot(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflcondbot(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflcondbot(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3487,7 +3487,7 @@
                              a2D(i,j,n_siflsaltbot(ns),iblk) = &
                              a2D(i,j,n_siflsaltbot(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflsaltbot(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflsaltbot(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3500,7 +3500,7 @@
                              a2D(i,j,n_siflfwbot(ns),iblk) = &
                              a2D(i,j,n_siflfwbot(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflfwbot(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflfwbot(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3513,7 +3513,7 @@
                              a2D(i,j,n_siflfwdrain(ns),iblk) = &
                              a2D(i,j,n_siflfwdrain(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siflfwdrain(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siflfwdrain(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3526,7 +3526,7 @@
                              a2D(i,j,n_sidragtop(ns),iblk) = &
                              a2D(i,j,n_sidragtop(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sidragtop(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sidragtop(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3539,7 +3539,7 @@
                              a2D(i,j,n_sirdgthick(ns),iblk) = &
                              a2D(i,j,n_sirdgthick(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_sirdgthick(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_sirdgthick(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3552,7 +3552,7 @@
                              a2D(i,j,n_siforcetiltx(ns),iblk) = &
                              a2D(i,j,n_siforcetiltx(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siforcetiltx(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siforcetiltx(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3565,7 +3565,7 @@
                              a2D(i,j,n_siforcetilty(ns),iblk) = &
                              a2D(i,j,n_siforcetilty(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siforcetilty(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siforcetilty(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3578,7 +3578,7 @@
                              a2D(i,j,n_siforcecoriolx(ns),iblk) = &
                              a2D(i,j,n_siforcecoriolx(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siforcecoriolx(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siforcecoriolx(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3591,7 +3591,7 @@
                              a2D(i,j,n_siforcecorioly(ns),iblk) = &
                              a2D(i,j,n_siforcecorioly(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siforcecorioly(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siforcecorioly(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3604,7 +3604,7 @@
                              a2D(i,j,n_siforceintstrx(ns),iblk) = &
                              a2D(i,j,n_siforceintstrx(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siforceintstrx(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siforceintstrx(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3617,7 +3617,7 @@
                              a2D(i,j,n_siforceintstry(ns),iblk) = &
                              a2D(i,j,n_siforceintstry(ns),iblk)*avgct(ns)*ravgip(i,j)
                        endif
-                       if (ravgip(i,j) == c0) a2D(i,j,n_siforceintstry(ns),iblk) = spval
+                       if (ravgip(i,j) == c0) a2D(i,j,n_siforceintstry(ns),iblk) = spval_dbl
                     enddo             ! i
                     enddo             ! j
                  endif
@@ -3724,7 +3724,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a3Dc(i,j,k,n,iblk) = spval
+                    a3Dc(i,j,k,n,iblk) = spval_dbl
                  else                            ! convert units
                     a3Dc(i,j,k,n,iblk) = avail_hist_fields(nn)%cona*a3Dc(i,j,k,n,iblk) &
                                    * ravgct + avail_hist_fields(nn)%conb
@@ -3773,7 +3773,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a3Dz(i,j,k,n,iblk) = spval
+                    a3Dz(i,j,k,n,iblk) = spval_dbl
                  else                            ! convert units
                     a3Dz(i,j,k,n,iblk) = avail_hist_fields(nn)%cona*a3Dz(i,j,k,n,iblk) &
                                    * ravgct + avail_hist_fields(nn)%conb
@@ -3790,7 +3790,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a3Db(i,j,k,n,iblk) = spval
+                    a3Db(i,j,k,n,iblk) = spval_dbl
                  else                            ! convert units
                     a3Db(i,j,k,n,iblk) = avail_hist_fields(nn)%cona*a3Db(i,j,k,n,iblk) &
                                    * ravgct + avail_hist_fields(nn)%conb
@@ -3808,7 +3808,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a3Da(i,j,k,n,iblk) = spval
+                    a3Da(i,j,k,n,iblk) = spval_dbl
                  else                            ! convert units
                     a3Da(i,j,k,n,iblk) = avail_hist_fields(nn)%cona*a3Da(i,j,k,n,iblk) &
                                    * ravgct + avail_hist_fields(nn)%conb
@@ -3826,7 +3826,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a3Df(i,j,k,n,iblk) = spval
+                    a3Df(i,j,k,n,iblk) = spval_dbl
                  else                            ! convert units
                     a3Df(i,j,k,n,iblk) = avail_hist_fields(nn)%cona*a3Df(i,j,k,n,iblk) &
                                    * ravgct + avail_hist_fields(nn)%conb
@@ -3845,7 +3845,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a4Di(i,j,k,ic,n,iblk) = spval
+                    a4Di(i,j,k,ic,n,iblk) = spval_dbl
                  else                            ! convert units
                     a4Di(i,j,k,ic,n,iblk) = avail_hist_fields(nn)%cona*a4Di(i,j,k,ic,n,iblk) &
                                    * ravgct + avail_hist_fields(nn)%conb
@@ -3865,7 +3865,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a4Ds(i,j,k,ic,n,iblk) = spval
+                    a4Ds(i,j,k,ic,n,iblk) = spval_dbl
                  else                            ! convert units
                     a4Ds(i,j,k,ic,n,iblk) = avail_hist_fields(nn)%cona*a4Ds(i,j,k,ic,n,iblk) &
                                    * ravgct + avail_hist_fields(nn)%conb
@@ -3885,7 +3885,7 @@
               do j = jlo, jhi
               do i = ilo, ihi
                  if (.not. tmask(i,j,iblk)) then ! mask out land points
-                    a4Df(i,j,k,ic,n,iblk) = spval
+                    a4Df(i,j,k,ic,n,iblk) = spval_dbl
                  else                            ! convert units
                     a4Df(i,j,k,ic,n,iblk) = avail_hist_fields(nn)%cona*a4Df(i,j,k,ic,n,iblk) &
                                    * ravgct + avail_hist_fields(nn)%conb
@@ -3915,32 +3915,32 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (.not. tmask(i,j,iblk)) then ! mask out land points
-                 if (n_divu     (ns) /= 0) a2D(i,j,n_divu(ns),     iblk) = spval
-                 if (n_shear    (ns) /= 0) a2D(i,j,n_shear(ns),    iblk) = spval
-                 if (n_sig1     (ns) /= 0) a2D(i,j,n_sig1(ns),     iblk) = spval
-                 if (n_sig2     (ns) /= 0) a2D(i,j,n_sig2(ns),     iblk) = spval
-                 if (n_sigP     (ns) /= 0) a2D(i,j,n_sigP(ns),     iblk) = spval
-                 if (n_sistreave(ns) /= 0) a2D(i,j,n_sistreave(ns),iblk) = spval
-                 if (n_sistremax(ns) /= 0) a2D(i,j,n_sistremax(ns),iblk) = spval
-                 if (n_mlt_onset(ns) /= 0) a2D(i,j,n_mlt_onset(ns),iblk) = spval
-                 if (n_frz_onset(ns) /= 0) a2D(i,j,n_frz_onset(ns),iblk) = spval
-                 if (n_hisnap   (ns) /= 0) a2D(i,j,n_hisnap(ns),   iblk) = spval
-                 if (n_aisnap   (ns) /= 0) a2D(i,j,n_aisnap(ns),   iblk) = spval
-                 if (n_trsig    (ns) /= 0) a2D(i,j,n_trsig(ns),    iblk) = spval
-                 if (n_iage     (ns) /= 0) a2D(i,j,n_iage(ns),     iblk) = spval
-                 if (n_FY       (ns) /= 0) a2D(i,j,n_FY(ns),       iblk) = spval
+                 if (n_divu     (ns) /= 0) a2D(i,j,n_divu(ns),     iblk) = spval_dbl
+                 if (n_shear    (ns) /= 0) a2D(i,j,n_shear(ns),    iblk) = spval_dbl
+                 if (n_sig1     (ns) /= 0) a2D(i,j,n_sig1(ns),     iblk) = spval_dbl
+                 if (n_sig2     (ns) /= 0) a2D(i,j,n_sig2(ns),     iblk) = spval_dbl
+                 if (n_sigP     (ns) /= 0) a2D(i,j,n_sigP(ns),     iblk) = spval_dbl
+                 if (n_sistreave(ns) /= 0) a2D(i,j,n_sistreave(ns),iblk) = spval_dbl
+                 if (n_sistremax(ns) /= 0) a2D(i,j,n_sistremax(ns),iblk) = spval_dbl
+                 if (n_mlt_onset(ns) /= 0) a2D(i,j,n_mlt_onset(ns),iblk) = spval_dbl
+                 if (n_frz_onset(ns) /= 0) a2D(i,j,n_frz_onset(ns),iblk) = spval_dbl
+                 if (n_hisnap   (ns) /= 0) a2D(i,j,n_hisnap(ns),   iblk) = spval_dbl
+                 if (n_aisnap   (ns) /= 0) a2D(i,j,n_aisnap(ns),   iblk) = spval_dbl
+                 if (n_trsig    (ns) /= 0) a2D(i,j,n_trsig(ns),    iblk) = spval_dbl
+                 if (n_iage     (ns) /= 0) a2D(i,j,n_iage(ns),     iblk) = spval_dbl
+                 if (n_FY       (ns) /= 0) a2D(i,j,n_FY(ns),       iblk) = spval_dbl
 
-                 if (n_a11      (ns) /= 0) a2D(i,j,n_a11(ns),      iblk) = spval
-                 if (n_a12      (ns) /= 0) a2D(i,j,n_a12(ns),      iblk) = spval
-                 if (n_e11      (ns) /= 0) a2D(i,j,n_e11(ns),      iblk) = spval
-                 if (n_e12      (ns) /= 0) a2D(i,j,n_e12(ns),      iblk) = spval
-                 if (n_e22      (ns) /= 0) a2D(i,j,n_e22(ns),      iblk) = spval
-                 if (n_s11      (ns) /= 0) a2D(i,j,n_s11(ns),      iblk) = spval
-                 if (n_s12      (ns) /= 0) a2D(i,j,n_s12(ns),      iblk) = spval
-                 if (n_s22      (ns) /= 0) a2D(i,j,n_s22(ns),      iblk) = spval
-                 if (n_yieldstress11 (ns) /= 0) a2D(i,j,n_yieldstress11(ns),iblk) = spval
-                 if (n_yieldstress12 (ns) /= 0) a2D(i,j,n_yieldstress12(ns),iblk) = spval
-                 if (n_yieldstress22 (ns) /= 0) a2D(i,j,n_yieldstress22(ns),iblk) = spval
+                 if (n_a11      (ns) /= 0) a2D(i,j,n_a11(ns),      iblk) = spval_dbl
+                 if (n_a12      (ns) /= 0) a2D(i,j,n_a12(ns),      iblk) = spval_dbl
+                 if (n_e11      (ns) /= 0) a2D(i,j,n_e11(ns),      iblk) = spval_dbl
+                 if (n_e12      (ns) /= 0) a2D(i,j,n_e12(ns),      iblk) = spval_dbl
+                 if (n_e22      (ns) /= 0) a2D(i,j,n_e22(ns),      iblk) = spval_dbl
+                 if (n_s11      (ns) /= 0) a2D(i,j,n_s11(ns),      iblk) = spval_dbl
+                 if (n_s12      (ns) /= 0) a2D(i,j,n_s12(ns),      iblk) = spval_dbl
+                 if (n_s22      (ns) /= 0) a2D(i,j,n_s22(ns),      iblk) = spval_dbl
+                 if (n_yieldstress11 (ns) /= 0) a2D(i,j,n_yieldstress11(ns),iblk) = spval_dbl
+                 if (n_yieldstress12 (ns) /= 0) a2D(i,j,n_yieldstress12(ns),iblk) = spval_dbl
+                 if (n_yieldstress22 (ns) /= 0) a2D(i,j,n_yieldstress22(ns),iblk) = spval_dbl
               else
                  if (n_divu     (ns) /= 0) a2D(i,j,n_divu(ns),iblk)      = &
                        divu (i,j,iblk)*avail_hist_fields(n_divu(ns))%cona

--- a/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -67,11 +67,9 @@
 
       ! local variables
 
-      real (kind=dbl_kind),  dimension(:,:),   allocatable :: work_g1
-      real (kind=real_kind), dimension(:,:),   allocatable :: work_gr
-      real (kind=real_kind), dimension(:,:,:), allocatable :: work_gr3
-      real (kind=dbl_kind),  dimension(nx_block,ny_block,max_blocks) :: &
-         work1
+      real (kind=dbl_kind), dimension(:,:),   allocatable :: work_g1
+      real (kind=dbl_kind), dimension(:,:,:), allocatable :: work1_3
+      real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks) :: work1
 
       integer (kind=int_kind) :: i,k,ic,n,nn, &
          ncid,status,imtid,jmtid,kmtidi,kmtids,kmtidb, cmtid,timid,varid, &
@@ -362,20 +360,7 @@
           status = nf90_put_att(ncid, varid, 'units', coord_var(i)%units)
           if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining units for '//coord_var(i)%short_name)
-          if (lprecision == nf90_float) then
-             status = nf90_put_att(ncid,varid,'missing_value',spval)
-          else
-             status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-          endif
-          if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//coord_var(i)%short_name)
-          if (lprecision == nf90_float) then
-             status = nf90_put_att(ncid,varid,'_FillValue',spval)
-          else
-             status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-          endif
-          if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//coord_var(i)%short_name)
+          call ice_write_hist_fill(ncid,varid,coord_var(i)%short_name,history_precision)
           if (coord_var(i)%short_name == 'ULAT') then
              status = nf90_put_att(ncid,varid,'comment', &
                   'Latitude of NE corner of T grid cell')
@@ -422,18 +407,7 @@
            if (status /= nf90_noerr) call abort_ice(subname//'ERROR: tmask units') 
            status = nf90_put_att(ncid,varid,'comment', '0 = land, 1 = ocean')
            if (status /= nf90_noerr) call abort_ice(subname//'ERROR: tmask comment') 
-           if (lprecision == nf90_float) then
-              status = nf90_put_att(ncid,varid,'missing_value',spval)
-           else
-              status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-           endif
-           if (status /= nf90_noerr) call abort_ice(subname//'ERROR: defining missing_value for tmask')
-           if (lprecision == nf90_float) then
-              status = nf90_put_att(ncid,varid,'_FillValue',spval)
-           else
-              status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-           endif
-           if (status /= nf90_noerr) call abort_ice(subname//'ERROR: defining _FillValue for tmask')
+           call ice_write_hist_fill(ncid,varid,'tmask',history_precision)
         endif
 
         if (igrd(n_blkmask)) then
@@ -445,18 +419,7 @@
            if (status /= nf90_noerr) call abort_ice(subname//'ERROR: blkmask units') 
            status = nf90_put_att(ncid,varid,'comment', 'mytask + iblk/100')
            if (status /= nf90_noerr) call abort_ice(subname//'ERROR: blkmask comment') 
-           if (lprecision == nf90_float) then
-              status = nf90_put_att(ncid,varid,'missing_value',spval)
-           else
-              status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-           endif
-           if (status /= nf90_noerr) call abort_ice(subname//'ERROR: defining missing_value for blkmask')
-           if (lprecision == nf90_float) then
-              status = nf90_put_att(ncid,varid,'_FillValue',spval)
-           else
-              status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-           endif
-           if (status /= nf90_noerr) call abort_ice(subname//'ERROR: defining _FillValue for blkmask')
+           call ice_write_hist_fill(ncid,varid,'blkmask',history_precision)
         endif
 
         do i = 3, nvar      ! note n_tmask=1, n_blkmask=2
@@ -474,20 +437,7 @@
              status = nf90_put_att(ncid, varid, 'coordinates', var(i)%coordinates)
              if (status /= nf90_noerr) call abort_ice(subname// &
                   'ERROR: defining coordinates for '//var(i)%req%short_name)
-             if (lprecision == nf90_float) then
-                status = nf90_put_att(ncid,varid,'missing_value',spval)
-             else
-                status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-             endif
-             if (status /= nf90_noerr) call abort_ice(subname// &
-                  'ERROR: defining missing_value for '//var(i)%req%short_name)
-             if (lprecision == nf90_float) then
-                status = nf90_put_att(ncid,varid,'_FillValue',spval)
-             else
-                status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-             endif
-             if (status /= nf90_noerr) call abort_ice(subname// &
-                  'ERROR: defining _FillValue for '//var(i)%req%short_name)
+             call ice_write_hist_fill(ncid,varid,var(i)%req%short_name,history_precision)
           endif
         enddo
 
@@ -507,20 +457,7 @@
              status = nf90_put_att(ncid, varid, 'units', var_nverts(i)%units)
              if (status /= nf90_noerr) call abort_ice(subname// &
                   'ERROR: defining units for '//var_nverts(i)%short_name)
-             if (lprecision == nf90_float) then
-                status = nf90_put_att(ncid,varid,'missing_value',spval)
-             else
-                status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-             endif
-             if (status /= nf90_noerr) call abort_ice(subname// &
-                  'ERROR: defining missing_value for '//var_nverts(i)%short_name)
-             if (lprecision == nf90_float) then
-                status = nf90_put_att(ncid,varid,'_FillValue',spval)
-             else
-                status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-             endif
-             if (status /= nf90_noerr) call abort_ice(subname// &
-                  'ERROR: defining _FillValue for '//var_nverts(i)%short_name)
+             call ice_write_hist_fill(ncid,varid,var_nverts(i)%short_name,history_precision)
           endif
         enddo
 
@@ -546,20 +483,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
       !-----------------------------------------------------------------
       ! Add cell_methods attribute to variables if averaged
@@ -618,20 +542,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
       !-----------------------------------------------------------------
       ! Add cell_methods attribute to variables if averaged
@@ -678,20 +589,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
           endif
         enddo  ! num_avail_hist_fields_3Dz
@@ -723,20 +621,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
           endif
         enddo  ! num_avail_hist_fields_3Db
@@ -768,20 +653,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
           endif
         enddo  ! num_avail_hist_fields_3Da
@@ -813,20 +685,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
           endif
         enddo  ! num_avail_hist_fields_3Df
@@ -860,20 +719,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
       !-----------------------------------------------------------------
       ! Add cell_methods attribute to variables if averaged
@@ -922,20 +768,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
       !-----------------------------------------------------------------
       ! Add cell_methods attribute to variables if averaged
@@ -984,20 +817,7 @@
                         avail_hist_fields(n)%vcellmeas)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: defining cell measures for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'missing_value',spval)
-            else
-               status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining missing_value for '//avail_hist_fields(n)%vname)
-            if (lprecision == nf90_float) then
-               status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            else
-               status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
-            endif
-            if (status /= nf90_noerr) call abort_ice(subname// &
-               'ERROR: defining _FillValue for '//avail_hist_fields(n)%vname)
+            call ice_write_hist_fill(ncid,varid,avail_hist_fields(n)%vname,history_precision)
 
       !-----------------------------------------------------------------
       ! Add cell_methods attribute to variables if averaged
@@ -1120,9 +940,7 @@
 
       if (my_task==master_task) then
          allocate(work_g1(nx_global,ny_global))
-         allocate(work_gr(nx_global,ny_global))
       else
-         allocate(work_gr(1,1))   ! to save memory
          allocate(work_g1(1,1))
       endif
 
@@ -1153,11 +971,10 @@
           END SELECT
           
           if (my_task == master_task) then
-             work_gr = work_g1
              status = nf90_inq_varid(ncid, coord_var(i)%short_name, varid)
              if (status /= nf90_noerr) call abort_ice(subname// &
                   'ERROR: getting varid for '//coord_var(i)%short_name)
-             status = nf90_put_var(ncid,varid,work_gr)
+             status = nf90_put_var(ncid,varid,work_g1)
              if (status /= nf90_noerr) call abort_ice(subname// &
                   'ERROR: writing'//coord_var(i)%short_name)
           endif
@@ -1199,11 +1016,10 @@
       if (igrd(n_tmask)) then
       call gather_global(work_g1, hm, master_task, distrb_info)
       if (my_task == master_task) then
-        work_gr=work_g1
         status = nf90_inq_varid(ncid, 'tmask', varid)
         if (status /= nf90_noerr) call abort_ice(subname// &
                       'ERROR: getting varid for tmask')
-        status = nf90_put_var(ncid,varid,work_gr)
+        status = nf90_put_var(ncid,varid,work_g1)
         if (status /= nf90_noerr) call abort_ice(subname// &
                       'ERROR: writing variable tmask')
       endif
@@ -1212,11 +1028,10 @@
       if (igrd(n_blkmask)) then
       call gather_global(work_g1, bm, master_task, distrb_info)
       if (my_task == master_task) then
-        work_gr=work_g1
         status = nf90_inq_varid(ncid, 'blkmask', varid)
         if (status /= nf90_noerr) call abort_ice(subname// &
                       'ERROR: getting varid for blkmask')
-        status = nf90_put_var(ncid,varid,work_gr)
+        status = nf90_put_var(ncid,varid,work_g1)
         if (status /= nf90_noerr) call abort_ice(subname// &
                       'ERROR: writing variable blkmask')
       endif
@@ -1249,18 +1064,15 @@
         END SELECT
 
         if (my_task == master_task) then
-          work_gr=work_g1
           status = nf90_inq_varid(ncid, var(i)%req%short_name, varid)
           if (status /= nf90_noerr) call abort_ice(subname// &
                         'ERROR: getting varid for '//var(i)%req%short_name)
-          status = nf90_put_var(ncid,varid,work_gr)
+          status = nf90_put_var(ncid,varid,work_g1)
           if (status /= nf90_noerr) call abort_ice(subname// &
                         'ERROR: writing variable '//var(i)%req%short_name)
         endif
         endif
       enddo
-
-      deallocate(work_gr)
 
       !----------------------------------------------------------------
       ! Write coordinates of grid box vertices
@@ -1268,12 +1080,12 @@
 
       if (f_bounds) then
       if (my_task==master_task) then
-         allocate(work_gr3(nverts,nx_global,ny_global))
+         allocate(work1_3(nverts,nx_global,ny_global))
       else
-         allocate(work_gr3(1,1,1))   ! to save memory
+         allocate(work1_3(1,1,1))   ! to save memory
       endif
 
-      work_gr3(:,:,:) = c0
+      work1_3(:,:,:) = c0
       work1   (:,:,:) = c0
 
       do i = 1, nvar_verts
@@ -1283,25 +1095,25 @@
         do ivertex = 1, nverts 
            work1(:,:,:) = lont_bounds(ivertex,:,:,:)
            call gather_global(work_g1, work1, master_task, distrb_info)
-           if (my_task == master_task) work_gr3(ivertex,:,:) = work_g1(:,:)
+           if (my_task == master_task) work1_3(ivertex,:,:) = work_g1(:,:)
         enddo
         CASE ('latt_bounds')
         do ivertex = 1, nverts
            work1(:,:,:) = latt_bounds(ivertex,:,:,:)
            call gather_global(work_g1, work1, master_task, distrb_info)
-           if (my_task == master_task) work_gr3(ivertex,:,:) = work_g1(:,:)
+           if (my_task == master_task) work1_3(ivertex,:,:) = work_g1(:,:)
         enddo
         CASE ('lonu_bounds')
         do ivertex = 1, nverts
            work1(:,:,:) = lonu_bounds(ivertex,:,:,:)
            call gather_global(work_g1, work1, master_task, distrb_info)
-           if (my_task == master_task) work_gr3(ivertex,:,:) = work_g1(:,:)
+           if (my_task == master_task) work1_3(ivertex,:,:) = work_g1(:,:)
         enddo
         CASE ('latu_bounds')
         do ivertex = 1, nverts
            work1(:,:,:) = latu_bounds(ivertex,:,:,:)
            call gather_global(work_g1, work1, master_task, distrb_info)
-           if (my_task == master_task) work_gr3(ivertex,:,:) = work_g1(:,:)
+           if (my_task == master_task) work1_3(ivertex,:,:) = work_g1(:,:)
         enddo
         END SELECT
 
@@ -1309,24 +1121,18 @@
           status = nf90_inq_varid(ncid, var_nverts(i)%short_name, varid)
           if (status /= nf90_noerr) call abort_ice(subname// &
              'ERROR: getting varid for '//var_nverts(i)%short_name)
-          status = nf90_put_var(ncid,varid,work_gr3)
+          status = nf90_put_var(ncid,varid,work1_3)
           if (status /= nf90_noerr) call abort_ice(subname// &
              'ERROR: writing variable '//var_nverts(i)%short_name)
         endif
       enddo
-      deallocate(work_gr3)
+      deallocate(work1_3)
       endif
 
       !-----------------------------------------------------------------
       ! write variable data
       !-----------------------------------------------------------------
 
-      if (my_task==master_task) then
-         allocate(work_gr(nx_global,ny_global))
-      else
-         allocate(work_gr(1,1))     ! to save memory
-      endif
-      work_gr(:,:) = c0
       work_g1(:,:) = c0
 
       do n=1,num_avail_hist_fields_2D
@@ -1334,19 +1140,18 @@
           call gather_global(work_g1, a2D(:,:,n,:), &
                              master_task, distrb_info)
           if (my_task == master_task) then
-            work_gr(:,:) = work_g1(:,:)
             status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: getting varid for '//avail_hist_fields(n)%vname)
-            status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+            status  = nf90_put_var(ncid,varid,work_g1, &
                                    count=(/nx_global,ny_global/))
             if (status /= nf90_noerr) call abort_ice(subname// &
                'ERROR: writing variable '//avail_hist_fields(n)%vname)
           endif
+
         endif
       enddo ! num_avail_hist_fields_2D
 
-      work_gr(:,:) = c0
       work_g1(:,:) = c0
 
       do n = n2D + 1, n3Dccum
@@ -1360,13 +1165,12 @@
           do k = 1, ncat_hist
              call gather_global(work_g1, a3Dc(:,:,k,nn,:), &
                                 master_task, distrb_info)
-             work_gr(:,:) = work_g1(:,:)
 
              if (my_task == master_task) then
              status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
              if (status /= nf90_noerr) call abort_ice(subname// &
                 'ERROR: getting varid for '//avail_hist_fields(n)%vname)
-             status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+             status  = nf90_put_var(ncid,varid,work_g1, &
                                     start=(/        1,        1,k/), &
                                     count=(/nx_global,ny_global,1/))
              if (status /= nf90_noerr) call abort_ice(subname// &
@@ -1376,7 +1180,6 @@
         endif
       enddo ! num_avail_hist_fields_3Dc
 
-      work_gr(:,:) = c0
       work_g1(:,:) = c0
 
       do n = n3Dccum+1, n3Dzcum
@@ -1390,10 +1193,9 @@
           do k = 1, nzilyr
              call gather_global(work_g1, a3Dz(:,:,k,nn,:), &
                                 master_task, distrb_info)
-             work_gr(:,:) = work_g1(:,:)
 
              if (my_task == master_task) then
-             status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+             status  = nf90_put_var(ncid,varid,work_g1, &
                                     start=(/        1,        1,k/), &
                                     count=(/nx_global,ny_global,1/))
              if (status /= nf90_noerr) call abort_ice(subname// &
@@ -1403,7 +1205,6 @@
         endif
       enddo ! num_avail_hist_fields_3Dz
 
-      work_gr(:,:) = c0
       work_g1(:,:) = c0
 
      do n = n3Dzcum+1, n3Dbcum
@@ -1417,10 +1218,9 @@
           do k = 1, nzblyr
              call gather_global(work_g1, a3Db(:,:,k,nn,:), &
                                 master_task, distrb_info)
-             work_gr(:,:) = work_g1(:,:)
 
              if (my_task == master_task) then
-             status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+             status  = nf90_put_var(ncid,varid,work_g1, &
                                     start=(/        1,        1,k/), &
                                     count=(/nx_global,ny_global,1/))
              if (status /= nf90_noerr) call abort_ice(subname// &
@@ -1430,7 +1230,6 @@
         endif
       enddo ! num_avail_hist_fields_3Db
 
-      work_gr(:,:) = c0
       work_g1(:,:) = c0
 
       do n = n3Dbcum+1, n3Dacum
@@ -1444,10 +1243,9 @@
           do k = 1, nzalyr
              call gather_global(work_g1, a3Da(:,:,k,nn,:), &
                                 master_task, distrb_info)
-             work_gr(:,:) = work_g1(:,:)
 
              if (my_task == master_task) then
-             status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+             status  = nf90_put_var(ncid,varid,work_g1, &
                                     start=(/        1,        1,k/), &
                                     count=(/nx_global,ny_global,1/))
              if (status /= nf90_noerr) call abort_ice(subname// &
@@ -1457,7 +1255,6 @@
         endif
       enddo ! num_avail_hist_fields_3Da
 
-      work_gr(:,:) = c0
       work_g1(:,:) = c0
 
       do n = n3Dacum+1, n3Dfcum
@@ -1471,9 +1268,8 @@
           do k = 1, nfsd_hist
              call gather_global(work_g1, a3Df(:,:,k,nn,:), &
                                 master_task, distrb_info)
-             work_gr(:,:) = work_g1(:,:)
              if (my_task == master_task) then
-             status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+             status  = nf90_put_var(ncid,varid,work_g1, &
                                     start=(/        1,        1,k/), &
                                     count=(/nx_global,ny_global,1/))
              if (status /= nf90_noerr) call abort_ice(subname// &
@@ -1483,7 +1279,6 @@
         endif
       enddo ! num_avail_hist_fields_3Df
 
-      work_gr(:,:) = c0
       work_g1(:,:) = c0
 
       do n = n3Dfcum+1, n4Dicum
@@ -1498,9 +1293,8 @@
              do k = 1, nzilyr
                 call gather_global(work_g1, a4Di(:,:,k,ic,nn,:), &
                                 master_task, distrb_info)
-                work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
-                  status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+                  status  = nf90_put_var(ncid,varid,work_g1, &
                                          start=(/        1,        1,k,ic/), &
                                          count=(/nx_global,ny_global,1, 1/))
                   if (status /= nf90_noerr) call abort_ice(subname// &
@@ -1511,7 +1305,6 @@
         endif
       enddo ! num_avail_hist_fields_4Di
 
-      work_gr(:,:) = c0
       work_g1(:,:) = c0
 
       do n = n4Dicum+1, n4Dscum
@@ -1526,9 +1319,8 @@
              do k = 1, nzslyr
                 call gather_global(work_g1, a4Ds(:,:,k,ic,nn,:), &
                                 master_task, distrb_info)
-                work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
-                  status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+                  status  = nf90_put_var(ncid,varid,work_g1, &
                                          start=(/        1,        1,k,ic/), &
                                          count=(/nx_global,ny_global,1, 1/))
                   if (status /= nf90_noerr) call abort_ice(subname// &
@@ -1551,9 +1343,8 @@
              do k = 1, nfsd_hist
                 call gather_global(work_g1, a4Df(:,:,k,ic,nn,:), &
                                 master_task, distrb_info)
-                work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
-                  status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+                  status  = nf90_put_var(ncid,varid,work_g1, &
                                          start=(/        1,        1,k,ic/), &
                                          count=(/nx_global,ny_global,1, 1/))
                   if (status /= nf90_noerr) call abort_ice(subname// &
@@ -1564,7 +1355,6 @@
         endif
       enddo ! num_avail_hist_fields_4Df
 
-      deallocate(work_gr)
       deallocate(work_g1)
 
       !-----------------------------------------------------------------
@@ -1585,6 +1375,43 @@
 #endif
 
       end subroutine ice_write_hist
+
+!=======================================================================
+
+      subroutine ice_write_hist_fill(ncid,varid,vname,precision)
+
+      use ice_kinds_mod
+#ifdef USE_NETCDF
+      use netcdf
+#endif
+
+      integer (kind=int_kind), intent(in) :: ncid   ! netcdf file id
+      integer (kind=int_kind), intent(in) :: varid  ! netcdf var id
+      character(len=*),        intent(in) :: vname  ! var name
+      integer (kind=int_kind), intent(in) :: precision   ! precision
+
+      ! local variables
+
+      integer (kind=int_kind) :: status
+      character(len=*), parameter :: subname = '(ice_write_hist_fill)'
+
+      if (precision == 8) then
+         status = nf90_put_att(ncid,varid,'missing_value',spval_dbl)
+      else
+         status = nf90_put_att(ncid,varid,'missing_value',spval)
+      endif
+      if (status /= nf90_noerr) call abort_ice(subname// &
+         'ERROR: defining missing_value for '//trim(vname))
+
+      if (precision == 8) then
+         status = nf90_put_att(ncid,varid,'_FillValue',spval_dbl)
+      else
+         status = nf90_put_att(ncid,varid,'_FillValue',spval)
+      endif
+      if (status /= nf90_noerr) call abort_ice(subname// &
+         'ERROR: defining _FillValue for '//trim(vname))
+
+      end subroutine ice_write_hist_fill
 
 !=======================================================================
 

--- a/cicecore/cicedynB/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio2/ice_history_write.F90
@@ -116,10 +116,10 @@
       TYPE(coord_attributes), dimension(nvarz) :: var_nz
       CHARACTER (char_len), dimension(ncoord) :: coord_bounds
 
-      real (kind=dbl_kind), allocatable :: workd2(:,:,:)
-      real (kind=dbl_kind), allocatable :: workd3(:,:,:,:)
-      real (kind=dbl_kind), allocatable :: workd4(:,:,:,:,:)
-      real (kind=dbl_kind), allocatable :: workd3v(:,:,:,:)
+      real (kind=dbl_kind) , allocatable :: workd2(:,:,:)
+      real (kind=dbl_kind) , allocatable :: workd3(:,:,:,:)
+      real (kind=dbl_kind) , allocatable :: workd4(:,:,:,:,:)
+      real (kind=dbl_kind) , allocatable :: workd3v(:,:,:,:)
 
       real (kind=real_kind), allocatable :: workr2(:,:,:)
       real (kind=real_kind), allocatable :: workr3(:,:,:,:)

--- a/cicecore/cicedynB/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio2/ice_history_write.F90
@@ -18,6 +18,7 @@
       module ice_history_write
 
       use ice_kinds_mod
+      use ice_constants, only: c0, c360, spval, spval_dbl
       use ice_fileunits, only: nu_diag
       use ice_exit, only: abort_ice
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
@@ -45,7 +46,6 @@
           histfreq, histfreq_n, days_per_year, use_leap_years, dayyr, &
           hh_init, mm_init, ss_init
       use ice_communicate, only: my_task, master_task
-      use ice_constants, only: c0, c360, spval, spval_dbl
       use ice_domain, only: distrb_info, nblocks
       use ice_domain_size, only: nx_global, ny_global, max_blocks, max_nstrm
       use ice_gather_scatter, only: gather_global
@@ -116,10 +116,15 @@
       TYPE(coord_attributes), dimension(nvarz) :: var_nz
       CHARACTER (char_len), dimension(ncoord) :: coord_bounds
 
-      real (kind=dbl_kind), allocatable :: workr2(:,:,:)
-      real (kind=dbl_kind), allocatable :: workr3(:,:,:,:)
-      real (kind=dbl_kind), allocatable :: workr4(:,:,:,:,:)
-      real (kind=dbl_kind), allocatable :: workr3v(:,:,:,:)
+      real (kind=dbl_kind), allocatable :: workd2(:,:,:)
+      real (kind=dbl_kind), allocatable :: workd3(:,:,:,:)
+      real (kind=dbl_kind), allocatable :: workd4(:,:,:,:,:)
+      real (kind=dbl_kind), allocatable :: workd3v(:,:,:,:)
+
+      real (kind=real_kind), allocatable :: workr2(:,:,:)
+      real (kind=real_kind), allocatable :: workr3(:,:,:,:)
+      real (kind=real_kind), allocatable :: workr4(:,:,:,:,:)
+      real (kind=real_kind), allocatable :: workr3v(:,:,:,:)
 
       character(len=char_len_long) :: &
            filename
@@ -164,16 +169,16 @@
       call ice_pio_init(mode='write', filename=trim(filename), File=File, &
         clobber=.true., cdf64=lcdf64, iotype=iotype)
 
-      call ice_pio_initdecomp(iodesc=iodesc2d)
-      call ice_pio_initdecomp(ndim3=ncat_hist, iodesc=iodesc3dc)
-      call ice_pio_initdecomp(ndim3=nzilyr,    iodesc=iodesc3di)
-      call ice_pio_initdecomp(ndim3=nzblyr,    iodesc=iodesc3db)
-      call ice_pio_initdecomp(ndim3=nzalyr,    iodesc=iodesc3da)
-      call ice_pio_initdecomp(ndim3=nfsd_hist, iodesc=iodesc3df)
-      call ice_pio_initdecomp(ndim3=nverts,    iodesc=iodesc3dv, inner_dim=.true.)
-      call ice_pio_initdecomp(ndim3=nzilyr,    ndim4=ncat_hist, iodesc=iodesc4di)
-      call ice_pio_initdecomp(ndim3=nzslyr,    ndim4=ncat_hist, iodesc=iodesc4ds)
-      call ice_pio_initdecomp(ndim3=nfsd_hist, ndim4=ncat_hist, iodesc=iodesc4df)
+      call ice_pio_initdecomp(iodesc=iodesc2d, precision=history_precision)
+      call ice_pio_initdecomp(ndim3=ncat_hist, iodesc=iodesc3dc, precision=history_precision)
+      call ice_pio_initdecomp(ndim3=nzilyr,    iodesc=iodesc3di, precision=history_precision)
+      call ice_pio_initdecomp(ndim3=nzblyr,    iodesc=iodesc3db, precision=history_precision)
+      call ice_pio_initdecomp(ndim3=nzalyr,    iodesc=iodesc3da, precision=history_precision)
+      call ice_pio_initdecomp(ndim3=nfsd_hist, iodesc=iodesc3df, precision=history_precision)
+      call ice_pio_initdecomp(ndim3=nverts,    iodesc=iodesc3dv, inner_dim=.true., precision=history_precision)
+      call ice_pio_initdecomp(ndim3=nzilyr,    ndim4=ncat_hist, iodesc=iodesc4di, precision=history_precision)
+      call ice_pio_initdecomp(ndim3=nzslyr,    ndim4=ncat_hist, iodesc=iodesc4ds, precision=history_precision)
+      call ice_pio_initdecomp(ndim3=nfsd_hist, ndim4=ncat_hist, iodesc=iodesc4df, precision=history_precision)
 
       ltime2 = timesecs/secday
 
@@ -339,13 +344,7 @@
                                 dimid2, varid)
           status = pio_put_att(File,varid,'long_name',trim(coord_var(i)%long_name))
           status = pio_put_att(File, varid, 'units', trim(coord_var(i)%units))
-          if (lprecision == pio_real) then
-             status = pio_put_att(File, varid, 'missing_value', spval)
-             status = pio_put_att(File, varid,'_FillValue',spval)
-          else
-             status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-             status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-          endif
+          call ice_write_hist_fill(File,varid,coord_var(i)%short_name,history_precision)
           if (coord_var(i)%short_name == 'ULAT') then
              status = pio_put_att(File,varid,'comment', &
                   trim('Latitude of NE corner of T grid cell'))
@@ -377,13 +376,7 @@
            status = pio_def_var(File, 'tmask', lprecision, dimid2, varid)
            status = pio_put_att(File,varid, 'long_name', 'ocean grid mask') 
            status = pio_put_att(File, varid, 'coordinates', 'TLON TLAT')
-           if (lprecision == pio_real) then
-              status = pio_put_att(File, varid, 'missing_value', spval)
-              status = pio_put_att(File, varid,'_FillValue',spval)
-           else
-              status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-              status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-           endif
+           call ice_write_hist_fill(File,varid,'tmask',history_precision)
            status = pio_put_att(File,varid,'comment', '0 = land, 1 = ocean')
         endif
         if (igrd(n_blkmask)) then
@@ -391,13 +384,7 @@
            status = pio_put_att(File,varid, 'long_name', 'ice grid block mask') 
            status = pio_put_att(File, varid, 'coordinates', 'TLON TLAT')
            status = pio_put_att(File,varid,'comment', 'mytask + iblk/100')
-           if (lprecision == pio_real) then
-              status = pio_put_att(File, varid, 'missing_value', spval)
-              status = pio_put_att(File, varid,'_FillValue',spval)
-           else
-              status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-              status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-           endif
+           call ice_write_hist_fill(File,varid,'blkmask',history_precision)
         endif
 
         do i = 3, nvar       ! note: n_tmask=1, n_blkmask=2
@@ -407,13 +394,7 @@
              status = pio_put_att(File,varid, 'long_name', trim(var(i)%req%long_name))
              status = pio_put_att(File, varid, 'units', trim(var(i)%req%units))
              status = pio_put_att(File, varid, 'coordinates', trim(var(i)%coordinates))
-             if (lprecision == pio_real) then
-                status = pio_put_att(File, varid, 'missing_value', spval)
-                status = pio_put_att(File, varid,'_FillValue',spval)
-             else
-                status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-                status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-             endif
+             call ice_write_hist_fill(File,varid,var(i)%req%short_name,history_precision)
           endif
         enddo
 
@@ -429,13 +410,7 @@
              pio_put_att(File,varid, 'long_name', trim(var_nverts(i)%long_name))
              status = &
              pio_put_att(File, varid, 'units', trim(var_nverts(i)%units))
-             if (lprecision == pio_real) then
-                status = pio_put_att(File, varid, 'missing_value', spval)
-                status = pio_put_att(File, varid,'_FillValue',spval)
-             else
-                status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-                status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-             endif
+             call ice_write_hist_fill(File,varid,var_nverts(i)%short_name,history_precision)
           endif
         enddo
  
@@ -463,13 +438,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -518,13 +487,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -561,13 +524,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -604,13 +561,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -647,13 +598,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -690,13 +635,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -739,13 +678,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -783,13 +716,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -828,13 +755,7 @@
                         trim(avail_hist_fields(n)%vcoord))
             status = pio_put_att(File,varid,'cell_measures', &
                         trim(avail_hist_fields(n)%vcellmeas))
-            if (lprecision == pio_real) then
-               status = pio_put_att(File, varid, 'missing_value', spval)
-               status = pio_put_att(File, varid,'_FillValue',spval)
-            else
-               status = pio_put_att(File, varid, 'missing_value', spval_dbl)
-               status = pio_put_att(File, varid,'_FillValue',spval_dbl)
-            endif
+            call ice_write_hist_fill(File,varid,avail_hist_fields(n)%vname,history_precision)
 
             ! Add cell_methods attribute to variables if averaged
             if (hist_avg) then
@@ -928,6 +849,7 @@
       ! write coordinate variables
       !-----------------------------------------------------------------
 
+        allocate(workd2(nx_block,ny_block,nblocks))
         allocate(workr2(nx_block,ny_block,nblocks))
 
         do i = 1,ncoord
@@ -935,16 +857,22 @@
           SELECT CASE (coord_var(i)%short_name)
             CASE ('TLON')
               ! Convert T grid longitude from -180 -> 180 to 0 to 360
-                 workr2(:,:,:) = mod(tlon(:,:,1:nblocks)*rad_to_deg + c360, c360)
+                 workd2(:,:,:) = mod(tlon(:,:,1:nblocks)*rad_to_deg + c360, c360)
             CASE ('TLAT')
-              workr2(:,:,:) = tlat(:,:,1:nblocks)*rad_to_deg
+              workd2(:,:,:) = tlat(:,:,1:nblocks)*rad_to_deg
             CASE ('ULON')
-              workr2(:,:,:) = ulon(:,:,1:nblocks)*rad_to_deg
+              workd2(:,:,:) = ulon(:,:,1:nblocks)*rad_to_deg
             CASE ('ULAT')
-              workr2(:,:,:) = ulat(:,:,1:nblocks)*rad_to_deg
+              workd2(:,:,:) = ulat(:,:,1:nblocks)*rad_to_deg
           END SELECT
-          call pio_write_darray(File, varid, iodesc2d, &
-               workr2, status, fillval=spval_dbl)
+          if (history_precision == 8) then
+             call pio_write_darray(File, varid, iodesc2d, &
+                  workd2, status, fillval=spval_dbl)
+          else
+             workr2 = workd2
+             call pio_write_darray(File, varid, iodesc2d, &
+                  workr2, status, fillval=spval)
+          endif
         enddo
 
         ! Extra dimensions (NCAT, NFSD, VGRD*)
@@ -988,33 +916,39 @@
          if (igrd(i)) then
             SELECT CASE (var(i)%req%short_name)
             CASE ('tmask')
-               workr2 = hm(:,:,1:nblocks)
+               workd2 = hm(:,:,1:nblocks)
             CASE ('blkmask')
-               workr2 = bm(:,:,1:nblocks)
+               workd2 = bm(:,:,1:nblocks)
             CASE ('tarea')
-               workr2 = tarea(:,:,1:nblocks)
+               workd2 = tarea(:,:,1:nblocks)
             CASE ('uarea')
-               workr2 = uarea(:,:,1:nblocks)
+               workd2 = uarea(:,:,1:nblocks)
             CASE ('dxu')
-               workr2 = dxu(:,:,1:nblocks)
+               workd2 = dxu(:,:,1:nblocks)
             CASE ('dyu')
-               workr2 = dyu(:,:,1:nblocks)
+               workd2 = dyu(:,:,1:nblocks)
             CASE ('dxt')
-               workr2 = dxt(:,:,1:nblocks)
+               workd2 = dxt(:,:,1:nblocks)
             CASE ('dyt')
-               workr2 = dyt(:,:,1:nblocks)
+               workd2 = dyt(:,:,1:nblocks)
             CASE ('HTN')
-               workr2 = HTN(:,:,1:nblocks)
+               workd2 = HTN(:,:,1:nblocks)
             CASE ('HTE')
-               workr2 = HTE(:,:,1:nblocks)
+               workd2 = HTE(:,:,1:nblocks)
             CASE ('ANGLE')
-               workr2 = ANGLE(:,:,1:nblocks)
+               workd2 = ANGLE(:,:,1:nblocks)
             CASE ('ANGLET')
-               workr2 = ANGLET(:,:,1:nblocks)
+               workd2 = ANGLET(:,:,1:nblocks)
             END SELECT
             status = pio_inq_varid(File, var(i)%req%short_name, varid)
-            call pio_write_darray(File, varid, iodesc2d, &
-                 workr2, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc2d, &
+                    workd2, status, fillval=spval_dbl)
+            else
+               workr2 = workd2
+               call pio_write_darray(File, varid, iodesc2d, &
+                    workr2, status, fillval=spval)
+            endif
          endif
       enddo
 
@@ -1023,32 +957,40 @@
       !----------------------------------------------------------------
 
       if (f_bounds) then
+      allocate(workd3v(nverts,nx_block,ny_block,nblocks))
       allocate(workr3v(nverts,nx_block,ny_block,nblocks))
-      workr3v (:,:,:,:) = c0
+      workd3v (:,:,:,:) = c0
       do i = 1, nvar_verts
         SELECT CASE (var_nverts(i)%short_name)
         CASE ('lont_bounds')
            do ivertex = 1, nverts 
-              workr3v(ivertex,:,:,:) = lont_bounds(ivertex,:,:,1:nblocks)
+              workd3v(ivertex,:,:,:) = lont_bounds(ivertex,:,:,1:nblocks)
            enddo
         CASE ('latt_bounds')
            do ivertex = 1, nverts 
-              workr3v(ivertex,:,:,:) = latt_bounds(ivertex,:,:,1:nblocks)
+              workd3v(ivertex,:,:,:) = latt_bounds(ivertex,:,:,1:nblocks)
            enddo
         CASE ('lonu_bounds')
            do ivertex = 1, nverts 
-              workr3v(ivertex,:,:,:) = lonu_bounds(ivertex,:,:,1:nblocks)
+              workd3v(ivertex,:,:,:) = lonu_bounds(ivertex,:,:,1:nblocks)
            enddo
         CASE ('latu_bounds')
            do ivertex = 1, nverts 
-              workr3v(ivertex,:,:,:) = latu_bounds(ivertex,:,:,1:nblocks)
+              workd3v(ivertex,:,:,:) = latu_bounds(ivertex,:,:,1:nblocks)
            enddo
         END SELECT
 
           status = pio_inq_varid(File, var_nverts(i)%short_name, varid)
-          call pio_write_darray(File, varid, iodesc3dv, &
-                                workr3v, status, fillval=spval_dbl)
+          if (history_precision == 8) then
+             call pio_write_darray(File, varid, iodesc3dv, &
+                                   workd3v, status, fillval=spval_dbl)
+          else
+             workr3v = workd3v
+             call pio_write_darray(File, varid, iodesc3dv, &
+                                   workr3v, status, fillval=spval)
+          endif
       enddo
+      deallocate(workd3v)
       deallocate(workr3v)
       endif  ! f_bounds
 
@@ -1063,20 +1005,28 @@
             status  = pio_inq_varid(File,avail_hist_fields(n)%vname,varid)
             if (status /= pio_noerr) call abort_ice(subname// &
                'ERROR getting varid for '//avail_hist_fields(n)%vname)
-            workr2(:,:,:) = a2D(:,:,n,1:nblocks)
+            workd2(:,:,:) = a2D(:,:,n,1:nblocks)
 #ifdef CESM1_PIO
             call pio_setframe(varid, int(1,kind=PIO_OFFSET))
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc2d,&
-                                  workr2, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc2d,&
+                                     workd2, status, fillval=spval_dbl)
+            else
+               workr2 = workd2
+               call pio_write_darray(File, varid, iodesc2d,&
+                                     workr2, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_2D
 
+      deallocate(workd2)
       deallocate(workr2)
 
       ! 3D (category)
+      allocate(workd3(nx_block,ny_block,nblocks,ncat_hist))
       allocate(workr3(nx_block,ny_block,nblocks,ncat_hist))
       do n = n2D + 1, n3Dccum
          nn = n - n2D
@@ -1086,7 +1036,7 @@
                'ERROR: getting varid for '//avail_hist_fields(n)%vname)
             do j = 1, nblocks
             do i = 1, ncat_hist
-               workr3(:,:,j,i) = a3Dc(:,:,i,nn,j)
+               workd3(:,:,j,i) = a3Dc(:,:,i,nn,j)
             enddo
             enddo
 #ifdef CESM1_PIO
@@ -1094,13 +1044,21 @@
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc3dc,&
-                                  workr3, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc3dc,&
+                                     workd3, status, fillval=spval_dbl)
+            else
+               workr3 = workd3
+               call pio_write_darray(File, varid, iodesc3dc,&
+                                     workr3, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_3Dc
+      deallocate(workd3)
       deallocate(workr3)
 
       ! 3D (vertical ice)
+      allocate(workd3(nx_block,ny_block,nblocks,nzilyr))
       allocate(workr3(nx_block,ny_block,nblocks,nzilyr))
       do n = n3Dccum+1, n3Dzcum
          nn = n - n3Dccum
@@ -1110,7 +1068,7 @@
                'ERROR: getting varid for '//avail_hist_fields(n)%vname)
             do j = 1, nblocks
             do i = 1, nzilyr
-               workr3(:,:,j,i) = a3Dz(:,:,i,nn,j)
+               workd3(:,:,j,i) = a3Dz(:,:,i,nn,j)
             enddo
             enddo
 #ifdef CESM1_PIO
@@ -1118,13 +1076,21 @@
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc3di,&
-                                  workr3, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc3di,&
+                                     workd3, status, fillval=spval_dbl)
+            else
+               workr3 = workd3
+               call pio_write_darray(File, varid, iodesc3di,&
+                                     workr3, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_3Dz
+      deallocate(workd3)
       deallocate(workr3)
 
       ! 3D (vertical ice biology)
+      allocate(workd3(nx_block,ny_block,nblocks,nzblyr))
       allocate(workr3(nx_block,ny_block,nblocks,nzblyr))
       do n = n3Dzcum+1, n3Dbcum
          nn = n - n3Dzcum
@@ -1134,7 +1100,7 @@
                'ERROR: getting varid for '//avail_hist_fields(n)%vname)
             do j = 1, nblocks
             do i = 1, nzblyr
-               workr3(:,:,j,i) = a3Db(:,:,i,nn,j)
+               workd3(:,:,j,i) = a3Db(:,:,i,nn,j)
             enddo
             enddo
 #ifdef CESM1_PIO
@@ -1142,13 +1108,21 @@
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc3db,&
-                                  workr3, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc3db,&
+                                     workd3, status, fillval=spval_dbl)
+            else
+               workr3 = workd3
+               call pio_write_darray(File, varid, iodesc3db,&
+                                     workr3, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_3Db
+      deallocate(workd3)
       deallocate(workr3)
 
       ! 3D (vertical snow biology)
+      allocate(workd3(nx_block,ny_block,nblocks,nzalyr))
       allocate(workr3(nx_block,ny_block,nblocks,nzalyr))
       do n = n3Dbcum+1, n3Dacum
          nn = n - n3Dbcum
@@ -1158,7 +1132,7 @@
                'ERROR: getting varid for '//avail_hist_fields(n)%vname)
             do j = 1, nblocks
             do i = 1, nzalyr
-               workr3(:,:,j,i) = a3Da(:,:,i,nn,j)
+               workd3(:,:,j,i) = a3Da(:,:,i,nn,j)
             enddo
             enddo
 #ifdef CESM1_PIO
@@ -1166,13 +1140,21 @@
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc3da,&
-                                  workr3, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc3da,&
+                                     workd3, status, fillval=spval_dbl)
+            else
+               workr3 = workd3
+               call pio_write_darray(File, varid, iodesc3da,&
+                                     workr3, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_3Db
+      deallocate(workd3)
       deallocate(workr3)
 
       ! 3D (fsd)
+      allocate(workd3(nx_block,ny_block,nblocks,nfsd_hist))
       allocate(workr3(nx_block,ny_block,nblocks,nfsd_hist))
       do n = n3Dacum+1, n3Dfcum
          nn = n - n3Dacum
@@ -1182,7 +1164,7 @@
                'ERROR: getting varid for '//avail_hist_fields(n)%vname)
             do j = 1, nblocks
             do i = 1, nfsd_hist
-               workr3(:,:,j,i) = a3Df(:,:,i,nn,j)
+               workd3(:,:,j,i) = a3Df(:,:,i,nn,j)
             enddo
             enddo
 #ifdef CESM1_PIO
@@ -1190,12 +1172,20 @@
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc3df,&
-                                  workr3, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc3df,&
+                                     workd3, status, fillval=spval_dbl)
+            else
+               workr3 = workd3
+               call pio_write_darray(File, varid, iodesc3df,&
+                                     workr3, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_3Df
+      deallocate(workd3)
       deallocate(workr3)
 
+      allocate(workd4(nx_block,ny_block,nblocks,ncat_hist,nzilyr))
       allocate(workr4(nx_block,ny_block,nblocks,ncat_hist,nzilyr))
       ! 4D (categories, fsd)
       do n = n3Dfcum+1, n4Dicum
@@ -1207,7 +1197,7 @@
             do j = 1, nblocks
             do i = 1, ncat_hist
             do k = 1, nzilyr
-               workr4(:,:,j,i,k) = a4Di(:,:,k,i,nn,j)
+               workd4(:,:,j,i,k) = a4Di(:,:,k,i,nn,j)
             enddo ! k
             enddo ! i
             enddo ! j
@@ -1216,12 +1206,20 @@
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc4di,&
-                                  workr4, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc4di,&
+                                     workd4, status, fillval=spval_dbl)
+            else
+               workr4 = workd4
+               call pio_write_darray(File, varid, iodesc4di,&
+                                     workr4, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_4Di
+      deallocate(workd4)
       deallocate(workr4)
 
+      allocate(workd4(nx_block,ny_block,nblocks,ncat_hist,nzslyr))
       allocate(workr4(nx_block,ny_block,nblocks,ncat_hist,nzslyr))
       ! 4D (categories, vertical ice)
       do n = n4Dicum+1, n4Dscum
@@ -1233,7 +1231,7 @@
             do j = 1, nblocks
             do i = 1, ncat_hist
             do k = 1, nzslyr
-               workr4(:,:,j,i,k) = a4Ds(:,:,k,i,nn,j)
+               workd4(:,:,j,i,k) = a4Ds(:,:,k,i,nn,j)
             enddo ! k
             enddo ! i
             enddo ! j
@@ -1242,12 +1240,20 @@
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc4ds,&
-                                  workr4, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc4ds,&
+                                     workd4, status, fillval=spval_dbl)
+            else
+               workr4 = workd4
+               call pio_write_darray(File, varid, iodesc4ds,&
+                                     workr4, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_4Ds
+      deallocate(workd4)
       deallocate(workr4)
 
+      allocate(workd4(nx_block,ny_block,nblocks,ncat_hist,nfsd_hist))
       allocate(workr4(nx_block,ny_block,nblocks,ncat_hist,nfsd_hist))
       ! 4D (categories, vertical ice)
       do n = n4Dscum+1, n4Dfcum
@@ -1259,7 +1265,7 @@
             do j = 1, nblocks
             do i = 1, ncat_hist
             do k = 1, nfsd_hist
-               workr4(:,:,j,i,k) = a4Df(:,:,k,i,nn,j)
+               workd4(:,:,j,i,k) = a4Df(:,:,k,i,nn,j)
             enddo ! k
             enddo ! i
             enddo ! j
@@ -1268,13 +1274,20 @@
 #else
             call pio_setframe(File, varid, int(1,kind=PIO_OFFSET_KIND))
 #endif
-            call pio_write_darray(File, varid, iodesc4df,&
-                                  workr4, status, fillval=spval_dbl)
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc4df,&
+                                     workd4, status, fillval=spval_dbl)
+            else
+               workr4 = workd4
+               call pio_write_darray(File, varid, iodesc4df,&
+                                     workr4, status, fillval=spval)
+            endif
          endif
       enddo ! num_avail_hist_fields_4Df
+      deallocate(workd4)
       deallocate(workr4)
 
-!     similarly for num_avail_hist_fields_4Db (define workr4b, iodesc4db)
+!     similarly for num_avail_hist_fields_4Db (define workd4b, iodesc4db)
 
 
       !-----------------------------------------------------------------
@@ -1303,6 +1316,34 @@
       endif
 
       end subroutine ice_write_hist
+
+!=======================================================================
+
+      subroutine ice_write_hist_fill(File,varid,vname,precision)
+
+      use ice_kinds_mod
+      use ice_pio
+      use pio
+
+      type(file_desc_t)      , intent(inout) :: File
+      type(var_desc_t)       , intent(in) :: varid
+      character(len=*),        intent(in) :: vname  ! var name
+      integer (kind=int_kind), intent(in) :: precision   ! precision
+
+      ! local variables
+
+      integer (kind=int_kind) :: status
+      character(len=*), parameter :: subname = '(ice_write_hist_fill)'
+
+      if (precision == 8) then
+         status = pio_put_att(File, varid, 'missing_value', spval_dbl)
+         status = pio_put_att(File, varid,'_FillValue',spval_dbl)
+      else
+         status = pio_put_att(File, varid, 'missing_value', spval)
+         status = pio_put_att(File, varid,'_FillValue',spval)
+      endif
+
+      end subroutine ice_write_hist_fill
 
 !=======================================================================
 

--- a/cicecore/cicedynB/infrastructure/io/io_pio2/ice_pio.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio2/ice_pio.F90
@@ -197,9 +197,10 @@
 
 !================================================================================
 
-   subroutine ice_pio_initdecomp_2d(iodesc)
+   subroutine ice_pio_initdecomp_2d(iodesc, precision)
 
       type(io_desc_t), intent(out) :: iodesc
+      integer(kind=int_kind), optional, intent(in) :: precision
 
       integer (kind=int_kind) :: &
           iblk,ilo,ihi,jlo,jhi,lon,lat,i,j,n,k
@@ -207,7 +208,11 @@
       type(block) :: this_block 
 
       integer(kind=int_kind), pointer :: dof2d(:)
+      integer(kind=int_kind) :: lprecision
       character(len=*), parameter :: subname = '(ice_pio_initdecomp_2d)'
+
+      lprecision = 8
+      if (present(precision)) lprecision = precision
 
       allocate(dof2d(nx_block*ny_block*nblocks))
 
@@ -235,8 +240,13 @@
          enddo !j
       end do
 
-      call pio_initdecomp(ice_pio_subsystem, pio_double, (/nx_global,ny_global/), &
-           dof2d, iodesc)
+      if (lprecision == 8) then
+         call pio_initdecomp(ice_pio_subsystem, pio_double, (/nx_global,ny_global/), &
+              dof2d, iodesc)
+      else
+         call pio_initdecomp(ice_pio_subsystem, pio_real, (/nx_global,ny_global/), &
+              dof2d, iodesc)
+      endif
 
       deallocate(dof2d)
  
@@ -244,18 +254,23 @@
 
 !================================================================================
 
-   subroutine ice_pio_initdecomp_3d (ndim3, iodesc, remap)
+   subroutine ice_pio_initdecomp_3d (ndim3, iodesc, remap, precision)
 
       integer(kind=int_kind), intent(in) :: ndim3
       type(io_desc_t), intent(out) :: iodesc
       logical, optional :: remap
+      integer(kind=int_kind), optional, intent(in) :: precision
       integer (kind=int_kind) :: &
           iblk,ilo,ihi,jlo,jhi,lon,lat,i,j,n,k 
 
       type(block) :: this_block 
       logical :: lremap
       integer(kind=int_kind), pointer :: dof3d(:)
+      integer(kind=int_kind) :: lprecision
       character(len=*), parameter :: subname = '(ice_pio_initdecomp_2d)'
+
+      lprecision = 8
+      if (present(precision)) lprecision = precision
 
       allocate(dof3d(nx_block*ny_block*nblocks*ndim3))
       lremap=.false.
@@ -313,8 +328,13 @@
          enddo !ndim3
       endif
 
-      call pio_initdecomp(ice_pio_subsystem, pio_double, (/nx_global,ny_global,ndim3/), &
-           dof3d, iodesc)
+      if (lprecision == 8) then
+         call pio_initdecomp(ice_pio_subsystem, pio_double, (/nx_global,ny_global,ndim3/), &
+              dof3d, iodesc)
+      else
+         call pio_initdecomp(ice_pio_subsystem, pio_real, (/nx_global,ny_global,ndim3/), &
+              dof3d, iodesc)
+      endif
 
       deallocate(dof3d)
 
@@ -322,11 +342,12 @@
 
 !================================================================================
 
-   subroutine ice_pio_initdecomp_3d_inner(ndim3, inner_dim, iodesc)
+   subroutine ice_pio_initdecomp_3d_inner(ndim3, inner_dim, iodesc, precision)
 
       integer(kind=int_kind), intent(in) :: ndim3
       logical, intent(in) :: inner_dim
       type(io_desc_t), intent(out) :: iodesc
+      integer(kind=int_kind), optional, intent(in) :: precision
 
       integer (kind=int_kind) :: &
           iblk,ilo,ihi,jlo,jhi,lon,lat,i,j,n,k 
@@ -334,8 +355,11 @@
       type(block) :: this_block 
 
       integer(kind=int_kind), pointer :: dof3d(:)
-
+      integer(kind=int_kind) :: lprecision
       character(len=*), parameter :: subname = '(ice_pio_initdecomp_3d_inner)'
+
+      lprecision = 8
+      if (present(precision)) lprecision = precision
 
       allocate(dof3d(nx_block*ny_block*nblocks*ndim3))
 
@@ -365,8 +389,13 @@
          enddo  !j
       end do    !iblk
 
-      call pio_initdecomp(ice_pio_subsystem, pio_double, (/ndim3,nx_global,ny_global/), &
-           dof3d, iodesc)
+      if (lprecision == 8) then
+         call pio_initdecomp(ice_pio_subsystem, pio_double, (/ndim3,nx_global,ny_global/), &
+              dof3d, iodesc)
+      else
+         call pio_initdecomp(ice_pio_subsystem, pio_real, (/ndim3,nx_global,ny_global/), &
+              dof3d, iodesc)
+      endif
 
       deallocate(dof3d)
 
@@ -374,10 +403,11 @@
 
 !================================================================================
 
-   subroutine ice_pio_initdecomp_4d (ndim3, ndim4, iodesc)
+   subroutine ice_pio_initdecomp_4d (ndim3, ndim4, iodesc, precision)
 
       integer(kind=int_kind), intent(in) :: ndim3, ndim4
       type(io_desc_t), intent(out) :: iodesc
+      integer(kind=int_kind), optional, intent(in) :: precision
 
       integer (kind=int_kind) :: &
           iblk,ilo,ihi,jlo,jhi,lon,lat,i,j,n,k,l 
@@ -385,8 +415,11 @@
       type(block) :: this_block 
 
       integer(kind=int_kind), pointer :: dof4d(:)
-
+      integer(kind=int_kind) :: lprecision
       character(len=*), parameter :: subname = '(ice_pio_initdecomp_4d)'
+
+      lprecision = 8
+      if (present(precision)) lprecision = precision
 
       allocate(dof4d(nx_block*ny_block*nblocks*ndim3*ndim4))
 
@@ -420,8 +453,13 @@
       enddo !ndim3
       enddo !ndim4
 
-      call pio_initdecomp(ice_pio_subsystem, pio_double, &
-          (/nx_global,ny_global,ndim3,ndim4/), dof4d, iodesc)
+      if (lprecision == 8) then
+         call pio_initdecomp(ice_pio_subsystem, pio_double, &
+             (/nx_global,ny_global,ndim3,ndim4/), dof4d, iodesc)
+      else
+         call pio_initdecomp(ice_pio_subsystem, pio_real, &
+             (/nx_global,ny_global,ndim3,ndim4/), dof4d, iodesc)
+      endif
 
       deallocate(dof4d)
 

--- a/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
@@ -83,8 +83,8 @@
          File%fh=-1
          call ice_pio_init(mode='read', filename=trim(filename), File=File, iotype=iotype)
       
-         call ice_pio_initdecomp(iodesc=iodesc2d)
-         call ice_pio_initdecomp(ndim3=ncat  , iodesc=iodesc3d_ncat,remap=.true.)
+         call ice_pio_initdecomp(iodesc=iodesc2d, precision=8)
+         call ice_pio_initdecomp(ndim3=ncat  , iodesc=iodesc3d_ncat,remap=.true., precision=8)
 
          if (use_restart_time) then
             status1 = PIO_noerr
@@ -649,8 +649,8 @@
          deallocate(dims)
          status = pio_enddef(File)
 
-         call ice_pio_initdecomp(iodesc=iodesc2d)
-         call ice_pio_initdecomp(ndim3=ncat  , iodesc=iodesc3d_ncat, remap=.true.)
+         call ice_pio_initdecomp(iodesc=iodesc2d, precision=8)
+         call ice_pio_initdecomp(ndim3=ncat  , iodesc=iodesc3d_ncat, remap=.true., precision=8)
 
 !     endif  ! restart_format
 


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix history single/double precision issues
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    All tests pass bit-for-bit on cheyenne with 3 compilers, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#a779775c6e0cf1dd0f5153b8e97aeedda1b555de.  The only failing test is the gx1prod test which is expected.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

- Fix io_netcdf.  Double precision output was passed thru a single precision variable before writing so the precision in the output was lost.  This is now fixed.  Single and double precision netcdf output now reflects the internal model data correctly.
    
- Fix io_pio2.  Single precision output with pio2 was producing garbage for both netcdf and pnetcdf cases.  This is not the case with pio1.  Several changes were needed.
      - The iodesc initialization has to differentiate single or double target variables
      - The write_darray has to explicitly send a single or double array
    
- Migrated to spval_dbl fills everywhere data is a double type, mostly in ice_history.F90.
    
- Created a ice_write_hist_fill method in both io_netcdf and io_pio2 to improve reuse.
    
Ran io_suite on cheyenne and checked that values are produced correctly for each case.

Closes #625.
