### PR TITLE
Minor modif to doc: advice for value of ndte

### DIFF
--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -1070,6 +1070,18 @@
   url = {https://doi.org/10.5194/tc-15-2873-2021}
 }
 
+@article{Bouchat22,
+author = {Bouchat, Amelie and Hutter, Nils and Chanut, Jerome and Dupont, Frederic and Dukhovskoy, Dmitry and Garric, Gilles and Lee, Younjoo J. and Lemieux, Jean-Francois and Lique, Camille and Losch, Martin and Maslowski, Wieslaw and Myers, Paul G. and Olason, Einar and Rampal, Pierre and Rasmussen, Till and Talandier, Claude and Tremblay, Bruno and Wang, Qiang},
+title = {Sea Ice Rheology Experiment (SIREx): 1. Scaling and Statistical Properties of Sea-Ice Deformation Fields},
+journal = {Journal of Geophysical Research: Oceans},
+volume = {127},
+number = {4},
+pages = {e2021JC017667},
+doi = {https://doi.org/10.1029/2021JC017667},
+url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2021JC017667},
+year = {2022}
+}
+
 @Article{Tsujino18,
   author = "H. Tsujino and S. Urakawa and R.J. Small and W.M. Kim and S.G. Yeager and et al.",
   title = "{JRA‐55 based surface dataset for driving ocean–sea‐ice models (JRA55‐do)}",

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -1038,10 +1038,7 @@ stable as long as the subcycling time step :math:`\Delta t_e`
 sufficiently resolves the damping timescale :math:`T`. For the stability
 analysis we had to make several simplifications of the problem; hence
 the location of the boundary between stable and unstable regions is
-merely an estimate. In practice, the ratio
-:math:`\Delta t_e ~:~ T ~:~ \Delta t`  = 1 : 40 : 120 provides both
-stability and acceptable efficiency for time steps (:math:`\Delta t`) on
-the order of 1 hour.
+merely an estimate. The current default parameters for the EVP and EAP are :math:`ndte=240` and :math:`E_\circ=0.36`. For high resolution applications, it is however recommended to increase the value of :math:`ndte` :cite:`Koldunov19`, :cite:`Bouchat22`.
 
 Note that only :math:`T` and :math:`\Delta t_e` figure into the
 stability of the dynamics component; :math:`\Delta t` does not. Although


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Advice in doc to increase nb of subcycles for high resolution applications
- [x] Developer(s): 
    @JFLemieux73 
- [x] Suggest PR reviewers from list in the column to the right.
 @eclare108213 
- [x] Please copy the PR test results link or provide a summary of testing completed below.
  N.A.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:
 @eclare108213 I have removed a sentence...please verify that this is ok. There might be a typo that I have not corrected yet. Look at "the elastic parameter E is also limited by stability" in section 3.1.3.3. Shouldn't it be Eo instead? 

