### PR TITLE
Deprecate CESM ponds (tr_pond_cesm)

### DIFF
--- a/cicecore/cicedynB/analysis/ice_history_pond.F90
+++ b/cicecore/cicedynB/analysis/ice_history_pond.F90
@@ -268,9 +268,13 @@
 
       integer (kind=int_kind) :: &
          nt_apnd, nt_hpnd, nt_alvl, nt_ipnd
-
+#ifdef UNDEPRECATE_CESMPONDS
       logical (kind=log_kind) :: &
          tr_pond_cesm, tr_pond_lvl, tr_pond_topo
+#else
+      logical (kind=log_kind) :: &
+         tr_pond_lvl, tr_pond_topo
+#endif
 
       real (kind=dbl_kind) :: &
          puny
@@ -285,8 +289,13 @@
       !---------------------------------------------------------------
 
          call icepack_query_parameters(puny_out=puny)
+#ifdef UNDEPRECATE_CESMPONDS
          call icepack_query_tracer_flags(tr_pond_cesm_out=tr_pond_cesm, &
               tr_pond_lvl_out=tr_pond_lvl, tr_pond_topo_out=tr_pond_topo)
+#else
+         call icepack_query_tracer_flags(tr_pond_lvl_out=tr_pond_lvl, &
+              tr_pond_topo_out=tr_pond_topo)
+#endif
          call icepack_query_tracer_indices(nt_apnd_out=nt_apnd, nt_hpnd_out=nt_hpnd, &
               nt_alvl_out=nt_alvl, nt_ipnd_out=nt_ipnd)
          call icepack_warnings_flush(nu_diag)
@@ -294,6 +303,7 @@
             file=__FILE__, line=__LINE__)
 
          if (allocated(a2D)) then
+#ifdef UNDEPRECATE_CESMPONDS
          if (tr_pond_cesm) then
          if (f_apond(1:1)/= 'x') &
              call accum_hist_field(n_apond, iblk, &
@@ -311,6 +321,9 @@
                                                   * trcr(:,:,nt_hpnd,iblk), a2D)
 
          elseif (tr_pond_lvl) then
+#else
+         if (tr_pond_lvl) then
+#endif
          if (f_apond(1:1)/= 'x') &
              call accum_hist_field(n_apond, iblk, &
                             trcr(:,:,nt_alvl,iblk) * trcr(:,:,nt_apnd,iblk), a2D)

--- a/cicecore/cicedynB/dynamics/ice_transport_driver.F90
+++ b/cicecore/cicedynB/dynamics/ice_transport_driver.F90
@@ -1533,8 +1533,13 @@
       integer (kind=int_kind) :: &
          nt_alvl, nt_apnd, nt_fbri
 
+#ifdef UNDEPRECATE_CESMPONDS
       logical (kind=log_kind) :: &
          tr_pond_cesm, tr_pond_lvl, tr_pond_topo
+#else
+      logical (kind=log_kind) :: &
+         tr_pond_lvl, tr_pond_topo
+#endif
 
       integer (kind=int_kind) ::      &
          i, j, n, it, & ! counting indices
@@ -1542,8 +1547,13 @@
 
       character(len=*), parameter :: subname = '(state_to_work)'
 
+#ifdef UNDEPRECATE_CESMPONDS
       call icepack_query_tracer_flags(tr_pond_cesm_out=tr_pond_cesm, &
            tr_pond_lvl_out=tr_pond_lvl, tr_pond_topo_out=tr_pond_topo)
+#else
+      call icepack_query_tracer_flags(tr_pond_lvl_out=tr_pond_lvl, &
+           tr_pond_topo_out=tr_pond_topo)
+#endif
       call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_apnd_out=nt_apnd, &
            nt_fbri_out=nt_fbri)
       call icepack_warnings_flush(nu_diag)
@@ -1602,8 +1612,13 @@
                                         * trcrn(i,j,it     ,n)
                enddo
                enddo
+#ifdef UNDEPRECATE_CESMPONDS
             elseif (trcr_depend(it) == 2+nt_apnd .and. &
                     tr_pond_cesm .or. tr_pond_topo) then
+#else
+            elseif (trcr_depend(it) == 2+nt_apnd .and. &
+                    tr_pond_topo) then
+#endif
                do j = 1, ny_block
                do i = 1, nx_block
                   works(i,j,narrays+it) = aicen(i,j        ,n) &

--- a/cicecore/cicedynB/general/ice_step_mod.F90
+++ b/cicecore/cicedynB/general/ice_step_mod.F90
@@ -237,7 +237,11 @@
          nt_isosno, nt_isoice, nt_rsnw, nt_smice, nt_smliq
 
       logical (kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iage, tr_FY, tr_iso, tr_aero, tr_pond, tr_pond_cesm, &
+#else
+         tr_iage, tr_FY, tr_iso, tr_aero, tr_pond, &
+#endif
          tr_pond_lvl, tr_pond_topo, calc_Tsfc, highfreq, tr_snow
 
       real (kind=dbl_kind) :: &
@@ -265,7 +269,11 @@
       call icepack_query_tracer_sizes(ntrcr_out=ntrcr)
       call icepack_query_tracer_flags( &
          tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_iso_out=tr_iso, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_aero_out=tr_aero, tr_pond_out=tr_pond, tr_pond_cesm_out=tr_pond_cesm, &
+#else
+         tr_aero_out=tr_aero, tr_pond_out=tr_pond, &
+#endif
          tr_pond_lvl_out=tr_pond_lvl, tr_pond_topo_out=tr_pond_topo, &
          tr_snow_out=tr_snow)
       call icepack_query_tracer_indices( &

--- a/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
@@ -58,7 +58,11 @@
 
       logical (kind=log_kind) :: &
          solve_zsal, tr_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, tr_pond_cesm, &
+#else
+         tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, &
+#endif
          tr_pond_topo, tr_pond_lvl, tr_brine, tr_snow
 
       character(len=char_len_long) :: &
@@ -83,7 +87,11 @@
          nbtrcr_out=nbtrcr)
       call icepack_query_tracer_flags( &
          tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, tr_fsd_out=tr_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iso_out=tr_iso, tr_aero_out=tr_aero, tr_pond_cesm_out=tr_pond_cesm, &
+#else
+         tr_iso_out=tr_iso, tr_aero_out=tr_aero, &
+#endif
          tr_pond_topo_out=tr_pond_topo, tr_pond_lvl_out=tr_pond_lvl, &
          tr_snow_out=tr_snow, tr_brine_out=tr_brine)
       call icepack_warnings_flush(nu_diag)
@@ -228,6 +236,7 @@
          endif
       endif
 
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm) then
          if (my_task == master_task) then
             n = index(filename0,trim(restart_file))
@@ -247,6 +256,7 @@
             write(nu_diag,*) 'Reading ',filename(1:lenstr(filename))
          endif
       endif
+#endif
 
       if (tr_pond_lvl) then
          if (my_task == master_task) then
@@ -414,7 +424,11 @@
 
       logical (kind=log_kind) :: &
          solve_zsal, tr_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, tr_pond_cesm, &
+#else
+         tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, &
+#endif
          tr_pond_topo, tr_pond_lvl, tr_brine, tr_snow
 
       integer (kind=int_kind) :: &
