### PR TITLE
doc: remove mention of renamed variable 'forcing_diag'

### DIFF
--- a/doc/source/user_guide/ug_troubleshooting.rst
+++ b/doc/source/user_guide/ug_troubleshooting.rst
@@ -126,7 +126,7 @@ conflicts in module dependencies.
 *print\_state* (**ice\_diagnostics.F90**)
     Print the ice state and forcing fields for a given grid cell.
 
-`forcing\_diag` = true (**ice\_in**)
+`debug\_forcing` = true (**ice\_in**)
     Print numerous diagnostic quantities associated with input forcing.
 
 `debug\_blocks` = true (**ice\_in**)


### PR DESCRIPTION
'forcing_diag' was renamed to 'debug_forcing' in d6eb125 (Add new unit
tests sumchk and bcstchk and update tests (#606), 2021-06-09), but this
instance was not renamed in the doc.


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    see title
- [x] Developer(s): 
    me
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
   None - doc fix only
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

'forcing_diag' was renamed to 'debug_forcing' in d6eb125 (Add new unit
tests sumchk and bcstchk and update tests (#606), 2021-06-09), but this
instance was not renamed in the doc.
