### PR TITLE
ice_grid: do call 'gridbox_verts' for rectangular grids

### DIFF
--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -1404,6 +1404,7 @@
          enddo
          work_g1(:,:) = work_g1(:,:) / rad_to_deg
       endif
+      call gridbox_verts(work_g1,lont_bounds)
       call scatter_global(ULON, work_g1, master_task, distrb_info, &
                           field_loc_NEcorner, field_type_scalar)
       call ice_HaloExtrapolate(ULON, distrb_info, &
@@ -1423,6 +1424,7 @@
          enddo
          work_g1(:,:) = work_g1(:,:) / rad_to_deg
       endif
+      call gridbox_verts(work_g1,latt_bounds)
       call scatter_global(ULAT, work_g1, master_task, distrb_info, &
                           field_loc_NEcorner, field_type_scalar)
       call ice_HaloExtrapolate(ULAT, distrb_info, &


### PR DESCRIPTION

## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me
- [X] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    base suite is bfb with CICE6.4.0, as expected:
```
349 measured results of 349 total results
349 of 349 tests PASSED
0 of 349 tests PENDING
0 of 349 tests MISSING data
0 of 349 tests FAILED
```

I also set up a case on  a rectangular grid (`gbox80`) and compiled with `-init=snan,arrays` and verified that the code does not crash as it did before (see "Problems in ice_grid.F90" in https://github.com/CICE-Consortium/CICE/issues/599#issue-865459873).

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

At the end of subroutine ice_grid::gridbox_corners, the arrays
'lont_bounds' and 'lonu_bounds', which contain the longitude of the
corners of each grid cell on the T and U grids, are converted to to the
[0, 360] range.

In the case of rectangular grids ('grid_type = rectangular'), at the
point where 'gridbox_corners' is called in 'init_grid2', 'lont_bounds'
is not initialized, causing the code to abort if compiling with NaN
initialization. This is due to the fact that 'gridbox_verts', which
initializes 'lont_bounds' and 'latt_bounds', is not called in
'rectgrid', whereas it is called in 'popgrid[_nc]'.

Do call 'gridbox_verts' in 'rectgrid', so that 'lont_bounds' and
'latt_bounds' are correctly initalized in that case also.

Note that these calls are also missing in 'latlongrid' and 'cpomgrid',
but since these two subroutines are not used in standalone
configuration, let's not bother for now.

