### PR TITLE
Refactored evp sub cycling loop

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -813,7 +813,7 @@
 
                ! U fields at NE corner
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,          halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,          halo_info_mask,    &
                                     field_loc_NEcorner, field_type_vector, &
                                     uvel, vvel)
 
@@ -848,7 +848,7 @@
                !$OMP END PARALLEL DO
 
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,          halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,          halo_info_mask,    &
                                     field_loc_NEcorner, field_type_scalar, &
                                     shearU)
 
@@ -888,7 +888,7 @@
                !$OMP END PARALLEL DO
 
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,        halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,        halo_info_mask,    &
                                     field_loc_center, field_type_scalar, &
                                     zetax2T, etax2T, stresspT, stressmT)
 
@@ -911,7 +911,7 @@
                !$OMP END PARALLEL DO
 
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info         , halo_info_mask,    &
+               call dyn_haloUpdate (halo_info         , halo_info_mask,    &
                                     field_loc_NEcorner, field_type_scalar, &
                                     stress12U)
 
@@ -969,10 +969,10 @@
                !$OMP END PARALLEL DO
 
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,       halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,       halo_info_mask,    &
                                     field_loc_Eface, field_type_vector, &
                                     uvelE)
-               call dyn_HaloUpdate (halo_info,       halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,       halo_info_mask,    &
                                     field_loc_Nface, field_type_vector, &
                                     vvelN)
 
@@ -982,10 +982,10 @@
                vvelE(:,:,:) = vvelE(:,:,:)*epm(:,:,:)
 
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,       halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,       halo_info_mask,    &
                                     field_loc_Nface, field_type_vector, &
                                     uvelN)
-               call dyn_HaloUpdate (halo_info,       halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,       halo_info_mask,    &
                                     field_loc_Eface, field_type_vector, &
                                     vvelE)
 
@@ -996,9 +996,9 @@
                vvel(:,:,:) = vvel(:,:,:)*uvm(:,:,:)
                ! U fields at NE corner
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,          halo_info_mask,    &
-                                 field_loc_NEcorner, field_type_vector, &
-                                 uvel, vvel)
+               call dyn_haloUpdate (halo_info,          halo_info_mask,    &
+                                    field_loc_NEcorner, field_type_vector, &
+                                    uvel, vvel)
 
             enddo                     ! subcycling
 
@@ -1040,7 +1040,7 @@
                !$OMP END PARALLEL DO
 
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,        halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,        halo_info_mask,    &
                                     field_loc_center, field_type_scalar, &
                                     zetax2T, etax2T)
 
@@ -1085,10 +1085,10 @@
                !$OMP END PARALLEL DO
 
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,         halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,         halo_info_mask,    &
                                     field_loc_center,  field_type_scalar, &
                                     stresspT, stressmT, stress12T)
-               call dyn_HaloUpdate (halo_info,         halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,         halo_info_mask,    &
                                     field_loc_NEcorner,field_type_scalar, &
                                     stresspU, stressmU, stress12U)
 
@@ -1168,10 +1168,10 @@
                !$OMP END PARALLEL DO
 
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,       halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,       halo_info_mask,    &
                                     field_loc_Eface, field_type_vector, &
                                     uvelE, vvelE)