@@ -430,7 +444,11 @@
          nbtrcr_out=nbtrcr)
       call icepack_query_tracer_flags( &
          tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, tr_fsd_out=tr_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iso_out=tr_iso, tr_aero_out=tr_aero, tr_pond_cesm_out=tr_pond_cesm, &
+#else
+         tr_iso_out=tr_iso, tr_aero_out=tr_aero, &
+#endif
          tr_pond_topo_out=tr_pond_topo, tr_pond_lvl_out=tr_pond_lvl, &
          tr_snow_out=tr_snow, tr_brine_out=tr_brine)
       call icepack_warnings_flush(nu_diag)
@@ -563,6 +581,7 @@
 
       endif
 
+#ifdef UNDEPRECATE_CESMPONDS
       if (tr_pond_cesm) then
 
          write(filename,'(a,a,a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
@@ -582,6 +601,7 @@
          endif
 
       endif
+#endif
 
       if (tr_pond_lvl) then
 
@@ -851,7 +871,11 @@
 
       logical (kind=log_kind) :: &
          solve_zsal, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, tr_pond_cesm, &
+#else
+         tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, &
+#endif
          tr_pond_topo, tr_pond_lvl, tr_brine, tr_snow
 
       integer (kind=int_kind) :: &
@@ -865,7 +889,11 @@
          nbtrcr_out=nbtrcr)
       call icepack_query_tracer_flags( &
          tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iso_out=tr_iso, tr_aero_out=tr_aero, tr_pond_cesm_out=tr_pond_cesm, &
+#else
+         tr_iso_out=tr_iso, tr_aero_out=tr_aero, &
+#endif
          tr_pond_topo_out=tr_pond_topo, tr_pond_lvl_out=tr_pond_lvl, &
          tr_snow_out=tr_snow, tr_brine_out=tr_brine)
       call icepack_warnings_flush(nu_diag)
@@ -880,7 +908,9 @@
          if (tr_iage)      close(nu_dump_age)
          if (tr_FY)        close(nu_dump_FY)
          if (tr_lvl)       close(nu_dump_lvl)
+#ifdef UNDEPRECATE_CESMPONDS
          if (tr_pond_cesm) close(nu_dump_pond)
+#endif
          if (tr_pond_lvl)  close(nu_dump_pond)
          if (tr_pond_topo) close(nu_dump_pond)
          if (tr_snow)      close(nu_dump_snow)

--- a/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
@@ -145,7 +145,11 @@
 
       logical (kind=log_kind) :: &
          solve_zsal, skl_bgc, z_tracers, tr_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, tr_pond_cesm, &
+#else
+         tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, &
+#endif
          tr_pond_topo, tr_pond_lvl, tr_brine, tr_snow, &
          tr_bgc_N, tr_bgc_C, tr_bgc_Nit, &
          tr_bgc_Sil, tr_bgc_DMS, &
@@ -181,7 +185,11 @@
          nbtrcr_out=nbtrcr)
       call icepack_query_tracer_flags( &
          tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, tr_fsd_out=tr_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iso_out=tr_iso, tr_aero_out=tr_aero, tr_pond_cesm_out=tr_pond_cesm, &
+#else
+         tr_iso_out=tr_iso, tr_aero_out=tr_aero, &
+#endif
          tr_pond_topo_out=tr_pond_topo, tr_pond_lvl_out=tr_pond_lvl, &
          tr_snow_out=tr_snow, tr_brine_out=tr_brine, &
          tr_bgc_N_out=tr_bgc_N, tr_bgc_C_out=tr_bgc_C, tr_bgc_Nit_out=tr_bgc_Nit, &
@@ -408,10 +416,12 @@
             call define_rest_field(ncid,'vlvl',dims)
          end if
 
+#ifdef UNDEPRECATE_CESMPONDS
          if (tr_pond_cesm) then
             call define_rest_field(ncid,'apnd',dims)
             call define_rest_field(ncid,'hpnd',dims)
          end if
+#endif
 
          if (tr_pond_topo) then
             call define_rest_field(ncid,'apnd',dims)

--- a/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedynB/infrastructure/io/io_pio2/ice_restart.F90
@@ -151,7 +151,11 @@
           solve_zsal, skl_bgc, z_tracers
 
       logical (kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, tr_pond_cesm, &
+#else
+          tr_iage, tr_FY, tr_lvl, tr_iso, tr_aero, &
+#endif
           tr_pond_topo, tr_pond_lvl, tr_brine, tr_snow, &
           tr_bgc_N, tr_bgc_C, tr_bgc_Nit, &
           tr_bgc_Sil, tr_bgc_DMS, &
@@ -187,7 +191,11 @@
       call icepack_query_tracer_sizes(nbtrcr_out=nbtrcr)
       call icepack_query_tracer_flags( &
           tr_iage_out=tr_iage, tr_FY_out=tr_FY, tr_lvl_out=tr_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iso_out=tr_iso, tr_aero_out=tr_aero, tr_pond_cesm_out=tr_pond_cesm, &
+#else
+          tr_iso_out=tr_iso, tr_aero_out=tr_aero, &
+#endif
           tr_pond_topo_out=tr_pond_topo, tr_pond_lvl_out=tr_pond_lvl, &
           tr_snow_out=tr_snow, tr_brine_out=tr_brine, &
           tr_bgc_N_out=tr_bgc_N, tr_bgc_C_out=tr_bgc_C, tr_bgc_Nit_out=tr_bgc_Nit, &
@@ -412,10 +420,12 @@
             call define_rest_field(File,'vlvl',dims)
          end if
 
+#ifdef UNDEPRECATE_CESMPONDS
          if (tr_pond_cesm) then
             call define_rest_field(File,'apnd',dims)
             call define_rest_field(File,'hpnd',dims)
          end if
+#endif
 
          if (tr_pond_topo) then
             call define_rest_field(File,'apnd',dims)

--- a/cicecore/drivers/direct/hadgem3/CICE_InitMod.F90
+++ b/cicecore/drivers/direct/hadgem3/CICE_InitMod.F90
@@ -235,11 +235,17 @@
       use ice_grid, only: tmask
       use ice_init, only: ice_ic
       use ice_init_column, only: init_age, init_FY, init_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           init_meltponds_cesm,  init_meltponds_lvl, init_meltponds_topo, &
+#else
+          init_meltponds_lvl, init_meltponds_topo, &
+#endif
           init_aerosol, init_hbrine, init_bgc, init_fsd
       use ice_restart_column, only: restart_age, read_restart_age, &
           restart_FY, read_restart_FY, restart_lvl, read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           restart_pond_cesm, read_restart_pond_cesm, &
+#endif
           restart_pond_lvl, read_restart_pond_lvl, &
           restart_pond_topo, read_restart_pond_topo, &
           restart_fsd, read_restart_fsd, &
@@ -254,7 +260,11 @@
          i, j        , & ! horizontal indices
          iblk            ! block index
       logical(kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iage, tr_FY, tr_lvl, tr_pond_cesm, tr_pond_lvl, &
+#else
+          tr_iage, tr_FY, tr_lvl, tr_pond_lvl, &
+#endif
           tr_pond_topo, tr_fsd, tr_aero, tr_brine, &
           skl_bgc, z_tracers, solve_zsal
       integer(kind=int_kind) :: &
@@ -273,7 +283,11 @@
       call icepack_query_parameters(skl_bgc_out=skl_bgc, &
            z_tracers_out=z_tracers, solve_zsal_out=solve_zsal)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_aero_out=tr_aero, tr_brine_out=tr_brine, &
            tr_fsd_out=tr_fsd)
       call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_vlvl_out=nt_vlvl, &
@@ -332,6 +346,7 @@
             enddo ! iblk
          endif
       endif
+#ifdef UNDEPRECATE_CESMPONDS
       ! CESM melt ponds
       if (tr_pond_cesm) then
          if (trim(runtype) == 'continue') &
@@ -345,6 +360,7 @@
             enddo ! iblk
          endif
       endif
+#endif
       ! level-ice melt ponds
       if (tr_pond_lvl) then
          if (trim(runtype) == 'continue') &

--- a/cicecore/drivers/direct/hadgem3/CICE_RunMod.F90
+++ b/cicecore/drivers/direct/hadgem3/CICE_RunMod.F90
@@ -145,7 +145,11 @@
       use ice_history_bgc, only: init_history_bgc
       use ice_restart, only: final_restart
       use ice_restart_column, only: write_restart_age, write_restart_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
           write_restart_lvl, write_restart_pond_cesm, write_restart_pond_lvl, &
+#else
+          write_restart_lvl, write_restart_pond_lvl, &
+#endif
           write_restart_pond_topo, write_restart_aero, write_restart_fsd, &
           write_restart_bgc, write_restart_hbrine
       use ice_restart_driver, only: dumpfile
@@ -168,7 +172,11 @@
 
       logical (kind=log_kind) :: &
           tr_iage, tr_FY, tr_lvl, tr_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_brine, tr_aero, &
+#else
+          tr_pond_lvl, tr_pond_topo, tr_brine, tr_aero, &
+#endif
           calc_Tsfc, skl_bgc, solve_zsal, z_tracers, wave_spec
 
       character(len=*), parameter :: subname = '(ice_step)'
@@ -177,7 +185,11 @@
            solve_zsal_out=solve_zsal, z_tracers_out=z_tracers, ktherm_out=ktherm, &
            wave_spec_out=wave_spec)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_brine_out=tr_brine, tr_aero_out=tr_aero, &
            tr_fsd_out=tr_fsd)
       call icepack_warnings_flush(nu_diag)
@@ -321,7 +333,9 @@
             if (tr_iage)      call write_restart_age
             if (tr_FY)        call write_restart_FY
             if (tr_lvl)       call write_restart_lvl
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm) call write_restart_pond_cesm
+#endif
             if (tr_pond_lvl)  call write_restart_pond_lvl
             if (tr_pond_topo) call write_restart_pond_topo
             if (tr_fsd)       call write_restart_fsd

