### PR TITLE
tests: run 'cice.run' with '-nomodules'

### DIFF
--- a/configuration/scripts/tests/test_decomp.script
+++ b/configuration/scripts/tests/test_decomp.script
@@ -26,7 +26,7 @@ foreach decomp (${decomps})
   ${ICE_CASEDIR}/casescripts/parse_namelist.sh ice_in ${ICE_CASEDIR}/casescripts/set_nml.d${decomp}
   cp ice_in ice_in.${decomp}
 
-  ./cice.run
+  ./cice.run -nomodules
   set res="$status"
 
   set grade = FAIL

--- a/configuration/scripts/tests/test_qcchk.script
+++ b/configuration/scripts/tests/test_qcchk.script
@@ -6,7 +6,7 @@ cp ${ICE_SANDBOX}/configuration/scripts/tests/QC/CICE_Lookup_Table_p0.8_n1825.nc
 # Run the CICE model
 # cice.run returns -1 if run did not complete successfully
 
-./cice.run
+./cice.run -nomodules
 set res="$status"
 
 set log_file = `ls -t1 ${ICE_RUNDIR}/cice.runlog* | head -1`

--- a/configuration/scripts/tests/test_restart.script
+++ b/configuration/scripts/tests/test_restart.script
@@ -7,7 +7,7 @@ cp ice_in ice_in.0
 ${ICE_CASEDIR}/casescripts/parse_namelist.sh ice_in ${ICE_CASEDIR}/casescripts/test_nml.restart1
 cp ice_in ice_in.1
 
-./cice.run
+./cice.run -nomodules
 set res="$status"
 
 if ( $res != 0 ) then
@@ -44,7 +44,7 @@ perl -i -pe's/(\d{4})-(\d{2})-(\d{2})/sprintf("%04d-%02d-%02d",$1,$2,$3-5)/e' ${
 ${ICE_CASEDIR}/casescripts/parse_namelist.sh ice_in ${ICE_CASEDIR}/casescripts/test_nml.restart2
 cp ice_in ice_in.2
 
-./cice.run
+./cice.run -nomodules
 set res="$status"
 
 cp ice_in.0 ice_in

--- a/configuration/scripts/tests/test_restart2.script
+++ b/configuration/scripts/tests/test_restart2.script
@@ -7,7 +7,7 @@ cp ice_in ice_in.0
 ${ICE_CASEDIR}/casescripts/parse_namelist.sh ice_in ${ICE_CASEDIR}/casescripts/test_nml.restart21
 cp ice_in ice_in.1
 
-./cice.run
+./cice.run -nomodules
 set res="$status"
 
 if ( $res != 0 ) then
@@ -44,7 +44,7 @@ perl -i -pe's/(\d{4})-(\d{2})-(\d{2})/sprintf("%04d-%02d-%02d",$1,$2,$3-1)/e' ${
 ${ICE_CASEDIR}/casescripts/parse_namelist.sh ice_in ${ICE_CASEDIR}/casescripts/test_nml.restart22
 cp ice_in ice_in.2
 
-./cice.run
+./cice.run -nomodules
 set res="$status"
 
 cp ice_in.0 ice_in

--- a/configuration/scripts/tests/test_smoke.script
+++ b/configuration/scripts/tests/test_smoke.script
@@ -3,7 +3,7 @@
 # Run the CICE model
 # cice.run returns -1 if run did not complete successfully
 
-./cice.run
+./cice.run -nomodules
 set res="$status"
 
 set log_file = `ls -t1 ${ICE_RUNDIR}/cice.runlog* | head -1`

--- a/configuration/scripts/tests/test_unittest.script
+++ b/configuration/scripts/tests/test_unittest.script
@@ -3,7 +3,7 @@
 # Run the CICE model
 # cice.run returns -1 if run did not complete successfully
 
-./cice.run
+./cice.run -nomodules
 set rres="$status"
 
 set log_file = `ls -t1 ${ICE_RUNDIR}/cice.runlog* | head -1`


### PR DESCRIPTION


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    no code changes, no test suite ran. I tested this works as intended.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

Some compiler environments (namely newer version of Intel's oneAPI
toolkit) prevent users form sourcing their initialization script twice,
at least by default.

The CICE test infrastructure currently does this, because
env.$machine_$env is sourced by cice.test and then again by cice.run
(which is ran from cice.test). Sourcing the env file in 'cice.run', when
ran from 'cice.test', is thus unnecessary.

Most env files already support the '-nomodules' flag, which is used by
'cice.setup' when only machine variables are needed, and not a full
compiling environment. Leverage this flag by calling 'cice.run' with
'-nomodules' in 'cice.test'. As a byprodcut, this should make tests run
slightly faster since the environment setup is done only once.

