### PR TITLE
Change visc_method default to avg_zeta

### DIFF
--- a/cice.setup
+++ b/cice.setup
@@ -1180,21 +1180,26 @@ echo "-------test--------------"
 echo "${testname_base}"
 cd ${testname_base}
 source ./cice.settings
+set bldstat = 0
 if (\${dobuild} == true) then
    if (\${doreuse} == true) then
      set ciceexe = "../ciceexe.\${ICE_TARGET}.\${ICE_ENVNAME}.\${ICE_COMMDIR}.\${ICE_BLDDEBUG}.\${ICE_THREADED}.\${ICE_IOTYPE}"
      ./cice.build --exe \${ciceexe}
+     set bldstat = \${status}
      if !(-e \${ciceexe}) cp -p \${ICE_RUNDIR}/cice \${ciceexe}
    else
      ./cice.build
+     set bldstat = \${status}
    endif
 endif
-if (\${dosubmit} == true) then
-  set jobid = \`./cice.submit\`
-  echo "\$jobid"
-  echo "\$jobid  \${ICE_TESTNAME}  " >> ../suite.jobs
-else if (\${dorun} == true) then
-  ./cice.test
+if (\$bldstat == 0) then
+  if (\${dosubmit} == true) then
+    set jobid = \`./cice.submit\`
+    echo "\$jobid"
+    echo "\$jobid  \${ICE_TESTNAME}  " >> ../suite.jobs
+  else if (\${dorun} == true) then
+    ./cice.test
+  endif
 endif
 cd ..
 EOF

--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -404,7 +404,7 @@
       Ktens = 0.0_dbl_kind    ! T=Ktens*P (tensile strength: see Konig and Holland, 2010)
       e_yieldcurve = 2.0_dbl_kind  ! VP aspect ratio of elliptical yield curve               
       e_plasticpot = 2.0_dbl_kind  ! VP aspect ratio of elliptical plastic potential
-      visc_method = 'avg_strength' ! calc viscosities at U point: avg_strength, avg_zeta
+      visc_method = 'avg_zeta' ! calc viscosities at U point: avg_strength, avg_zeta
       deltaminEVP = 1e-11_dbl_kind ! minimum delta for viscosities (EVP, Hunke 2001)
       deltaminVP  = 2e-9_dbl_kind  ! minimum delta for viscosities (VP, Hibler 1979)
       capping_method  = 'max'  ! method for capping of viscosities (max=Hibler 1979,sum=Kreyscher2000)
@@ -889,7 +889,7 @@
       call broadcast_scalar(Ktens,                master_task)
       call broadcast_scalar(e_yieldcurve,         master_task)
       call broadcast_scalar(e_plasticpot,         master_task)
-      call broadcast_scalar(visc_method,    master_task)
+      call broadcast_scalar(visc_method,          master_task)
       call broadcast_scalar(deltaminEVP,          master_task)
       call broadcast_scalar(deltaminVP,           master_task)
       call broadcast_scalar(capping_method,       master_task)

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -147,7 +147,7 @@
     Ktens           = 0.
     e_yieldcurve    = 2.
     e_plasticpot    = 2.
-    visc_method     = 'avg_strength'
+    visc_method     = 'avg_zeta'
     elasticDamp     = 0.36d0
     deltaminEVP     = 1e-11
     deltaminVP      = 2e-9

--- a/configuration/scripts/options/set_nml.alt07
+++ b/configuration/scripts/options/set_nml.alt07
@@ -2,5 +2,5 @@ kdyn            = 1
 evp_algorithm   = 'standard_2d'
 ndte            = 300
 capping_method  = 'sum'
-visc_method     = 'avg_zeta'
+visc_method     = 'avg_strength'
 

--- a/doc/source/cice_index.rst
+++ b/doc/source/cice_index.rst
@@ -738,7 +738,7 @@ either Celsius or Kelvin units).
    "vice(n)", "volume per unit area of ice (in category n)", "m"
    "vicen_init", "ice volume at beginning of timestep", "m"
    "viscosity_dyn", "dynamic viscosity of brine", ":math:`1.79\times 10^{-3}` kg/m/s"
-   "visc_method", "method for calculating viscosities (‘avg_strength’ or ‘avg_zeta’)", "avg_strength"
+   "visc_method", "method for calculating viscosities (‘avg_strength’ or ‘avg_zeta’)", "avg_zeta"
    "vocn", "ocean current in the y-direction", "m/s"
    "vonkar", "von Karman constant", "0.4"
    "vraftn", "volume of rafted ice", "m"

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -488,7 +488,7 @@ dynamics_nml
    "", "``geostropic``", "computed from ocean velocity", ""
    "``threshold_hw``", "real", "Max water depth for grounding (see :cite:`Amundrud04`)", "30."
    "``use_mean_vrel``", "logical", "Use mean of two previous iterations for vrel in VP", "``.true.``"
-   "``visc_method``", "``avg_strength``", "average strength for viscosities on U grid", "``avg_strength``"
+   "``visc_method``", "``avg_strength``", "average strength for viscosities on U grid", "``avg_zeta``"
    "", "``avg_zeta``", "average zeta for viscosities on U grid", ""
    "``yield_curve``", "``ellipse``", "elliptical yield curve", "``ellipse``"
    "", "", "", ""


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Change visc_method default to avg_zeta, change alt07 to test avg_strength
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    full test suite on cheyenne indicates several failures with visc_method=avg_zeta that didn't failed with avg_strength, only for gridCD, no problem with gridB or gridC.  https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#063a7f2151ec20571d641af0552f4ea182acb9b6
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial, default visc_method change in gridC and gridCD 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No, but changes default and alt07.
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

Also update the suite.submit to not submit jobs that don't build successfully.

Several gridCD test cases fail with avg_zeta, but passed with avg_strength.  gridCD is not validated yet, so I will let these fail for now.

FAIL cheyenne_intel_smoke_gbox80_2x2_boxwallblock_gridcd run -1 -1 -1
FAIL cheyenne_intel_smoke_gbox80_4x1_boxsyme_gridcd_kmtislands_run1day run -1 -1 -1
FAIL cheyenne_intel_smoke_gbox80_4x2_boxislandse_gridcd_run1day run -1 -1 -1
FAIL cheyenne_intel_smoke_gbox128_8x2_gridcd_reprosum_run10day run -1 -1 -1
FAIL cheyenne_intel_smoke_gbox128_8x1_cmplogrest_gridcd_reprosum_run10day_thread run -1 -1 -1
FAIL cheyenne_pgi_smoke_gbox80_2x2_boxwallblock_gridcd run -1 -1 -1
FAIL cheyenne_pgi_smoke_gbox80_4x1_boxsyme_gridcd_kmtislands_run1day run -1 -1 -1
FAIL cheyenne_pgi_smoke_gbox80_4x2_boxislandse_gridcd_run1day run -1 -1 -1
FAIL cheyenne_pgi_smoke_gx1_15x2_gridcd_reprosum_run10day_seabedprob run -1 -1 -1
FAIL cheyenne_pgi_smoke_gbox128_8x2_gridcd_reprosum_run10day run -1 -1 -1
FAIL cheyenne_pgi_smoke_gx1_18x1_cmplogrest_gridcd_reprosum_run10day_seabedprob_thread run -1 -1 -1
FAIL cheyenne_pgi_smoke_gbox128_8x1_cmplogrest_gridcd_reprosum_run10day_thread run -1 -1 -1
FAIL cheyenne_pgi_smoke_gx1_144x2_gx1prod_long_run10year run -1 -1 -1
FAIL cheyenne_gnu_smoke_gbox80_2x2_boxwallblock_gridcd run -1 -1 -1
FAIL cheyenne_gnu_smoke_gbox80_4x1_boxsyme_gridcd_kmtislands_run1day run -1 -1 -1
FAIL cheyenne_gnu_smoke_gbox80_4x2_boxislandse_gridcd_run1day run -1 -1 -1
FAIL cheyenne_gnu_smoke_gbox128_8x2_gridcd_reprosum_run10day run -1 -1 -1
FAIL cheyenne_gnu_smoke_gbox128_8x1_cmplogrest_gridcd_reprosum_run10day_thread run -1 -1 -1