--- a/cicecore/drivers/direct/nemo_concepts/CICE_InitMod.F90
+++ b/cicecore/drivers/direct/nemo_concepts/CICE_InitMod.F90
@@ -235,11 +235,17 @@
       use ice_grid, only: tmask
       use ice_init, only: ice_ic
       use ice_init_column, only: init_age, init_FY, init_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           init_meltponds_cesm,  init_meltponds_lvl, init_meltponds_topo, &
+#else
+          init_meltponds_lvl, init_meltponds_topo, &
+#endif
           init_aerosol, init_hbrine, init_bgc, init_fsd
       use ice_restart_column, only: restart_age, read_restart_age, &
           restart_FY, read_restart_FY, restart_lvl, read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           restart_pond_cesm, read_restart_pond_cesm, &
+#endif
           restart_pond_lvl, read_restart_pond_lvl, &
           restart_pond_topo, read_restart_pond_topo, &
           restart_fsd, read_restart_fsd, &
@@ -254,7 +260,11 @@
          i, j        , & ! horizontal indices
          iblk            ! block index
       logical(kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iage, tr_FY, tr_lvl, tr_pond_cesm, tr_pond_lvl, &
+#else
+          tr_iage, tr_FY, tr_lvl, tr_pond_lvl, &
+#endif
           tr_pond_topo, tr_fsd, tr_aero, tr_brine, &
           skl_bgc, z_tracers, solve_zsal
       integer(kind=int_kind) :: &
@@ -273,7 +283,11 @@
       call icepack_query_parameters(skl_bgc_out=skl_bgc, &
            z_tracers_out=z_tracers, solve_zsal_out=solve_zsal)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_aero_out=tr_aero, tr_brine_out=tr_brine, &
            tr_fsd_out=tr_fsd)
       call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_vlvl_out=nt_vlvl, &
@@ -332,6 +346,7 @@
             enddo ! iblk
          endif
       endif
+#ifdef UNDEPRECATE_CESMPONDS
       ! CESM melt ponds
       if (tr_pond_cesm) then
          if (trim(runtype) == 'continue') &
@@ -345,6 +360,7 @@
             enddo ! iblk
          endif
       endif
+#endif
       ! level-ice melt ponds
       if (tr_pond_lvl) then
          if (trim(runtype) == 'continue') &

--- a/cicecore/drivers/direct/nemo_concepts/CICE_RunMod.F90
+++ b/cicecore/drivers/direct/nemo_concepts/CICE_RunMod.F90
@@ -145,7 +145,11 @@
       use ice_history_bgc, only: init_history_bgc
       use ice_restart, only: final_restart
       use ice_restart_column, only: write_restart_age, write_restart_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
           write_restart_lvl, write_restart_pond_cesm, write_restart_pond_lvl, &
+#else
+          write_restart_lvl, write_restart_pond_lvl, &
+#endif
           write_restart_pond_topo, write_restart_aero, write_restart_fsd, &
           write_restart_bgc, write_restart_hbrine
       use ice_restart_driver, only: dumpfile
@@ -168,7 +172,11 @@
 
       logical (kind=log_kind) :: &
           tr_iage, tr_FY, tr_lvl, tr_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_brine, tr_aero, &
+#else
+          tr_pond_lvl, tr_pond_topo, tr_brine, tr_aero, &
+#endif
           calc_Tsfc, skl_bgc, solve_zsal, z_tracers, wave_spec
 
       character(len=*), parameter :: subname = '(ice_step)'
@@ -177,7 +185,11 @@
            solve_zsal_out=solve_zsal, z_tracers_out=z_tracers, ktherm_out=ktherm, &
            wave_spec_out=wave_spec)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_brine_out=tr_brine, tr_aero_out=tr_aero, &
            tr_fsd_out=tr_fsd)
       call icepack_warnings_flush(nu_diag)
@@ -321,7 +333,9 @@
             if (tr_iage)      call write_restart_age
             if (tr_FY)        call write_restart_FY
             if (tr_lvl)       call write_restart_lvl
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm) call write_restart_pond_cesm
+#endif
             if (tr_pond_lvl)  call write_restart_pond_lvl
             if (tr_pond_topo) call write_restart_pond_topo
             if (tr_fsd)       call write_restart_fsd

