### PR TITLE
Add allocation checks for accumulating history variables.

### DIFF
--- a/cicecore/cicedynB/analysis/ice_history_bgc.F90
+++ b/cicecore/cicedynB/analysis/ice_history_bgc.F90
@@ -778,9 +778,9 @@
 
       ! 2D variables
 
-    if (tr_iso .or. tr_aero .or. tr_brine .or. solve_zsal .or. skl_bgc) then
+     if (tr_iso .or. tr_aero .or. tr_brine .or. solve_zsal .or. skl_bgc) then
 
-    do ns = 1, nstreams
+     do ns = 1, nstreams
        if (histfreq(ns) /= 'x') then
 
       if (f_iso(1:1) /= 'x') then
@@ -1782,9 +1782,9 @@
              ns, f_hbri)
 
        endif ! histfreq(ns) /= 'x'
-    enddo ! nstreams
+     enddo ! nstreams
 
-    endif ! tr_aero, etc 
+     endif ! tr_aero, etc 
       
       end subroutine init_hist_bgc_2D
 
@@ -1841,7 +1841,7 @@
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)
 
-    if (z_tracers .or. solve_zsal) then
+     if (z_tracers .or. solve_zsal) then
 
       do ns = 1, nstreams
          if (histfreq(ns) /= 'x') then
@@ -1880,7 +1880,7 @@
          endif ! histfreq(ns) /= 'x'
       enddo  ! ns
 
-    endif  ! z_tracers or solve_zsal
+     endif  ! z_tracers or solve_zsal
 
       end subroutine init_hist_bgc_3Db
 
@@ -2017,10 +2017,10 @@
       ! increment field
       !---------------------------------------------------------------
 
-    ! 2d bgc fields
-    if (allocated(a2D)) then
+     ! 2d bgc fields
+     if (allocated(a2D)) then
 
-    if (tr_iso .or. tr_aero .or. tr_brine .or. solve_zsal .or. skl_bgc) then
+     if (tr_iso .or. tr_aero .or. tr_brine .or. solve_zsal .or. skl_bgc) then
 
       ! zsalinity
       if (f_fzsal  (1:1) /= 'x') &  
@@ -2082,7 +2082,7 @@
          enddo
       endif
 
-    if (skl_bgc) then
+     if (skl_bgc) then
 
       ! skeletal layer bgc
 
@@ -2159,7 +2159,7 @@
          call accum_hist_field(n_bgc_DMS,  iblk, &
                 sk_l*trcr(:,:,nt_bgc_DMS,  iblk), a2D)   
 
-    endif  !skl_bgc 
+     endif  !skl_bgc 
 
       ! skeletal layer and vertical bgc 
 
@@ -2354,7 +2354,7 @@
 
       ! vertical biogeochemistry  
 
-    if (z_tracers) then
+     if (z_tracers) then
 
       if (f_fzaero(1:1)/= 'x') then
          do n=1,n_zaero
@@ -2634,30 +2634,30 @@
          call accum_hist_field(n_PONfrac,   iblk, &
                    trcr(:,:,nt_zbgc_frac - 1 + nlt_bgc_PON, iblk), a2D)
 
-    endif  ! z_tracers
+     endif  ! z_tracers
 
       ! brine
       if (f_hbri  (1:1) /= 'x') &
          call accum_hist_field(n_hbri,     iblk, &
                         hbri(:,:,iblk), a2D)
 
-    endif ! 2d bgc tracers, tr_aero, tr_brine, solve_zsal, skl_bgc
-    endif ! allocated(a2D)
+     endif ! 2d bgc tracers, tr_aero, tr_brine, solve_zsal, skl_bgc
+     endif ! allocated(a2D)
 
       ! 3D category fields
 
-    if (allocated(a3Dc)) then
-    if (tr_brine) then
+     if (allocated(a3Dc)) then
+     if (tr_brine) then
       ! 3Dc bgc category fields
 
       if (f_fbri   (1:1) /= 'x') &
          call accum_hist_field(n_fbri-n2D, iblk, ncat_hist, &
                                trcrn(:,:,nt_fbri,1:ncat_hist,iblk), a3Dc)
-    endif
-    endif ! allocated(a3Dc)
+     endif
+     endif ! allocated(a3Dc)
 
-    if (allocated(a3Db)) then
-    if (z_tracers .or. solve_zsal) then
+     if (allocated(a3Db)) then
+     if (z_tracers .or. solve_zsal) then
       ! 3Db category fields
 
       if (f_bTin  (1:1) /= 'x')  then
@@ -2763,11 +2763,11 @@
                                   workz(:,:,1:nzblyr), a3Db)
       endif
 
-    endif ! 3Db fields
-    endif ! allocated(a3Db)
+     endif ! 3Db fields
+     endif ! allocated(a3Db)
 
-    if (allocated(a3Da)) then
-    if (z_tracers) then
+     if (allocated(a3Da)) then
+     if (z_tracers) then
       ! 3Da category fields
 
       if (f_zaero   (1:1) /= 'x') then
@@ -3223,11 +3223,11 @@
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)
 
-    ! snow+bio grid
+     ! snow+bio grid
+ 
+     if (z_tracers) then
 
-    if (z_tracers) then
-
-    do ns = 1, nstreams
+     do ns = 1, nstreams
        if (histfreq(ns) /= 'x') then
  
 !----------------------------------------------------------------------------

--- a/cicecore/cicedynB/analysis/ice_history_drag.F90
+++ b/cicecore/cicedynB/analysis/ice_history_drag.F90
@@ -263,6 +263,8 @@
 
       ! 2D fields
 
+      if (allocated(a2D)) then
+
       if (f_Cdn_atm     (1:1) /= 'x') &
         call accum_hist_field(n_Cdn_atm, iblk, Cdn_atm(:,:,iblk), a2D)
       if (f_Cdn_ocn     (1:1) /= 'x') &
@@ -294,6 +296,7 @@
                               iblk, Cdn_ocn_skin(:,:,iblk), a2D)  
       end if
 
+      endif ! if(allocated(a2D))
       endif ! formdrag
 
       end subroutine accum_hist_drag


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Add allocated checks for accumulation of history variables. 
- [X] Developer(s): 
D. Bailey (dabail10)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
I have run this for a month with daily and monthly output on cheyenne_intel.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
This is a fix for issue #521 raised by @phil-blain . The fix is to check that the a2D, a3Dc, etc. arrays are allocated before doing the accumulation. Also, print a warning if there are no fields going to the history. Also added some spaces in ice_history_bgc.F90. Some the lines did not start in column 6.