### PR TITLE
Makefile: make Fortran object files depend on their dependency files

### DIFF
--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -73,7 +73,6 @@ RM    := rm
 AR    := ar
 
 .SUFFIXES:
-.SUFFIXES: .F90 .F .c .o
 
 .PHONY: all cice libcice targets target db_files db_flags clean realclean helloworld calchk sumchk bcstchk
 all: $(EXEC)
@@ -167,13 +166,13 @@ libcice: $(OBJS)
 	@ echo "$(AR) -r $(EXEC) $(OBJS)"
 	$(AR) -r $(EXEC) $(OBJS)
 
-.c.o:
+%.o : %.c
 	$(CC) $(CFLAGS) $(CPPDEFS) $(INCLDIR) $<
 
-.F.o:
+%.o : %.F %.d
 	$(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(CPPDEFS) $(INCLDIR) $<
 
-.F90.o:
+%.o : %.F90 %.d
 	$(FC) -c $(FFLAGS) $(FREEFLAGS) $(CPPDEFS) $(MODDIR) $(INCLDIR) $<
 
 clean:


### PR DESCRIPTION
When 'make' is invoked on the CICE Makefile, the first thing it does is
to try to make the included dependency files (*.d) (which are in fact
Makefiles themselves) [1], in alphabetical order.

The rule to make the dep files have the dependency generator, 'makdep',
as a prerequisite, so when processing the first dep file, make notices
'makdep' does not exist and proceeds to build it. If for whatever reason
this compilation fails, make will then proceed to the second dep file,
notice that it recently tried and failed to build its dependency
'makdep', give up on the second dep file, proceed to the third, and so
on.

In the end, no dep file is produced. Make then restarts itself and
proceeds to build the code, which of course fails catastrophically
because the Fortran source files are not compiled in the right order
because the dependency files are missing.

To avoid that, add a dependency on the dep file to the rules that make
the object file out of the Fortran source files. Since old-fashioned
suffix rules cannot have their own prerequisites [2], migrate the rules
for the Fortran source files to use pattern rules [3] instead. While at
it, also migrate the rule for the C source files.

With this new dependency, the builds abort early, before trying to
compile the Fortran sources, making it easier to understand what
has gone wrong.

Since we do not use suffix rules anymore, remove the '.SUFFIXES' line
that indicates which extension to use suffix rules for (but keep the
line that eliminates all default suffix rules).

[1] https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html
[2] https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html
[3] https://www.gnu.org/software/make/manual/html_node/Pattern-Rules.html#Pattern-Rules



## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    title
- [x] Developer(s): 
    me
- [x] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
 tested that everything compiles correctly (full base_suite) and that it fails early if `makdep` can't be compiled.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:

I stumbled on that while working on  the test system for our next HPC migration. This system does not have all locales installed, I was connecting from a system configured in French, and somehow the missing locale made `icc` completely fail to compile `makdep`, and catastrophy ensued. 