-               call dyn_HaloUpdate (halo_info,       halo_info_mask,    &
+               call dyn_haloUpdate (halo_info,       halo_info_mask,    &
                                     field_loc_Nface, field_type_vector, &
                                     uvelN, vvelN)
 
@@ -1182,9 +1182,9 @@
                vvel(:,:,:) = vvel(:,:,:)*uvm(:,:,:)
                ! U fields at NE corner
                ! calls ice_haloUpdate, controls bundles and masks
-               call dyn_HaloUpdate (halo_info,          halo_info_mask,    &
-                                 field_loc_NEcorner, field_type_vector, &
-                                 uvel, vvel)
+               call dyn_haloUpdate (halo_info,          halo_info_mask,    &
+                                    field_loc_NEcorner, field_type_vector, &
+                                    uvel, vvel)
 
             enddo                     ! subcycling
 

--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -745,9 +745,10 @@
       else ! evp_algorithm == standard_2d (Standard CICE)
 
          call ice_timer_start(timer_evp_2d)
-         do ksub = 1,ndte        ! subcycling
 
-            if (grid_ice == "B") then
+         if (grid_ice == "B") then
+
+            do ksub = 1,ndte        ! subcycling
 
                !$OMP PARALLEL DO PRIVATE(iblk,strtmp) SCHEDULE(runtime)
                do iblk = 1, nblocks
@@ -810,7 +811,17 @@
                enddo  ! iblk
                !$OMP END PARALLEL DO
 
-            elseif (grid_ice == "C") then
+               ! U fields at NE corner
+               ! calls ice_haloUpdate, controls bundles and masks
+               call dyn_HaloUpdate (halo_info,          halo_info_mask,    &
+                                    field_loc_NEcorner, field_type_vector, &
+                                    uvel, vvel)
+
+            enddo  ! sub cycling
+
+         elseif (grid_ice == "C") then
+
+            do ksub = 1,ndte        ! subcycling
 
                !$OMP PARALLEL DO PRIVATE(iblk)
                do iblk = 1, nblocks
@@ -983,8 +994,17 @@
 
                uvel(:,:,:) = uvel(:,:,:)*uvm(:,:,:)
                vvel(:,:,:) = vvel(:,:,:)*uvm(:,:,:)
+               ! U fields at NE corner
+               ! calls ice_haloUpdate, controls bundles and masks
+               call dyn_HaloUpdate (halo_info,          halo_info_mask,    &
+                                 field_loc_NEcorner, field_type_vector, &
+                                 uvel, vvel)
 
-            elseif (grid_ice == "CD") then
+            enddo                     ! subcycling
+
+         elseif (grid_ice == "CD") then
+
+            do ksub = 1,ndte        ! subcycling
 
                !$OMP PARALLEL DO PRIVATE(iblk)
                do iblk = 1, nblocks
@@ -1160,16 +1180,16 @@
 
                uvel(:,:,:) = uvel(:,:,:)*uvm(:,:,:)
                vvel(:,:,:) = vvel(:,:,:)*uvm(:,:,:)
-
-            endif   ! grid_ice
-
-            ! U fields at NE corner
-            ! calls ice_haloUpdate, controls bundles and masks
-            call dyn_HaloUpdate (halo_info,          halo_info_mask,    &
+               ! U fields at NE corner
+               ! calls ice_haloUpdate, controls bundles and masks
+               call dyn_HaloUpdate (halo_info,          halo_info_mask,    &
                                  field_loc_NEcorner, field_type_vector, &
                                  uvel, vvel)
 
-         enddo                     ! subcycling
+            enddo                     ! subcycling
+
+         endif   ! grid_ice
+
          call ice_timer_stop(timer_evp_2d)
       endif  ! evp_algorithm
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Refactored the evp subcycling in order to cycle for each grid (B, C and CD)
    ENTER INFORMATION HERE
- [] Developer(s): @TillRasmussen  
    ENTER INFORMATION HERE
- [ ] Suggest PR reviewers from list in the column to the right. @apcraig @eclare108213 @phil-blain 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
- How much do the PR code changes differ from the unmodified code? 
    - [x ] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [ x] No
- Does this PR add any new test cases?
[refactorbaseCD.log](https://github.com/CICE-Consortium/CICE/files/9397023/refactorbaseCD.log)
[refactorbasetB.log](https://github.com/CICE-Consortium/CICE/files/9397024/refactorbasetB.log)
[refactorbasetC.log](https://github.com/CICE-Consortium/CICE/files/9397025/refactorbasetC.log)
[refactortestB.log](https://github.com/CICE-Consortium/CICE/files/9397026/refactortestB.log)
[refactortestC.log](https://github.com/CICE-Consortium/CICE/files/9397027/refactortestC.log)
[refactortestCD.log](https://github.com/CICE-Consortium/CICE/files/9397028/refactortestCD.log)

    - [ ] Yes
    - [ x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [ x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x ] No 
- [ ] Please provide any additional information or relevant details below:
Test revealed that results after the change are bit for bit. There are test that failed while running
1 test with dynpicard for B grid
A number of test where namelist options for C and CD grid is not implemented. 
See attached files. base a original code. Test is new code for C, CD and B grids.
This relate
Test 
./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite,omp_suite --mach freya --env intel,gnu --testid refactorbaseB --bgen refactorbaseB
./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite,omp_suite --mach freya --env intel,gnu --testid refactortestB --bcmp refactorbaseB
./cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite,omp_suite --mach freya --env intel,gnu --testid refactorbaseC --bgen refactorbaseC -s gridc
/cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite,omp_suite --mach freya --env intel,gnu --testid refactortestC --bcmp refactorbaseC -s gridc
/cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite,omp_suite --mach freya --env intel,gnu --testid refactortestC --bcmp refactorbaseC -s gridc
/cice.setup --suite first_suite,base_suite,travis_suite,decomp_suite,reprosum_suite,quick_suite,omp_suite --mach freya --env intel,gnu --testid refactortestC --bcmp refactorbaseC -s gridc

This relates to #755 where this is the bit for bit part and issue #739 