### PR TITLE
Update some CICE variable names to clarify grid

### DIFF
--- a/cicecore/cicedynB/analysis/ice_diagnostics.F90
+++ b/cicecore/cicedynB/analysis/ice_diagnostics.F90
@@ -1761,7 +1761,7 @@
                            uvelE, vvelE, uvelN, vvelN, trcrn
       use ice_flux, only: uatm, vatm, potT, Tair, Qa, flw, frain, fsnow, &
           fsens, flat, evap, flwout, swvdr, swvdf, swidr, swidf, rhoa, &
-          frzmlt, sst, sss, Tf, Tref, Qref, Uref, uocn, vocn, strtltx, strtlty
+          frzmlt, sst, sss, Tf, Tref, Qref, Uref, uocn, vocn, strtltxU, strtltyU
 
       character (len=20), intent(in) :: plabel
 
@@ -1907,14 +1907,14 @@
       write(nu_diag,*) '            fsnow   = ',fsnow(i,j,iblk)
       write(nu_diag,*) ' '
       write(nu_diag,*) 'ocn states and fluxes'
-      write(nu_diag,*) '            frzmlt  = ',frzmlt (i,j,iblk)
-      write(nu_diag,*) '            sst     = ',sst    (i,j,iblk)
-      write(nu_diag,*) '            sss     = ',sss    (i,j,iblk)
-      write(nu_diag,*) '            Tf      = ',Tf     (i,j,iblk)
-      write(nu_diag,*) '            uocn    = ',uocn   (i,j,iblk)
-      write(nu_diag,*) '            vocn    = ',vocn   (i,j,iblk)
-      write(nu_diag,*) '            strtltx = ',strtltx(i,j,iblk)
-      write(nu_diag,*) '            strtlty = ',strtlty(i,j,iblk)
+      write(nu_diag,*) '            frzmlt  = ',frzmlt  (i,j,iblk)
+      write(nu_diag,*) '            sst     = ',sst     (i,j,iblk)
+      write(nu_diag,*) '            sss     = ',sss     (i,j,iblk)
+      write(nu_diag,*) '            Tf      = ',Tf      (i,j,iblk)
+      write(nu_diag,*) '            uocn    = ',uocn    (i,j,iblk)
+      write(nu_diag,*) '            vocn    = ',vocn    (i,j,iblk)
+      write(nu_diag,*) '            strtltxU= ',strtltxU(i,j,iblk)
+      write(nu_diag,*) '            strtltyU= ',strtltyU(i,j,iblk)
       write(nu_diag,*) ' '
       write(nu_diag,*) 'srf states and fluxes'
       write(nu_diag,*) '            Tref    = ',Tref  (i,j,iblk)
@@ -1944,7 +1944,7 @@
                            uvelE, vvelE, uvelE, vvelE, trcrn
       use ice_flux, only: uatm, vatm, potT, Tair, Qa, flw, frain, fsnow, &
           fsens, flat, evap, flwout, swvdr, swvdf, swidr, swidf, rhoa, &
-          frzmlt, sst, sss, Tf, Tref, Qref, Uref, uocn, vocn, strtltx, strtlty
+          frzmlt, sst, sss, Tf, Tref, Qref, Uref, uocn, vocn, strtltxU, strtltyU
 
       character (len=*), intent(in),optional :: plabel
       integer          , intent(in),optional :: ilabel
@@ -2060,14 +2060,14 @@
       write(nu_diag,*) '            fsnow   = ',fsnow(i,j,iblk)
       write(nu_diag,*) ' '
       write(nu_diag,*) 'ocn states and fluxes'