--- a/cicecore/drivers/mct/cesm1/CICE_InitMod.F90
+++ b/cicecore/drivers/mct/cesm1/CICE_InitMod.F90
@@ -264,11 +264,17 @@
       use ice_grid, only: tmask
       use ice_init, only: ice_ic
       use ice_init_column, only: init_age, init_FY, init_lvl, init_snowtracers, &
+#ifdef UNDEPRECATE_CESMPONDS
           init_meltponds_cesm,  init_meltponds_lvl, init_meltponds_topo, &
+#else
+          init_meltponds_lvl, init_meltponds_topo, &
+#endif
           init_isotope, init_aerosol, init_hbrine, init_bgc, init_fsd
       use ice_restart_column, only: restart_age, read_restart_age, &
           restart_FY, read_restart_FY, restart_lvl, read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           restart_pond_cesm, read_restart_pond_cesm, &
+#endif
           restart_pond_lvl, read_restart_pond_lvl, &
           restart_pond_topo, read_restart_pond_topo, &
           restart_snow, read_restart_snow, &
@@ -285,7 +291,11 @@
          i, j        , & ! horizontal indices
          iblk            ! block index
       logical(kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iage, tr_FY, tr_lvl, tr_pond_cesm, tr_pond_lvl, &
+#else
+          tr_iage, tr_FY, tr_lvl, tr_pond_lvl, &
+#endif
           tr_pond_topo, tr_snow, tr_fsd, tr_iso, tr_aero, tr_brine, &
           skl_bgc, z_tracers, solve_zsal
       integer(kind=int_kind) :: &
@@ -305,7 +315,11 @@
       call icepack_query_parameters(skl_bgc_out=skl_bgc, &
            z_tracers_out=z_tracers, solve_zsal_out=solve_zsal)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_aero_out=tr_aero, tr_brine_out=tr_brine, &
            tr_snow_out=tr_snow, tr_fsd_out=tr_fsd, tr_iso_out=tr_iso)
       call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_vlvl_out=nt_vlvl, &
@@ -367,6 +381,7 @@
             enddo ! iblk
          endif
       endif
+#ifdef UNDEPRECATE_CESMPONDS
       ! CESM melt ponds
       if (tr_pond_cesm) then
          if (trim(runtype) == 'continue') &
@@ -380,6 +395,7 @@
             enddo ! iblk
          endif
       endif
+#endif
       ! level-ice melt ponds
       if (tr_pond_lvl) then
          if (trim(runtype) == 'continue') &

--- a/cicecore/drivers/mct/cesm1/CICE_RunMod.F90
+++ b/cicecore/drivers/mct/cesm1/CICE_RunMod.F90
@@ -137,7 +137,11 @@
       use ice_history_bgc, only: init_history_bgc
       use ice_restart, only: final_restart
       use ice_restart_column, only: write_restart_age, write_restart_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
           write_restart_lvl, write_restart_pond_cesm, write_restart_pond_lvl, &
+#else
+          write_restart_lvl, write_restart_pond_lvl, &
+#endif
           write_restart_pond_topo, write_restart_aero, write_restart_fsd, &
           write_restart_iso, write_restart_bgc, write_restart_hbrine, &
           write_restart_snow
@@ -162,7 +166,11 @@
 
       logical (kind=log_kind) :: &
           tr_iage, tr_FY, tr_lvl, tr_fsd, tr_snow, &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_brine, tr_iso, tr_aero, &
+#else
+          tr_pond_lvl, tr_pond_topo, tr_brine, tr_iso, tr_aero, &
+#endif
           calc_Tsfc, skl_bgc, solve_zsal, z_tracers, wave_spec
 
       character(len=*), parameter :: subname = '(ice_step)'
@@ -180,7 +188,11 @@
            solve_zsal_out=solve_zsal, z_tracers_out=z_tracers, ktherm_out=ktherm, &
            wave_spec_out=wave_spec)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_brine_out=tr_brine, tr_aero_out=tr_aero, &
            tr_iso_out=tr_iso, tr_fsd_out=tr_fsd, tr_snow_out=tr_snow)
       call icepack_warnings_flush(nu_diag)
@@ -391,7 +403,9 @@
             if (tr_iage)      call write_restart_age
             if (tr_FY)        call write_restart_FY
             if (tr_lvl)       call write_restart_lvl
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm) call write_restart_pond_cesm
+#endif
             if (tr_pond_lvl)  call write_restart_pond_lvl
             if (tr_pond_topo) call write_restart_pond_topo
             if (tr_snow)      call write_restart_snow

--- a/cicecore/drivers/nuopc/cmeps/CICE_InitMod.F90
+++ b/cicecore/drivers/nuopc/cmeps/CICE_InitMod.F90
@@ -215,11 +215,17 @@ contains
     use ice_grid, only: tmask
     use ice_init, only: ice_ic
     use ice_init_column, only: init_age, init_FY, init_lvl, init_snowtracers, &
+#ifdef UNDEPRECATE_CESMPONDS
          init_meltponds_cesm,  init_meltponds_lvl, init_meltponds_topo, &
+#else
+         init_meltponds_lvl, init_meltponds_topo, &
+#endif
          init_isotope, init_aerosol, init_hbrine, init_bgc, init_fsd
     use ice_restart_column, only: restart_age, read_restart_age, &
          restart_FY, read_restart_FY, restart_lvl, read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
          restart_pond_cesm, read_restart_pond_cesm, &
+#endif
          restart_pond_lvl, read_restart_pond_lvl, &
          restart_pond_topo, read_restart_pond_topo, &
          restart_snow, read_restart_snow, &
@@ -236,7 +242,11 @@ contains
          i, j        , & ! horizontal indices
          iblk            ! block index
     logical(kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_iage, tr_FY, tr_lvl, tr_pond_cesm, tr_pond_lvl, &
+#else
+         tr_iage, tr_FY, tr_lvl, tr_pond_lvl, &
+#endif
          tr_pond_topo, tr_fsd, tr_iso, tr_aero, tr_brine, tr_snow, &
          skl_bgc, z_tracers, solve_zsal
     integer(kind=int_kind) :: &
@@ -257,7 +267,11 @@ contains
     call icepack_query_parameters(skl_bgc_out=skl_bgc, &
          z_tracers_out=z_tracers, solve_zsal_out=solve_zsal)
     call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+         tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
          tr_pond_topo_out=tr_pond_topo, tr_aero_out=tr_aero, tr_brine_out=tr_brine, &
          tr_snow_out=tr_snow, tr_fsd_out=tr_fsd, tr_iso_out=tr_iso)
     call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_vlvl_out=nt_vlvl, &
@@ -319,6 +333,7 @@ contains
           enddo ! iblk
        endif
     endif
+#ifdef UNDEPRECATE_CESMPONDS
     ! CESM melt ponds
     if (tr_pond_cesm) then
        if (trim(runtype) == 'continue') &
@@ -332,6 +347,7 @@ contains
           enddo ! iblk
        endif
     endif
+#endif
     ! level-ice melt ponds
     if (tr_pond_lvl) then
        if (trim(runtype) == 'continue') &

--- a/cicecore/drivers/nuopc/cmeps/CICE_RunMod.F90
+++ b/cicecore/drivers/nuopc/cmeps/CICE_RunMod.F90
@@ -121,7 +121,11 @@
       use ice_history_bgc, only: init_history_bgc
       use ice_restart, only: final_restart
       use ice_restart_column, only: write_restart_age, write_restart_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
           write_restart_lvl, write_restart_pond_cesm, write_restart_pond_lvl, &
