### PR TITLE
ice_grid: initialize 'l_readCenter' for all grid types

### DIFF
--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -475,6 +475,8 @@
       ! lat, lon, cell widths, angle, land mask
       !-----------------------------------------------------------------
 
+      l_readCenter = .false.
+
       call icepack_query_parameters(pi_out=pi, pi2_out=pi2, puny_out=puny)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
@@ -945,7 +947,6 @@
       call ice_open_nc(kmt_file,fid_kmt)
 
       diag = .true.       ! write diagnostic info
-      l_readCenter = .false.
       !-----------------------------------------------------------------
       ! topography
       !-----------------------------------------------------------------


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me
- [x] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    did not run a full suite, but confirmed that a case that was failing due to this bug (when compiling with NaN initialization) is fixed by this change. I can run a base_suite if we feel it's better.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

In 3fedc78 (Allow for read of tlat, tlon, anglet with popgrid (#463),
2020-06-24), ice_grid::init_grid2 was changed so that ice_grid::Tlatlon,
which computes the TLAT and TLON arrays from ULAT and ULON, is only
called if the private module variable 'l_readCenter' is false.

The idea is that if the grid file contains a variable 'anglet', then it
is assumed that it also contains variables 'tlon' and 'tlat', and so
these fields are read directly instead of being computed.

This logic, however, was only implemented in ice_grid::popgrid_nc, which
sets 'l_readCenter' depending on the presence or absence of 'anglet' in
the grid file. This means that if 'popgrid_nc' is not called (for
example with "grid_format='bin'", in which case init_grid2 calls
'popgrid' and not 'popgrid_nc'), then 'l_readCenter' is used
uninitialized in init_grid2, and so it's possible that 'Tlatlon' is not
called, if 'l_readCenter' happens to be initialized to true.

This in turns leads to 'TLAT' and 'TLON' being uninitialized, and the
code failing when accessing these arrays if compiling with NaN
initialization.

Fix this by initializing 'l_readCenter' at the beginning of init_grid2,
such that it is initialized for all choices of 'grid_format' and
'grid_type'. Remove the initialization in 'popgrid_nc'.