-      write(nu_diag,*) '            frzmlt  = ',frzmlt (i,j,iblk)
-      write(nu_diag,*) '            sst     = ',sst    (i,j,iblk)
-      write(nu_diag,*) '            sss     = ',sss    (i,j,iblk)
-      write(nu_diag,*) '            Tf      = ',Tf     (i,j,iblk)
-      write(nu_diag,*) '            uocn    = ',uocn   (i,j,iblk)
-      write(nu_diag,*) '            vocn    = ',vocn   (i,j,iblk)
-      write(nu_diag,*) '            strtltx = ',strtltx(i,j,iblk)
-      write(nu_diag,*) '            strtlty = ',strtlty(i,j,iblk)
+      write(nu_diag,*) '            frzmlt  = ',frzmlt  (i,j,iblk)
+      write(nu_diag,*) '            sst     = ',sst     (i,j,iblk)
+      write(nu_diag,*) '            sss     = ',sss     (i,j,iblk)
+      write(nu_diag,*) '            Tf      = ',Tf      (i,j,iblk)
+      write(nu_diag,*) '            uocn    = ',uocn    (i,j,iblk)
+      write(nu_diag,*) '            vocn    = ',vocn    (i,j,iblk)
+      write(nu_diag,*) '            strtltxU= ',strtltxU(i,j,iblk)
+      write(nu_diag,*) '            strtltyU= ',strtltyU(i,j,iblk)
       write(nu_diag,*) ' '
       write(nu_diag,*) 'srf states and fluxes'
       write(nu_diag,*) '            Tref    = ',Tref  (i,j,iblk)

--- a/cicecore/cicedynB/analysis/ice_history.F90
+++ b/cicecore/cicedynB/analysis/ice_history.F90
@@ -2104,13 +2104,13 @@
           Tair, Tref, Qref, congel, frazil, frazil_diag, snoice, dsnow, &
           melts, meltb, meltt, meltl, fresh, fsalt, fresh_ai, fsalt_ai, &
           fhocn, fhocn_ai, uatm, vatm, fbot, Tbot, Tsnice, fswthru_ai, &
-          strairx, strairy, strtltx, strtlty, strintx, strinty, &
-          taubx, tauby, strocnx, strocny, &
+          strairxU, strairyU, strtltxU, strtltyU, strintxU, strintyU, &
+          taubxU, taubyU, strocnxU, strocnyU, &
           strairxN, strairyN, strtltxN, strtltyN, strintxN, strintyN, &
           taubxN, taubyN, strocnxN, strocnyN, &
           strairxE, strairyE, strtltxE, strtltyE, strintxE, strintyE, &
           taubxE, taubyE, strocnxE, strocnyE, &
-          fm, fmN, fmE, daidtt, dvidtt, daidtd, dvidtd, fsurf, &
+          fmU, fmN, fmE, daidtt, dvidtt, daidtd, dvidtd, fsurf, &
           fcondtop, fcondbot, fsurfn, fcondtopn, flatn, fsensn, albcnt, snwcnt, &
           stressp_1, stressm_1, stress12_1, &
           stresspT, stressmT, stress12T, &
@@ -2528,29 +2528,29 @@
              call accum_hist_field(n_fswthru_ai,iblk, fswthru_ai(:,:,iblk), a2D)
                
          if (f_strairx(1:1) /= 'x') &
-             call accum_hist_field(n_strairx, iblk, strairx(:,:,iblk), a2D)
+             call accum_hist_field(n_strairx, iblk, strairxU(:,:,iblk), a2D)
          if (f_strairy(1:1) /= 'x') &
-             call accum_hist_field(n_strairy, iblk, strairy(:,:,iblk), a2D)
+             call accum_hist_field(n_strairy, iblk, strairyU(:,:,iblk), a2D)
          if (f_strtltx(1:1) /= 'x') &
-             call accum_hist_field(n_strtltx, iblk, strtltx(:,:,iblk), a2D)
+             call accum_hist_field(n_strtltx, iblk, strtltxU(:,:,iblk), a2D)
          if (f_strtlty(1:1) /= 'x') &
-             call accum_hist_field(n_strtlty, iblk, strtlty(:,:,iblk), a2D)
+             call accum_hist_field(n_strtlty, iblk, strtltyU(:,:,iblk), a2D)
          if (f_strcorx(1:1) /= 'x') &
-             call accum_hist_field(n_strcorx, iblk, fm(:,:,iblk)*vvel(:,:,iblk), a2D)
+             call accum_hist_field(n_strcorx, iblk, fmU(:,:,iblk)*vvel(:,:,iblk), a2D)
          if (f_strcory(1:1) /= 'x') &
-             call accum_hist_field(n_strcory, iblk,-fm(:,:,iblk)*uvel(:,:,iblk), a2D)
+             call accum_hist_field(n_strcory, iblk,-fmU(:,:,iblk)*uvel(:,:,iblk), a2D)
          if (f_strocnx(1:1) /= 'x') &
-             call accum_hist_field(n_strocnx, iblk, strocnx(:,:,iblk), a2D)
+             call accum_hist_field(n_strocnx, iblk, strocnxU(:,:,iblk), a2D)
          if (f_strocny(1:1) /= 'x') &
-             call accum_hist_field(n_strocny, iblk, strocny(:,:,iblk), a2D)
+             call accum_hist_field(n_strocny, iblk, strocnyU(:,:,iblk), a2D)
          if (f_strintx(1:1) /= 'x') &
-             call accum_hist_field(n_strintx, iblk, strintx(:,:,iblk), a2D)
+             call accum_hist_field(n_strintx, iblk, strintxU(:,:,iblk), a2D)
          if (f_strinty(1:1) /= 'x') &
-             call accum_hist_field(n_strinty, iblk, strinty(:,:,iblk), a2D)
+             call accum_hist_field(n_strinty, iblk, strintyU(:,:,iblk), a2D)
          if (f_taubx(1:1) /= 'x') &
-             call accum_hist_field(n_taubx, iblk, taubx(:,:,iblk), a2D)
+             call accum_hist_field(n_taubx, iblk, taubxU(:,:,iblk), a2D)
          if (f_tauby(1:1) /= 'x') &
-             call accum_hist_field(n_tauby, iblk, tauby(:,:,iblk), a2D)
+             call accum_hist_field(n_tauby, iblk, taubyU(:,:,iblk), a2D)
          if (f_strairxN(1:1) /= 'x') &
              call accum_hist_field(n_strairxN, iblk, strairxN(:,:,iblk), a2D)
          if (f_strairyN(1:1) /= 'x') &
@@ -2791,7 +2791,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice_init(i,j,iblk) > puny) &
-                 worka(i,j) = aice(i,j,iblk)*(aice(i,j,iblk)*strairx(i,j,iblk)/aice_init(i,j,iblk))
+                 worka(i,j) = aice(i,j,iblk)*(aice(i,j,iblk)*strairxU(i,j,iblk)/aice_init(i,j,iblk))
            enddo
            enddo
            call accum_hist_field(n_sistrxdtop, iblk, worka(:,:), a2D)
@@ -2802,7 +2802,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice_init(i,j,iblk) > puny) &
-                 worka(i,j) = aice(i,j,iblk)*(aice(i,j,iblk)*strairy(i,j,iblk)/aice_init(i,j,iblk))
+                 worka(i,j) = aice(i,j,iblk)*(aice(i,j,iblk)*strairyU(i,j,iblk)/aice_init(i,j,iblk))
            enddo
            enddo
            call accum_hist_field(n_sistrydtop, iblk, worka(:,:), a2D)
@@ -2813,7 +2813,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) &
-                 worka(i,j) = aice(i,j,iblk)*strocnx(i,j,iblk)
+                 worka(i,j) = aice(i,j,iblk)*strocnxU(i,j,iblk)
            enddo
            enddo
            call accum_hist_field(n_sistrxubot, iblk, worka(:,:), a2D)
@@ -2824,7 +2824,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) &
-                 worka(i,j) = aice(i,j,iblk)*strocny(i,j,iblk)
+                 worka(i,j) = aice(i,j,iblk)*strocnyU(i,j,iblk)
            enddo
            enddo
            call accum_hist_field(n_sistryubot, iblk, worka(:,:), a2D)
@@ -3293,7 +3293,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) then
-                 worka(i,j) = aice(i,j,iblk)*strtltx(i,j,iblk)
+                 worka(i,j) = aice(i,j,iblk)*strtltxU(i,j,iblk)
               endif
            enddo
            enddo
@@ -3305,7 +3305,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) then
-                 worka(i,j) = aice(i,j,iblk)*strtlty(i,j,iblk)
+                 worka(i,j) = aice(i,j,iblk)*strtltyU(i,j,iblk)
               endif
            enddo
            enddo
@@ -3317,7 +3317,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) then
-                 worka(i,j) = aice(i,j,iblk)*fm(i,j,iblk)*vvel(i,j,iblk)
+                 worka(i,j) = aice(i,j,iblk)*fmU(i,j,iblk)*vvel(i,j,iblk)
               endif
            enddo
            enddo
@@ -3329,7 +3329,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) then
-                 worka(i,j) = -aice(i,j,iblk)*fm(i,j,iblk)*uvel(i,j,iblk)
+                 worka(i,j) = -aice(i,j,iblk)*fmU(i,j,iblk)*uvel(i,j,iblk)
               endif
            enddo
            enddo
@@ -3341,7 +3341,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) then
-                 worka(i,j) = aice(i,j,iblk)*strintx(i,j,iblk)
+                 worka(i,j) = aice(i,j,iblk)*strintxU(i,j,iblk)
               endif
            enddo
            enddo
@@ -3353,7 +3353,7 @@
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) then
-                 worka(i,j) = aice(i,j,iblk)*strinty(i,j,iblk)
+                 worka(i,j) = aice(i,j,iblk)*strintyU(i,j,iblk)
               endif
            enddo
            enddo

--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -65,16 +65,16 @@
          sig1    , & ! normalized principal stress component
          sig2    , & ! normalized principal stress component
          sigP    , & ! internal ice pressure (N/m)
-         taubx   , & ! seabed stress (x) (N/m^2)
-         tauby   , & ! seabed stress (y) (N/m^2)
-         strairx , & ! stress on ice by air, x-direction at U points
-         strairy , & ! stress on ice by air, y-direction at U points
-         strocnx , & ! ice-ocean stress, x-direction at U points, computed in dyn_finish
-         strocny , & ! ice-ocean stress, y-direction at U points, computed in dyn_finish
-         strtltx , & ! stress due to sea surface slope, x-direction
-         strtlty , & ! stress due to sea surface slope, y-direction
-         strintx , & ! divergence of internal ice stress, x (N/m^2)
-         strinty , & ! divergence of internal ice stress, y (N/m^2)
+         taubxU  , & ! seabed stress (x) (N/m^2)
+         taubyU  , & ! seabed stress (y) (N/m^2)
+         strairxU, & ! stress on ice by air, x-direction at U points
+         strairyU, & ! stress on ice by air, y-direction at U points
+         strocnxU, & ! ice-ocean stress, x-direction at U points, computed in dyn_finish
+         strocnyU, & ! ice-ocean stress, y-direction at U points, computed in dyn_finish
+         strtltxU, & ! stress due to sea surface slope, x-direction
+         strtltyU, & ! stress due to sea surface slope, y-direction
+         strintxU, & ! divergence of internal ice stress, x (N/m^2)
+         strintyU, & ! divergence of internal ice stress, y (N/m^2)
          taubxN  , & ! seabed stress (x) at N points (N/m^2)
          taubyN  , & ! seabed stress (y) at N points (N/m^2)
          strairxN, & ! stress on ice by air, x-direction at N points
@@ -129,23 +129,11 @@
          stresspT, stressmT, stress12T, & ! sigma11+sigma22, sigma11-sigma22, sigma12
          stresspU, stressmU, stress12U    ! "
 
-      logical (kind=log_kind), &
-         dimension (:,:,:), allocatable, public :: &
-         iceumask   ! ice extent mask (U-cell)
-
-      logical (kind=log_kind), &
-         dimension (:,:,:), allocatable, public :: &
-         icenmask   ! ice extent mask (N-cell)
-
-      logical (kind=log_kind), &
-         dimension (:,:,:), allocatable, public :: &
-         iceemask   ! ice extent mask (E-cell)
-
        ! internal
 
       real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
-         fm       , & ! Coriolis param. * mass in U-cell (kg/s)
-         Tbu      , & ! factor for seabed stress (N/m^2)
+         fmU      , & ! Coriolis param. * mass in U-cell (kg/s)
+         TbU      , & ! factor for seabed stress (N/m^2)
          fmE      , & ! Coriolis param. * mass in E-cell (kg/s)
          TbE      , & ! factor for seabed stress (N/m^2)
          fmN      , & ! Coriolis param. * mass in N-cell (kg/s)
@@ -406,16 +394,16 @@
          sig1       (nx_block,ny_block,max_blocks), & ! normalized principal stress component
          sig2       (nx_block,ny_block,max_blocks), & ! normalized principal stress component
          sigP       (nx_block,ny_block,max_blocks), & ! internal ice pressure (N/m)
