### PR TITLE
ice_calendar: zero-initialize 'nstreams'

### DIFF
--- a/cicecore/shared/ice_calendar.F90
+++ b/cicecore/shared/ice_calendar.F90
@@ -204,6 +204,10 @@
       dt_dyn = dt/real(ndtd,kind=dbl_kind) ! dynamics et al timestep
       force_restart_now = .false.
 
+      ! initialize nstreams to zero (will be initialized from namelist in 'init_hist')
+      ! this avoids using it uninitialzed in 'calendar' below
+      nstreams = 0
+
 #ifdef CESMCOUPLED
       ! calendar_type set by coupling
 #else


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
 title 
- [X] Developer(s): 
me
- [X] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    I checked that the code runs fine with the fix when compiling with `-init=huge`. It crashes without the fix.
I ran the `base`, `decomp` and `nothread` suites with the fix and  `-init=huge` and everything passed as expected.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

The variable ice_calendar::nstreams, which corresponds to the number of
output history streams to use for the run, is initialized in
ice_history::init_hist depending on the number of non-'x' elements in
'histfreq' in the namelist.

However, the code does use 'nstreams' before ice_history::init_hist is
called, in ice_calendar::calendar when called from
ice_calendar::init_calendar. Both 'init_calendar' and 'init_hist' are
called from CICE_InitMod::cice_init, in that order, such that the loop
that initializes 'write_history' in 'calendar' uses 'nstreams'
uninitialized.

'calendar' ends up being called at least once more during 'cice_init', from
ice_calendar::advance_timestep, at which point 'nstreams' is correctly
defined and 'write_history' is thus correctly initialized, before its
first use in 'accum_hist'.

To avoid using 'nstreams' uninitialized in the first call to 'calendar'
from 'init_calendar', initialize it to zero in 'init_calendar' before
calling 'calendar'.

This issue was discovered by compiling using the '-init=huge' flag of
the Intel compiler.