### PR TITLE
Ensure binary identical restart files when using EAP

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
@@ -326,11 +326,18 @@
          do j = 1, ny_block
          do i = 1, nx_block
             if (icetmask(i,j,iblk)==0) then
+               if (tmask(i,j,iblk)) then
             ! structure tensor
-               a11_1(i,j,iblk) = p5
-               a11_2(i,j,iblk) = p5
-               a11_3(i,j,iblk) = p5
-               a11_4(i,j,iblk) = p5
+                  a11_1(i,j,iblk) = p5
+                  a11_2(i,j,iblk) = p5
+                  a11_3(i,j,iblk) = p5
+                  a11_4(i,j,iblk) = p5
+                else
+                  a11_1(i,j,iblk) = c0
+                  a11_2(i,j,iblk) = c0
+                  a11_3(i,j,iblk) = c0
+                  a11_4(i,j,iblk) = c0
+               endif
                a12_1(i,j,iblk) = c0
                a12_2(i,j,iblk) = c0
                a12_3(i,j,iblk) = c0


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>

## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    Set  a11_1, a11_2, a11_3, a11_4 to zero on all land points. This ensure bfb when runing baseline. test
 If not set to zero this will differ from the restart dump of masked blocks.
- [ ] Developer(s): 
     @TillRasmussen 
- [ ] Suggest PR reviewers from list in the column to the right.
- [ ] @eclare108213 @apcraig 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    Following test was run 
./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite --mach freya --env intel,gnu --testid baseeap3 --bgen baseeap3
All test was forced to run with eap.
With the following result
#totl = 1192 total
#chkd = 1192 checked
#pass = 1173
#pend = 14
#miss = 5
#fail = 0
    #failbuild = 0
    #failrun   = 0
    #failtest  = 0
    #failcomp  = 0
    #failbfbc  = 0
    #failgen   = 0

- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [] different at roundoff level
    - [ ] more substantial 
    - [ x] Not bit for bit but only changes landpoint, thus no influence on results
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x ] No 
- [ ] Please provide any additional information or relevant details below:
