### PR TITLE
cice.setup: remove 'suite.jobs' at start of 'suite.submit'

### DIFF
--- a/cice.setup
+++ b/cice.setup
@@ -489,6 +489,7 @@ else
 #!/bin/csh -f
 
 set nonomatch && rm -f ciceexe.* && unset nonomatch
+rm -f suite.jobs
 
 set dobuild  = true
 set doreuse  = true


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    tested it works.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No - but I'll do the same in Icepack for consistency
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

When running a test suite that includes 'bfbcomp' tests, the test
script ('cice.test') queries the file 'suite.jobs' in the suite
directory to get the job ID of the test against which to compare for
bit-for-bit-ness.

If re-running the suite, 'suite.jobs' is not removed, so that the new
job IDs are appended to the existing file. This leads to syntax errors
when 'cice.test' looks for the job ID to compare against since the
'grep' call returns several matches.

Remove 'suite.jobs' at the start of the 'suite.submit' script generated
by 'cice.setup' to avoid that.
