### PR TITLE
doc: fix typo in cice_index

### DIFF
--- a/doc/source/cice_index.rst
+++ b/doc/source/cice_index.rst
@@ -574,7 +574,7 @@ either Celsius or Kelvin units).
    "rside", "fraction of ice that melts laterally", ""
    "rsnw", "snow grain radius", "10\ :math:`^{-6}` m"
    "rsnw_fall", "freshly fallen snow grain radius", "100. :math:`\times` 10\ :math:`^{-6}` m"
-   "rsnw_melt", "melting snow grain radius", "1000. :math:`\times` 10\ :math:`^{-6}` m"
+   "rsnw_mlt", "melting snow grain radius", "1000. :math:`\times` 10\ :math:`^{-6}` m"
    "rsnw_nonmelt", "nonmelting snow grain radius", "500. :math:`\times` 10\ :math:`^{-6}` m"
    "rsnw_sig", "standard deviation of snow grain radius", "250. :math:`\times` 10\ :math:`^{-6}` m"
    "rsnw_tmax", "maximum snow radius", "1500.  :math:`\times` 10\ :math:`^{-6}` m"


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    doc only - no tests.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:
Fix a typo dating to the addition of 'rsnw_mlt' to the CICE index in
468d7910 (CICE documentation complete except a few minor outstanding
issues, 2017-08-20).