### PR TITLE
Add CESM1_PIO for fill value check

### DIFF
--- a/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
@@ -718,7 +718,8 @@
          status = pio_inq_varid(File,trim(vname),vardesc)
 
          if (status /= PIO_noerr) then
-            call abort_ice(subname//"ERROR: CICE restart? Missing variable: "//trim(vname))
+            call abort_ice(subname// &
+               "ERROR: CICE restart? Missing variable: "//trim(vname))
          endif
 
          status = pio_inq_varndims(File, vardesc, ndims)
@@ -728,7 +729,10 @@
 !         if (ndim3 == ncat .and. ncat>1) then
          if (ndim3 == ncat .and. ndims == 3) then
             call pio_read_darray(File, vardesc, iodesc3d_ncat, work, status)
+#ifndef CESM1_PIO
+!           This only works for PIO2
             where (work == PIO_FILL_DOUBLE) work = c0
+#endif
             if (present(field_loc)) then
                do n=1,ndim3
                   call ice_HaloUpdate (work(:,:,n,:), halo_info, &
@@ -738,7 +742,10 @@
 !         elseif (ndim3 == 1) then
          elseif (ndim3 == 1 .and. ndims == 2) then
             call pio_read_darray(File, vardesc, iodesc2d, work, status)
+#ifndef CESM1_PIO
+!           This only works for PIO2
             where (work == PIO_FILL_DOUBLE) work = c0
+#endif
             if (present(field_loc)) then
                call ice_HaloUpdate (work(:,:,1,:), halo_info, &
                                     field_loc, field_type)

--- a/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
@@ -729,10 +729,10 @@
 !         if (ndim3 == ncat .and. ncat>1) then
          if (ndim3 == ncat .and. ndims == 3) then
             call pio_read_darray(File, vardesc, iodesc3d_ncat, work, status)
-#ifndef CESM1_PIO
-!           This only works for PIO2
-            where (work == PIO_FILL_DOUBLE) work = c0
-#endif
+!#ifndef CESM1_PIO
+!!           This only works for PIO2
+!            where (work == PIO_FILL_DOUBLE) work = c0
+!#endif
             if (present(field_loc)) then
                do n=1,ndim3
                   call ice_HaloUpdate (work(:,:,n,:), halo_info, &
@@ -742,10 +742,10 @@
 !         elseif (ndim3 == 1) then
          elseif (ndim3 == 1 .and. ndims == 2) then
             call pio_read_darray(File, vardesc, iodesc2d, work, status)
-#ifndef CESM1_PIO
-!           This only works for PIO2
-            where (work == PIO_FILL_DOUBLE) work = c0
-#endif
+!#ifndef CESM1_PIO
+!!           This only works for PIO2
+!            where (work == PIO_FILL_DOUBLE) work = c0
+!#endif
             if (present(field_loc)) then
                call ice_HaloUpdate (work(:,:,1,:), halo_info, &
                                     field_loc, field_type)


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
This accounts for the possibility of PIO1 which does not recognize PIO_FILL_DOUBLE.
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#7a1bd6982e9c8fec985ca3b2cbdd421dffe9492a (PGI had to be run separately)
I also ran aux_cice6 in CESM.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
This fixes an issue with PIO1.