+#else
+          write_restart_lvl, write_restart_pond_lvl, &
+#endif
           write_restart_pond_topo, write_restart_aero, write_restart_fsd, &
           write_restart_iso, write_restart_bgc, write_restart_hbrine, &
           write_restart_snow
@@ -146,7 +150,11 @@
 
       logical (kind=log_kind) :: &
           tr_iage, tr_FY, tr_lvl, tr_fsd, tr_snow, &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_brine, tr_iso, tr_aero, &
+#else
+          tr_pond_lvl, tr_pond_topo, tr_brine, tr_iso, tr_aero, &
+#endif
           calc_Tsfc, skl_bgc, solve_zsal, z_tracers, wave_spec
 
       character(len=*), parameter :: subname = '(ice_step)'
@@ -164,7 +172,11 @@
            solve_zsal_out=solve_zsal, z_tracers_out=z_tracers, ktherm_out=ktherm, &
            wave_spec_out=wave_spec)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_brine_out=tr_brine, tr_aero_out=tr_aero, &
            tr_iso_out=tr_iso, tr_fsd_out=tr_fsd, tr_snow_out=tr_snow)
       call icepack_warnings_flush(nu_diag)
@@ -370,7 +382,9 @@
             if (tr_iage)      call write_restart_age
             if (tr_FY)        call write_restart_FY
             if (tr_lvl)       call write_restart_lvl
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm) call write_restart_pond_cesm
+#endif
             if (tr_pond_lvl)  call write_restart_pond_lvl
             if (tr_pond_topo) call write_restart_pond_topo
             if (tr_snow)      call write_restart_snow

--- a/cicecore/drivers/nuopc/dmi/CICE_InitMod.F90
+++ b/cicecore/drivers/nuopc/dmi/CICE_InitMod.F90
@@ -271,11 +271,17 @@
       use ice_grid, only: tmask
       use ice_init, only: ice_ic
       use ice_init_column, only: init_age, init_FY, init_lvl, init_snowtracers, &
+#ifdef UNDEPRECATE_CESMPONDS
           init_meltponds_cesm,  init_meltponds_lvl, init_meltponds_topo, &
+#else
+          init_meltponds_lvl, init_meltponds_topo, &
+#endif
           init_isotope, init_aerosol, init_hbrine, init_bgc, init_fsd
       use ice_restart_column, only: restart_age, read_restart_age, &
           restart_FY, read_restart_FY, restart_lvl, read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           restart_pond_cesm, read_restart_pond_cesm, &
+#endif
           restart_pond_lvl, read_restart_pond_lvl, &
           restart_pond_topo, read_restart_pond_topo, &
           restart_snow, read_restart_snow, &
@@ -292,7 +298,11 @@
          i, j        , & ! horizontal indices
          iblk            ! block index
       logical(kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iage, tr_FY, tr_lvl, tr_pond_cesm, tr_pond_lvl, &
+#else
+          tr_iage, tr_FY, tr_lvl, tr_pond_lvl, &
+#endif
           tr_pond_topo, tr_snow, tr_fsd, tr_iso, tr_aero, tr_brine, &
           skl_bgc, z_tracers, solve_zsal
       integer(kind=int_kind) :: &
@@ -312,7 +322,11 @@
       call icepack_query_parameters(skl_bgc_out=skl_bgc, &
            z_tracers_out=z_tracers, solve_zsal_out=solve_zsal)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_aero_out=tr_aero, tr_brine_out=tr_brine, &
            tr_snow_out=tr_snow, tr_fsd_out=tr_fsd, tr_iso_out=tr_iso)
       call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_vlvl_out=nt_vlvl, &
@@ -374,6 +388,7 @@
             enddo ! iblk
          endif
       endif
+#ifdef UNDEPRECATE_CESMPONDS
       ! CESM melt ponds
       if (tr_pond_cesm) then
          if (trim(runtype) == 'continue') &
@@ -387,6 +402,7 @@
             enddo ! iblk
          endif
       endif
+#endif
       ! level-ice melt ponds
       if (tr_pond_lvl) then
          if (trim(runtype) == 'continue') &

--- a/cicecore/drivers/nuopc/dmi/CICE_RunMod.F90
+++ b/cicecore/drivers/nuopc/dmi/CICE_RunMod.F90
@@ -157,7 +157,11 @@
       use ice_history_bgc, only: init_history_bgc
       use ice_restart, only: final_restart
       use ice_restart_column, only: write_restart_age, write_restart_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
           write_restart_lvl, write_restart_pond_cesm, write_restart_pond_lvl, &
+#else
+          write_restart_lvl, write_restart_pond_lvl, &
+#endif
           write_restart_pond_topo, write_restart_aero, write_restart_fsd, &
           write_restart_iso, write_restart_bgc, write_restart_hbrine, &
           write_restart_snow
@@ -180,7 +184,11 @@
 
       logical (kind=log_kind) :: &
           tr_iage, tr_FY, tr_lvl, tr_fsd, tr_snow, &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_brine, tr_iso, tr_aero, &
+#else
+          tr_pond_lvl, tr_pond_topo, tr_brine, tr_iso, tr_aero, &
+#endif
           calc_Tsfc, skl_bgc, solve_zsal, z_tracers, wave_spec
 
       character(len=*), parameter :: subname = '(ice_step)'
@@ -198,7 +206,11 @@
            solve_zsal_out=solve_zsal, z_tracers_out=z_tracers, ktherm_out=ktherm, &
            wave_spec_out=wave_spec)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_brine_out=tr_brine, tr_aero_out=tr_aero, &
            tr_iso_out=tr_iso, tr_fsd_out=tr_fsd, tr_snow_out=tr_snow)
       call icepack_warnings_flush(nu_diag)
@@ -400,7 +412,9 @@
             if (tr_iage)      call write_restart_age
             if (tr_FY)        call write_restart_FY
             if (tr_lvl)       call write_restart_lvl
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm) call write_restart_pond_cesm
+#endif
             if (tr_pond_lvl)  call write_restart_pond_lvl
             if (tr_pond_topo) call write_restart_pond_topo
             if (tr_snow)      call write_restart_snow

--- a/cicecore/drivers/standalone/cice/CICE_InitMod.F90
+++ b/cicecore/drivers/standalone/cice/CICE_InitMod.F90
@@ -266,11 +266,17 @@
       use ice_grid, only: tmask
       use ice_init, only: ice_ic
       use ice_init_column, only: init_age, init_FY, init_lvl, init_snowtracers, &
+#ifdef UNDEPRECATE_CESMPONDS
           init_meltponds_cesm,  init_meltponds_lvl, init_meltponds_topo, &
+#else
+          init_meltponds_lvl, init_meltponds_topo, &
+#endif
           init_isotope, init_aerosol, init_hbrine, init_bgc, init_fsd
       use ice_restart_column, only: restart_age, read_restart_age, &
           restart_FY, read_restart_FY, restart_lvl, read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           restart_pond_cesm, read_restart_pond_cesm, &
+#endif
           restart_pond_lvl, read_restart_pond_lvl, &
           restart_pond_topo, read_restart_pond_topo, &
           restart_snow, read_restart_snow, &
@@ -287,7 +293,11 @@
          i, j        , & ! horizontal indices
          iblk            ! block index
       logical(kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iage, tr_FY, tr_lvl, tr_pond_cesm, tr_pond_lvl, &
+#else
+          tr_iage, tr_FY, tr_lvl, tr_pond_lvl, &
+#endif
           tr_pond_topo, tr_snow, tr_fsd, tr_iso, tr_aero, tr_brine, &
           skl_bgc, z_tracers, solve_zsal
       integer(kind=int_kind) :: &
@@ -307,7 +317,11 @@
       call icepack_query_parameters(skl_bgc_out=skl_bgc, &
            z_tracers_out=z_tracers, solve_zsal_out=solve_zsal)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_aero_out=tr_aero, tr_brine_out=tr_brine, &
            tr_snow_out=tr_snow, tr_fsd_out=tr_fsd, tr_iso_out=tr_iso)
       call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_vlvl_out=nt_vlvl, &
@@ -369,6 +383,7 @@
             enddo ! iblk
          endif
       endif
+#ifdef UNDEPRECATE_CESMPONDS
       ! CESM melt ponds
       if (tr_pond_cesm) then
          if (trim(runtype) == 'continue') &
@@ -382,6 +397,7 @@
             enddo ! iblk
          endif
       endif
+#endif
       ! level-ice melt ponds
       if (tr_pond_lvl) then
          if (trim(runtype) == 'continue') &

--- a/cicecore/drivers/standalone/cice/CICE_RunMod.F90
+++ b/cicecore/drivers/standalone/cice/CICE_RunMod.F90
@@ -151,7 +151,11 @@
       use ice_history_bgc, only: init_history_bgc
       use ice_restart, only: final_restart
       use ice_restart_column, only: write_restart_age, write_restart_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
           write_restart_lvl, write_restart_pond_cesm, write_restart_pond_lvl, &
+#else
+          write_restart_lvl, write_restart_pond_lvl, &
+#endif
           write_restart_pond_topo, write_restart_aero, write_restart_fsd, &
           write_restart_iso, write_restart_bgc, write_restart_hbrine, &
           write_restart_snow
@@ -174,7 +178,11 @@
 
       logical (kind=log_kind) :: &
           tr_iage, tr_FY, tr_lvl, tr_fsd, tr_snow, &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_pond_cesm, tr_pond_lvl, tr_pond_topo, tr_brine, tr_iso, tr_aero, &
+#else
+          tr_pond_lvl, tr_pond_topo, tr_brine, tr_iso, tr_aero, &
+#endif
           calc_Tsfc, skl_bgc, solve_zsal, z_tracers, wave_spec
 
       character(len=*), parameter :: subname = '(ice_step)'
@@ -192,7 +200,11 @@
            solve_zsal_out=solve_zsal, z_tracers_out=z_tracers, ktherm_out=ktherm, &
            wave_spec_out=wave_spec)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_brine_out=tr_brine, tr_aero_out=tr_aero, &
            tr_iso_out=tr_iso, tr_fsd_out=tr_fsd, tr_snow_out=tr_snow)
       call icepack_warnings_flush(nu_diag)
@@ -396,7 +408,9 @@
             if (tr_iage)      call write_restart_age
             if (tr_FY)        call write_restart_FY
             if (tr_lvl)       call write_restart_lvl
+#ifdef UNDEPRECATE_CESMPONDS
             if (tr_pond_cesm) call write_restart_pond_cesm
+#endif
             if (tr_pond_lvl)  call write_restart_pond_lvl
             if (tr_pond_topo) call write_restart_pond_topo
             if (tr_snow)      call write_restart_snow

--- a/cicecore/drivers/unittest/gridavgchk/CICE_InitMod.F90
+++ b/cicecore/drivers/unittest/gridavgchk/CICE_InitMod.F90
@@ -241,11 +241,17 @@
       use ice_grid, only: tmask
       use ice_init, only: ice_ic
       use ice_init_column, only: init_age, init_FY, init_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           init_meltponds_cesm,  init_meltponds_lvl, init_meltponds_topo, &
+#else
+          init_meltponds_lvl, init_meltponds_topo, &
+#endif
           init_isotope, init_aerosol, init_hbrine, init_bgc, init_fsd
       use ice_restart_column, only: restart_age, read_restart_age, &
           restart_FY, read_restart_FY, restart_lvl, read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           restart_pond_cesm, read_restart_pond_cesm, &
+#endif
           restart_pond_lvl, read_restart_pond_lvl, &
           restart_pond_topo, read_restart_pond_topo, &
           restart_fsd, read_restart_fsd, &
@@ -261,7 +267,11 @@
          i, j        , & ! horizontal indices
          iblk            ! block index
       logical(kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iage, tr_FY, tr_lvl, tr_pond_cesm, tr_pond_lvl, &
+#else
+          tr_iage, tr_FY, tr_lvl, tr_pond_lvl, &
+#endif
           tr_pond_topo, tr_fsd, tr_iso, tr_aero, tr_brine, &
           skl_bgc, z_tracers, solve_zsal
       integer(kind=int_kind) :: &
@@ -280,7 +290,11 @@
       call icepack_query_parameters(skl_bgc_out=skl_bgc, &
            z_tracers_out=z_tracers, solve_zsal_out=solve_zsal)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_aero_out=tr_aero, tr_brine_out=tr_brine, &
            tr_fsd_out=tr_fsd, tr_iso_out=tr_iso)
       call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_vlvl_out=nt_vlvl, &
@@ -340,6 +354,7 @@
             enddo ! iblk
          endif
       endif
+#ifdef UNDEPRECATE_CESMPONDS
       ! CESM melt ponds
       if (tr_pond_cesm) then
          if (trim(runtype) == 'continue') &
@@ -353,6 +368,7 @@
             enddo ! iblk
          endif
       endif
+#endif
       ! level-ice melt ponds
       if (tr_pond_lvl) then
          if (trim(runtype) == 'continue') &

--- a/cicecore/drivers/unittest/sumchk/CICE_InitMod.F90
+++ b/cicecore/drivers/unittest/sumchk/CICE_InitMod.F90
@@ -241,11 +241,17 @@
       use ice_grid, only: tmask
       use ice_init, only: ice_ic
       use ice_init_column, only: init_age, init_FY, init_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           init_meltponds_cesm,  init_meltponds_lvl, init_meltponds_topo, &
+#else
+          init_meltponds_lvl, init_meltponds_topo, &
+#endif
           init_isotope, init_aerosol, init_hbrine, init_bgc, init_fsd
       use ice_restart_column, only: restart_age, read_restart_age, &
           restart_FY, read_restart_FY, restart_lvl, read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
           restart_pond_cesm, read_restart_pond_cesm, &
+#endif
           restart_pond_lvl, read_restart_pond_lvl, &
           restart_pond_topo, read_restart_pond_topo, &
           restart_fsd, read_restart_fsd, &
@@ -261,7 +267,11 @@
          i, j        , & ! horizontal indices
          iblk            ! block index
       logical(kind=log_kind) :: &