-         taubx      (nx_block,ny_block,max_blocks), & ! seabed stress (x) (N/m^2)
-         tauby      (nx_block,ny_block,max_blocks), & ! seabed stress (y) (N/m^2)
-         strairx    (nx_block,ny_block,max_blocks), & ! stress on ice by air, x-direction
-         strairy    (nx_block,ny_block,max_blocks), & ! stress on ice by air, y-direction
-         strocnx    (nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction
-         strocny    (nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction
-         strtltx    (nx_block,ny_block,max_blocks), & ! stress due to sea surface slope, x-direction
-         strtlty    (nx_block,ny_block,max_blocks), & ! stress due to sea surface slope, y-direction
-         strintx    (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, x (N/m^2)
-         strinty    (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, y (N/m^2)
+         taubxU     (nx_block,ny_block,max_blocks), & ! seabed stress (x) (N/m^2)
+         taubyU     (nx_block,ny_block,max_blocks), & ! seabed stress (y) (N/m^2)
+         strairxU   (nx_block,ny_block,max_blocks), & ! stress on ice by air, x-direction
+         strairyU   (nx_block,ny_block,max_blocks), & ! stress on ice by air, y-direction
+         strocnxU   (nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction
+         strocnyU   (nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction
+         strtltxU   (nx_block,ny_block,max_blocks), & ! stress due to sea surface slope, x-direction
+         strtltyU   (nx_block,ny_block,max_blocks), & ! stress due to sea surface slope, y-direction
+         strintxU   (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, x (N/m^2)
+         strintyU   (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, y (N/m^2)
          daidtd     (nx_block,ny_block,max_blocks), & ! ice area tendency due to transport   (1/s)
          dvidtd     (nx_block,ny_block,max_blocks), & ! ice volume tendency due to transport (m/s)
          dagedtd    (nx_block,ny_block,max_blocks), & ! ice age tendency due to transport (s/s)
@@ -435,9 +423,8 @@
          stress12_2 (nx_block,ny_block,max_blocks), & ! sigma12
          stress12_3 (nx_block,ny_block,max_blocks), & ! sigma12
          stress12_4 (nx_block,ny_block,max_blocks), & ! sigma12
-         iceumask   (nx_block,ny_block,max_blocks), & ! ice extent mask (U-cell)
-         fm         (nx_block,ny_block,max_blocks), & ! Coriolis param. * mass in U-cell (kg/s)
-         Tbu        (nx_block,ny_block,max_blocks), & ! factor for seabed stress (landfast ice)
+         fmU        (nx_block,ny_block,max_blocks), & ! Coriolis param. * mass in U-cell (kg/s)
+         TbU        (nx_block,ny_block,max_blocks), & ! factor for seabed stress (landfast ice)
          zlvl       (nx_block,ny_block,max_blocks), & ! atm level height (momentum) (m)
          zlvs       (nx_block,ny_block,max_blocks), & ! atm level height (scalar quantities) (m)
          uatm       (nx_block,ny_block,max_blocks), & ! wind velocity components (m/s)
@@ -592,7 +579,6 @@
          strtltyN   (nx_block,ny_block,max_blocks), & ! stress due to sea surface slope, y-direction at N points
          strintxN   (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, x at N points (N/m^2)
          strintyN   (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, y at N points (N/m^2)
-         icenmask   (nx_block,ny_block,max_blocks), & ! ice extent mask (N-cell)
          fmN        (nx_block,ny_block,max_blocks), & ! Coriolis param. * mass in N-cell (kg/s)
          TbN        (nx_block,ny_block,max_blocks), & ! factor for seabed stress (landfast ice)
          taubxE     (nx_block,ny_block,max_blocks), & ! seabed stress (x) at E points (N/m^2)
@@ -605,7 +591,6 @@
          strtltyE   (nx_block,ny_block,max_blocks), & ! stress due to sea surface slope, y-direction at E points
          strintxE   (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, x at E points (N/m^2)
          strintyE   (nx_block,ny_block,max_blocks), & ! divergence of internal ice stress, y at E points (N/m^2)
-         iceemask   (nx_block,ny_block,max_blocks), & ! ice extent mask (E-cell)
          fmE        (nx_block,ny_block,max_blocks), & ! Coriolis param. * mass in E-cell (kg/s)
          TbE        (nx_block,ny_block,max_blocks), & ! factor for seabed stress (landfast ice)
          stresspT   (nx_block,ny_block,max_blocks), & ! sigma11+sigma22
@@ -1041,17 +1026,17 @@
 
       sig1    (:,:,:) = c0
       sig2    (:,:,:) = c0
-      taubx   (:,:,:) = c0
-      tauby   (:,:,:) = c0
+      taubxU  (:,:,:) = c0
+      taubyU  (:,:,:) = c0
       strength (:,:,:) = c0
-      strocnx (:,:,:) = c0
-      strocny (:,:,:) = c0
-      strairx (:,:,:) = c0
-      strairy (:,:,:) = c0
-      strtltx (:,:,:) = c0
-      strtlty (:,:,:) = c0
-      strintx (:,:,:) = c0
-      strinty (:,:,:) = c0
+      strocnxU(:,:,:) = c0
+      strocnyU(:,:,:) = c0
+      strairxU(:,:,:) = c0
+      strairyU(:,:,:) = c0
+      strtltxU(:,:,:) = c0
+      strtltyU(:,:,:) = c0
+      strintxU(:,:,:) = c0
+      strintyU(:,:,:) = c0
       dardg1dt(:,:,:) = c0
       dardg2dt(:,:,:) = c0
       dvirdgdt(:,:,:) = c0
@@ -1060,7 +1045,7 @@
       dvidtd  (:,:,:) = vice(:,:,:) ! temporary initial volume
       if (tr_iage) &
          dagedtd (:,:,:) = trcr(:,:,nt_iage,:) ! temporary initial age
-      fm      (:,:,:) = c0
+      fmU     (:,:,:) = c0
       ardgn   (:,:,:,:) = c0
       vrdgn   (:,:,:,:) = c0
       krdgn   (:,:,:,:) = c1

--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -3230,56 +3230,6 @@
       end subroutine set_state_var
 
 !=======================================================================
-#if (1 == 0)
-! Set ice velocity for slotted cylinder advection test
-!
-! author: Philippe Blain (ECCC)
-
-      subroutine boxslotcyl_data_vel(i,        j,       &
-                                     nx_block, ny_block, &
-                                     iglob,    jglob,   &
-                                     uvel,     vvel)
-      
-      use ice_constants, only: c2, c12, p5, cm_to_m
-      use ice_domain_size, only: nx_global, ny_global
-      use ice_grid, only: dxrect
-
-      integer (kind=int_kind), intent(in) :: &
-         i, j,               & ! local indices
-         nx_block, ny_block, & ! block dimensions
-         iglob(nx_block),    & ! global indices
-         jglob(ny_block)
-
-      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(out) :: &
-         uvel, vvel            ! ice velocity
-
-      ! local variables
-      real (kind=dbl_kind) :: &
-         pi             , & ! pi
-         secday         , & ! seconds per day
-         max_vel        , & ! max velocity
-         domain_length  , & ! physical domain length
-         period             ! rotational period
-      
-      character(len=*), parameter :: subname = '(boxslotcyl_data_vel)'
-      
-      call icepack_query_parameters(secday_out=secday, pi_out=pi)
-      call icepack_warnings_flush(nu_diag)
-      if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
-         file=__FILE__, line=__LINE__)
-
-      domain_length = dxrect*cm_to_m*nx_global
-      period        = c12*secday               ! 12 days rotational period
-      max_vel       = pi*domain_length/period
-
-      uvel(i,j) =  c2*max_vel*(real(jglob(j), kind=dbl_kind) - p5) &
-                    / real(ny_global - 1, kind=dbl_kind) - max_vel
-      vvel(i,j) = -c2*max_vel*(real(iglob(i), kind=dbl_kind) - p5) &
-                    / real(nx_global - 1, kind=dbl_kind) + max_vel
-
-      end subroutine boxslotcyl_data_vel
-#endif
-!=======================================================================
 
       end module ice_init
 

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -173,8 +173,7 @@
          use_bathymetry, & ! flag for reading in bathymetry_file
          pgl_global_ext    ! flag for init primary grid lengths (global ext.)
 
-      logical (kind=log_kind), &
-         dimension (:,:,:), allocatable, public :: &
+      logical (kind=log_kind), dimension (:,:,:), allocatable, public :: &
          tmask  , & ! land/boundary mask, thickness (T-cell)
          umask  , & ! land/boundary mask  (U-cell) (1 if all surrounding T cells are ocean)
          umaskCD, & ! land/boundary mask  (U-cell) (1 if at least two surrounding T cells are ocean)
@@ -183,7 +182,12 @@
          lmask_n, & ! northern hemisphere mask
          lmask_s    ! southern hemisphere mask
 
-      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
+      logical (kind=log_kind), dimension (:,:,:), allocatable, public :: &
+         iceumask, &   ! ice extent mask (U-cell)
+         icenmask, &   ! ice extent mask (N-cell)
+         iceemask      ! ice extent mask (E-cell)
+
+real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          rndex_global       ! global index for local subdomain (dbl)
 
       logical (kind=log_kind), private :: &
@@ -263,6 +267,7 @@
          umaskCD  (nx_block,ny_block,max_blocks), & ! land/boundary mask, velocity (U-cell)
          nmask    (nx_block,ny_block,max_blocks), & ! land/boundary mask (N-cell)
          emask    (nx_block,ny_block,max_blocks), & ! land/boundary mask (E-cell)
+         iceumask (nx_block,ny_block,max_blocks), & ! u mask for dynamics
          lmask_n  (nx_block,ny_block,max_blocks), & ! northern hemisphere mask
          lmask_s  (nx_block,ny_block,max_blocks), & ! southern hemisphere mask
          rndex_global(nx_block,ny_block,max_blocks), & ! global index for local subdomain (dbl)
@@ -283,6 +288,8 @@
 
       if (grid_ice == 'CD' .or. grid_ice == 'C') then
          allocate( &
+            iceemask (nx_block,ny_block,max_blocks), & ! e mask for dynamics
+            icenmask (nx_block,ny_block,max_blocks), & ! n mask for dynamics
             ratiodxN (nx_block,ny_block,max_blocks), &
             ratiodyE (nx_block,ny_block,max_blocks), &
             ratiodxNr(nx_block,ny_block,max_blocks), &

--- a/cicecore/cicedynB/infrastructure/ice_restart_driver.F90
+++ b/cicecore/cicedynB/infrastructure/ice_restart_driver.F90
@@ -56,14 +56,14 @@
       use ice_domain, only: nblocks
       use ice_domain_size, only: nilyr, nslyr, ncat, max_blocks
       use ice_flux, only: scale_factor, swvdr, swvdf, swidr, swidf, &
-          strocnxT, strocnyT, sst, frzmlt, iceumask, iceemask, icenmask, &
+          strocnxT, strocnyT, sst, frzmlt, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4, &
           stresspT, stressmT, stress12T, &
           stresspU, stressmU, stress12U 
       use ice_flux, only: coszen
-      use ice_grid, only: grid_ice, tmask
+      use ice_grid, only: grid_ice, tmask, iceumask, iceemask, icenmask
       use ice_state, only: aicen, vicen, vsnon, trcrn, uvel, vvel, &
                            uvelE, vvelE, uvelN, vvelN
 
@@ -277,14 +277,15 @@
       use ice_domain_size, only: nilyr, nslyr, ncat, &
           max_blocks
       use ice_flux, only: scale_factor, swvdr, swvdf, swidr, swidf, &
-          strocnxT, strocnyT, sst, frzmlt, iceumask, iceemask, icenmask, &
+          strocnxT, strocnyT, sst, frzmlt, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4, &
           stresspT, stressmT, stress12T, &
           stresspU, stressmU, stress12U
       use ice_flux, only: coszen
-      use ice_grid, only: tmask, grid_type, grid_ice
+      use ice_grid, only: tmask, grid_type, grid_ice, &
+          iceumask, iceemask, icenmask
       use ice_state, only: trcr_depend, aice, vice, vsno, trcr, &
           aice0, aicen, vicen, vsnon, trcrn, aice_init, uvel, vvel, &
           uvelE, vvelE, uvelN, vvelN, &
@@ -707,12 +708,12 @@
       use ice_domain_size, only: nilyr, nslyr, ncat, nx_global, ny_global, &
           max_blocks
       use ice_flux, only: scale_factor, swvdr, swvdf, swidr, swidf, &
-          strocnxT, strocnyT, sst, frzmlt, iceumask, &
+          strocnxT, strocnyT, sst, frzmlt, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
       use ice_gather_scatter, only: scatter_global_stress
-      use ice_grid, only: tmask
+      use ice_grid, only: tmask, iceumask
       use ice_read_write, only: ice_open, ice_read, ice_read_global
       use ice_state, only: trcr_depend, aice, vice, vsno, trcr, &
           aice0, aicen, vicen, vsnon, trcrn, aice_init, uvel, vvel, &


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update some CICE variable names to clarify grid
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    All tests bit-for-bit, full test suites run on cheyenne, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#3079979f165ab96f73fb1b8e51d77bd027bce39e
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

Partly addresses several items in #660 

-Rename several variables to make compatible with C-grid names,
  - strairxU, strairyU, strtltxU, strtltyU, strintxU, strintyU,
  - taubxU, taubyU, strocnxU, strocnyU, fmU, TbU,
  - waterxU, wateryU, forcexU, forceyU, aiU
- Move iceumask, icenmask, iceemask from ice_flux to ice_grid
- Make dyn_prep2, stepu, stepuv_CD, stepv_C, implicit_solver, and anderson_solver argument names a little more generic/specific
- Inline boxslotcyl velocity calculation