+#ifdef UNDEPRECATE_CESMPONDS
           tr_iage, tr_FY, tr_lvl, tr_pond_cesm, tr_pond_lvl, &
+#else
+          tr_iage, tr_FY, tr_lvl, tr_pond_lvl, &
+#endif
           tr_pond_topo, tr_fsd, tr_iso, tr_aero, tr_brine, &
           skl_bgc, z_tracers, solve_zsal
       integer(kind=int_kind) :: &
@@ -280,7 +290,11 @@
       call icepack_query_parameters(skl_bgc_out=skl_bgc, &
            z_tracers_out=z_tracers, solve_zsal_out=solve_zsal)
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
+#ifdef UNDEPRECATE_CESMPONDS
            tr_lvl_out=tr_lvl, tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+           tr_lvl_out=tr_lvl, tr_pond_lvl_out=tr_pond_lvl, &
+#endif
            tr_pond_topo_out=tr_pond_topo, tr_aero_out=tr_aero, tr_brine_out=tr_brine, &
            tr_fsd_out=tr_fsd, tr_iso_out=tr_iso)
       call icepack_query_tracer_indices(nt_alvl_out=nt_alvl, nt_vlvl_out=nt_vlvl, &
@@ -340,6 +354,7 @@
             enddo ! iblk
          endif
       endif
+#ifdef UNDEPRECATE_CESMPONDS
       ! CESM melt ponds
       if (tr_pond_cesm) then
          if (trim(runtype) == 'continue') &
@@ -353,6 +368,7 @@
             enddo ! iblk
          endif
       endif
+#endif
       ! level-ice melt ponds
       if (tr_pond_lvl) then
          if (trim(runtype) == 'continue') &

--- a/cicecore/shared/ice_init_column.F90
+++ b/cicecore/shared/ice_init_column.F90
@@ -44,7 +44,11 @@
       private
       public :: init_thermo_vertical, init_shortwave, &
                 init_age, init_FY, init_lvl, init_fsd, &
+#ifdef UNDEPRECATE_CESMPONDS
                 init_meltponds_cesm, init_meltponds_lvl, init_meltponds_topo, &
+#else
+                init_meltponds_lvl, init_meltponds_topo, &
+#endif
                 init_aerosol, init_bgc, init_hbrine, init_zbgc, input_zbgc, &
                 count_tracers, init_isotope, init_snowtracers
 
@@ -543,6 +547,7 @@
 
       end subroutine init_lvl
 
+#ifdef UNDEPRECATE_CESMPONDS
 !=======================================================================
 
 !  Initialize melt ponds.
@@ -558,7 +563,7 @@
       hpnd(:,:,:) = c0
 
       end subroutine init_meltponds_cesm
-
+#endif
 !=======================================================================
 
 !  Initialize melt ponds.
@@ -1813,7 +1818,11 @@
       integer (kind=int_kind) :: ntrcr
       logical (kind=log_kind) :: tr_iage, tr_FY, tr_lvl, tr_pond, tr_aero, tr_fsd
       logical (kind=log_kind) :: tr_snow
+#ifdef UNDEPRECATE_CESMPONDS
       logical (kind=log_kind) :: tr_iso, tr_pond_cesm, tr_pond_lvl, tr_pond_topo
+#else
+      logical (kind=log_kind) :: tr_iso, tr_pond_lvl, tr_pond_topo
+#endif
       integer (kind=int_kind) :: nt_Tsfc, nt_sice, nt_qice, nt_qsno, nt_iage, nt_FY
       integer (kind=int_kind) :: nt_alvl, nt_vlvl, nt_apnd, nt_hpnd, nt_ipnd, nt_aero
       integer (kind=int_kind) :: nt_fsd, nt_isosno, nt_isoice
@@ -1898,7 +1907,11 @@
 
       call icepack_query_tracer_flags(tr_iage_out=tr_iage, tr_FY_out=tr_FY, &
          tr_lvl_out=tr_lvl, tr_aero_out=tr_aero, tr_pond_out=tr_pond, &
+#ifdef UNDEPRECATE_CESMPONDS
          tr_pond_cesm_out=tr_pond_cesm, tr_pond_lvl_out=tr_pond_lvl, &
+#else
+         tr_pond_lvl_out=tr_pond_lvl, &
+#endif
          tr_pond_topo_out=tr_pond_topo, tr_brine_out=tr_brine, tr_fsd_out=tr_fsd, &
          tr_snow_out=tr_snow, tr_iso_out=tr_iso, &
          tr_bgc_Nit_out=tr_bgc_Nit, tr_bgc_Am_out =tr_bgc_Am,  tr_bgc_Sil_out=tr_bgc_Sil,   &

--- a/cicecore/shared/ice_restart_column.F90
+++ b/cicecore/shared/ice_restart_column.F90
@@ -29,7 +29,9 @@
       public ::  write_restart_age,       read_restart_age, &
                  write_restart_FY,        read_restart_FY, &
                  write_restart_lvl,       read_restart_lvl, &
+#ifdef UNDEPRECATE_CESMPONDS
                  write_restart_pond_cesm, read_restart_pond_cesm, &
+#endif
                  write_restart_pond_lvl,  read_restart_pond_lvl, &
                  write_restart_pond_topo, read_restart_pond_topo, &
                  write_restart_snow,      read_restart_snow, &
@@ -43,7 +45,9 @@
          restart_age      , & ! if .true., read age tracer restart file
          restart_FY       , & ! if .true., read FY tracer restart file
          restart_lvl      , & ! if .true., read lvl tracer restart file
+#ifdef UNDEPRECATE_CESMPONDS
          restart_pond_cesm, & ! if .true., read meltponds restart file
+#endif
          restart_pond_lvl , & ! if .true., read meltponds restart file
          restart_pond_topo, & ! if .true., read meltponds restart file
          restart_snow     , & ! if .true., read snow tracer restart file
@@ -256,6 +260,7 @@
 
       end subroutine read_restart_lvl
 
+#ifdef UNDEPRECATE_CESMPONDS
 !=======================================================================
 !
 ! Dumps all values needed for restarting
@@ -322,7 +327,7 @@
                               'hpnd',ncat,diag,field_loc_center,field_type_scalar)
 
       end subroutine read_restart_pond_cesm
-
+#endif
 !=======================================================================
 !
 ! Dumps all values needed for restarting

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -100,8 +100,6 @@
     restart_FY   = .false.
     tr_lvl       = .true.
     restart_lvl  = .false.
-    tr_pond_cesm = .false.
-    restart_pond_cesm = .false.
     tr_pond_topo = .false.
     restart_pond_topo = .false.
     tr_pond_lvl  = .true.

--- a/configuration/scripts/options/set_nml.alt01
+++ b/configuration/scripts/options/set_nml.alt01
@@ -6,7 +6,6 @@ distribution_wght = 'block'
 tr_iage      = .false.
 tr_FY        = .false.
 tr_lvl       = .true.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .false.
 tr_aero      = .false.

--- a/configuration/scripts/options/set_nml.alt02
+++ b/configuration/scripts/options/set_nml.alt02
@@ -5,7 +5,6 @@ distribution_type = 'sectrobin'
 tr_iage      = .true.
 tr_FY        = .true.
 tr_lvl       = .true.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .false.
 tr_aero      = .false.

--- a/configuration/scripts/options/set_nml.alt03
+++ b/configuration/scripts/options/set_nml.alt03
@@ -6,7 +6,6 @@ conserv_check = .true.
 tr_iage      = .false.
 tr_FY        = .false.
 tr_lvl       = .false.
-tr_pond_cesm = .false.
 tr_pond_topo = .true.
 tr_pond_lvl  = .false.
 tr_aero      = .true.

--- a/configuration/scripts/options/set_nml.alt04
+++ b/configuration/scripts/options/set_nml.alt04
@@ -6,7 +6,6 @@ distribution_wght = 'block'
 tr_iage      = .true.
 tr_FY        = .true.
 tr_lvl       = .true.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .true.
 tr_aero      = .true.

--- a/configuration/scripts/options/set_nml.alt05
+++ b/configuration/scripts/options/set_nml.alt05
@@ -2,7 +2,6 @@ ice_ic = 'internal'
 tr_iage      = .false.
 tr_FY        = .false.
 tr_lvl       = .false.
-tr_pond_cesm = .true.
 tr_pond_topo = .false.
 tr_pond_lvl  = .false.
 tr_aero      = .false.

--- a/configuration/scripts/options/set_nml.boxadv
+++ b/configuration/scripts/options/set_nml.boxadv
@@ -13,7 +13,6 @@ ice_data_dist  = 'box2001'
 tr_iage      = .true.
 tr_FY        = .false.
 tr_lvl       = .true.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .false.
 tr_aero      = .false.

--- a/configuration/scripts/options/set_nml.boxnodyn
+++ b/configuration/scripts/options/set_nml.boxnodyn
@@ -38,7 +38,6 @@ ns_boundary_type = 'open'
 tr_iage      = .false.
 tr_FY        = .false.
 tr_lvl       = .false.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .false.
 tr_aero      = .false.

--- a/configuration/scripts/options/set_nml.boxrestore
+++ b/configuration/scripts/options/set_nml.boxrestore
@@ -18,7 +18,6 @@ f_aice	       = 'd'
 tr_iage      = .true.
 tr_FY        = .true.
 tr_lvl       = .true.
-tr_pond_cesm = .false.
 tr_pond_topo = .false.
 tr_pond_lvl  = .false.
 tr_aero      = .false.

--- a/doc/source/science_guide/sg_tracers.rst
+++ b/doc/source/science_guide/sg_tracers.rst
@@ -78,8 +78,6 @@ is not in use.
    "tr_FY", "1", "aice", "nt_FY", " "
    "tr_lvl", "2", "aice", "nt_alvl", " "
    " ", " ", "vice", "nt_vlvl", " "
-   "tr_pond_cesm", "2", "aice", "nt_apnd", " " 
-   " ", " ", "apnd", "nt_vpnd", " "
    "tr_pond_lvl", "3", "aice", "nt_apnd", " " 
    " ", " ", "apnd", "nt_vpnd", " "
    " ", " ", "apnd", "nt_ipnd", " "
@@ -113,7 +111,9 @@ is not in use.
    "tr_zaero", "n_zaero", "fbri or (a,v)ice", "nt_zaero", "nlt_zaero"
    " ", "1", "fbri", "nt_zbgc_frac", " "
 
-
+..
+   "tr_pond_cesm", "2", "aice", "nt_apnd", " " 
+   " ", " ", "apnd", "nt_vpnd", " "
 
 Users may add any number of additional tracers that are transported conservatively,
 provided that the dependency ``trcr_depend`` is defined appropriately. 

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -353,8 +353,8 @@ tracer_nml
    "``tr_iage``", "logical", "ice age", "``.false.``"
    "``tr_iso``", "logical", "isotopes", "``.false.``"
    "``tr_lvl``", "logical", "level ice area and volume", "``.false.``"
-   "``tr_pond_cesm``", "logical", "CESM melt ponds", "``.false.``"
    "``tr_pond_lvl``", "logical", "level-ice melt ponds", "``.false.``"
+   "``tr_pond_cesm``", " ", "DEPRECATED", " "
    "``tr_pond_topo``", "logical", "topo melt ponds", "``.false.``"
    "``tr_snow``", "logical", "advanced snow physics", "``.false.``"
    "``restart_aero``", "logical", "restart tracer values from file", "``.false.``"
@@ -363,11 +363,14 @@ tracer_nml
    "``restart_FY``", "logical", "restart tracer values from file", "``.false.``"
    "``restart_iso``", "logical", "restart tracer values from file", "``.false.``"
    "``restart_lvl``", "logical", "restart tracer values from file", "``.false.``"
-   "``restart_pond_cesm``", "logical", "restart tracer values from file", "``.false.``"
    "``restart_pond_lvl``", "logical", "restart tracer values from file", "``.false.``"
    "``restart_pond_topo``", "logical", "restart tracer values from file", "``.false.``"
    "``restart_snow``", "logical", "restart snow tracer values from file", "``.false.``"
    "", "", "", ""
+
+..
+   "``tr_pond_cesm``", "logical", "CESM melt ponds", "``.false.``"
+   "``restart_pond_cesm``", "logical", "restart tracer values from file", "``.false.``"
 
 thermo_nml
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -347,7 +347,6 @@ Lines that begin with # or are blank are ignored.  For example,
     smoke   col  1x1  debug,run1year  
    restart  col  1x1  debug  
    restart  col  1x1  diag1  
-   restart  col  1x1  pondcesm  
    restart  col  1x1  pondlvl  
    restart  col  1x1  pondtopo  
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Deprecate the tr_ponds_cesm option.
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Did a full test suite compared against the weekly baselines.
5945 measured results of 5945 total results
5856 of 5945 tests PASSED
0 of 5945 tests PENDING
0 of 5945 tests MISSING data
89 of 5945 tests FAILED

Of the 89 tests, the majority of the changed answers were alt05 related which had tr_pond_cesm = .true.

The remaining test failures were as follows. I'm not sure why.

FAIL cheyenne_intel_smoke_gx3_8x1_cmplogrest_dynpicard_reprosum_run10day_thread bfbcomp cheyenne_intel_smoke_gx3_6x4_dynpicard_reprosum_run10day different-data
FAIL cheyenne_pgi_smoke_gx3_8x1_cmplogrest_dynpicard_reprosum_run10day_thread bfbcomp cheyenne_pgi_smoke_gx3_6x4_dynpicard_reprosum_run10day different-data
FAIL cheyenne_pgi_smoke_gx1_144x2_gx1prod_long_run10year run -1 -1 -1
FAIL cheyenne_pgi_smoke_gx1_144x2_gx1prod_long_run10year test 
FAIL cheyenne_gnu_smoke_gx3_8x1_cmplogrest_dynpicard_reprosum_run10day_thread bfbcomp cheyenne_gnu_smoke_gx3_6x4_dynpicard_reprosum_run10day different-data

- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial 
Removes all tests with tr_ponds_cesm = .true.
- Does this PR create or have dependencies on Icepack or any other models?
    - [X] Yes
    - [ ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:
There is an option UNDEPRECATE_CESMPONDS to reverse this. It also requires adding tr_pond_cesm and restart_pond_cesm back to ice_in.