### PR TITLE
Update grid averaging for tmass, aice, uvelT, vvelT

### DIFF
--- a/cicecore/cicedynB/analysis/ice_history_shared.F90
+++ b/cicecore/cicedynB/analysis/ice_history_shared.F90
@@ -156,57 +156,25 @@
          igrdz(nvar_grdz)      ! true if category/vertical grid field is written
 
       character (len=25), public, parameter :: &
-         tcstr = 'area: tarea'          , & ! vcellmeas for T cell quantities
-         ucstr = 'area: uarea'          , & ! vcellmeas for U cell quantities
-         ncstr = 'area: narea'          , & ! vcellmeas for N cell quantities
-         ecstr = 'area: earea'          , & ! vcellmeas for E cell quantities
-         tstr2D  = 'TLON TLAT time'     , & ! vcoord for T cell quantities, 2D
-         ustr2D  = 'ULON ULAT time'     , & ! vcoord for U cell quantities, 2D
-         nstr2D  = 'NLON NLAT time'     , & ! vcoord for N cell quantities, 2D
-         estr2D  = 'ELON ELAT time'     , & ! vcoord for E cell quantities, 2D
-         tstr3Dz = 'TLON TLAT VGRDi time',& ! vcoord for T cell quantities, 3D
-         ustr3Dz = 'ULON ULAT VGRDi time',& ! vcoord for U cell quantities, 3D
-         nstr3Dz = 'NLON NLAT VGRDi time',& ! vcoord for N cell quantities, 3D
-         estr3Dz = 'ELON ELAT VGRDi time',& ! vcoord for E cell quantities, 3D
-         tstr3Dc = 'TLON TLAT NCAT  time',& ! vcoord for T cell quantities, 3D
-         ustr3Dc = 'ULON ULAT NCAT  time',& ! vcoord for U cell quantities, 3D
-         nstr3Dc = 'NLON NLAT NCAT  time',& ! vcoord for N cell quantities, 3D
-         estr3Dc = 'ELON ELAT NCAT  time',& ! vcoord for E cell quantities, 3D
-         tstr3Db = 'TLON TLAT VGRDb time',& ! vcoord for T cell quantities, 3D
-         ustr3Db = 'ULON ULAT VGRDb time',& ! vcoord for U cell quantities, 3D
-         nstr3Db = 'NLON NLAT VGRDb time',& ! vcoord for N cell quantities, 3D
-         estr3Db = 'ELON ELAT VGRDb time',& ! vcoord for E cell quantities, 3D
-         tstr3Da = 'TLON TLAT VGRDa time',& ! vcoord for T cell quantities, 3D
-         ustr3Da = 'ULON ULAT VGRDa time',& ! vcoord for U cell quantities, 3D
-         nstr3Da = 'NLON NLAT VGRDa time',& ! vcoord for N cell quantities, 3D
-         estr3Da = 'ELON ELAT VGRDa time',& ! vcoord for E cell quantities, 3D
-         tstr3Df = 'TLON TLAT NFSD  time',& ! vcoord for T cell quantities, 3D
-         ustr3Df = 'ULON ULAT NFSD  time',& ! vcoord for U cell quantities, 3D
-         nstr3Df = 'NLON NLAT NFSD  time',& ! vcoord for N cell quantities, 3D
-         estr3Df = 'ELON ELAT NFSD  time',& ! vcoord for E cell quantities, 3D
-
-!ferret
+         ! T grids
+         tcstr   = 'area: tarea'         , & ! vcellmeas for T cell quantities
+         tstr2D  = 'TLON TLAT time'      , & ! vcoord for T cell, 2D
+         tstr3Dc = 'TLON TLAT NCAT  time', & ! vcoord for T cell, 3D, ncat
+         tstr3Da = 'TLON TLAT VGRDa time', & ! vcoord for T cell, 3D, ice-snow-bio
+         tstr3Db = 'TLON TLAT VGRDb time', & ! vcoord for T cell, 3D, ice-bio
+         tstr3Df = 'TLON TLAT NFSD  time', & ! vcoord for T cell, 3D, fsd
          tstr4Di = 'TLON TLAT VGRDi NCAT', & ! vcoord for T cell, 4D, ice
-         ustr4Di = 'ULON ULAT VGRDi NCAT', & ! vcoord for U cell, 4D, ice
-         nstr4Di = 'NLON NLAT VGRDi NCAT', & ! vcoord for N cell, 4D, ice
-         estr4Di = 'ELON ELAT VGRDi NCAT', & ! vcoord for E cell, 4D, ice
          tstr4Ds = 'TLON TLAT VGRDs NCAT', & ! vcoord for T cell, 4D, snow
-         ustr4Ds = 'ULON ULAT VGRDs NCAT', & ! vcoord for U cell, 4D, snow
-         nstr4Ds = 'NLON NLAT VGRDs NCAT', & ! vcoord for N cell, 4D, snow
-         estr4Ds = 'ELON ELAT VGRDs NCAT', & ! vcoord for E cell, 4D, snow
          tstr4Df = 'TLON TLAT NFSD  NCAT', & ! vcoord for T cell, 4D, fsd
-         ustr4Df = 'ULON ULAT NFSD  NCAT', & ! vcoord for U cell, 4D, fsd
-         nstr4Df = 'NLON NLAT NFSD  NCAT', & ! vcoord for N cell, 4D, fsd
-         estr4Df = 'ELON ELAT NFSD  NCAT'    ! vcoord for E cell, 4D, fsd
-!ferret
-!         tstr4Di  = 'TLON TLAT VGRDi NCAT time', & ! ferret can not handle time
-!         ustr4Di  = 'ULON ULAT VGRDi NCAT time', & ! index on 4D variables.
-!         tstr4Ds  = 'TLON TLAT VGRDs NCAT time', & ! Use 'ferret' lines instead
-!         ustr4Ds  = 'ULON ULAT VGRDs NCAT time', & ! (below also)
-!         tstr4Db  = 'TLON TLAT VGRDb NCAT time', &
-!         ustr4Db  = 'ULON ULAT VGRDb NCAT time', &
-!         tstr4Df  = 'TLON TLAT NFSD  NCAT time', &
-!         ustr4Df  = 'ULON ULAT NFSD  NCAT time', &
+         ! U grids
+         ucstr   = 'area: uarea'         , & ! vcellmeas for U cell quantities
+         ustr2D  = 'ULON ULAT time'      , & ! vcoord for U cell, 2D
+         ! N grids
+         ncstr   = 'area: narea'         , & ! vcellmeas for N cell quantities
+         nstr2D  = 'NLON NLAT time'      , & ! vcoord for N cell, 2D
+         ! E grids
+         ecstr   = 'area: earea'         , & ! vcellmeas for E cell quantities
+         estr2D  = 'ELON ELAT time'          ! vcoord for E cell, 2D
 
       !---------------------------------------------------------------
       ! flags: write to output file if true or histfreq value

--- a/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
@@ -270,8 +270,8 @@
       ! convert fields from T to U grid
       !-----------------------------------------------------------------
 
-      call grid_average_X2Y('F', tmass    , 'T'          , umass, 'U')
-      call grid_average_X2Y('F', aice_init, 'T'          , aiU  , 'U')
+      call grid_average_X2Y('S', tmass    , 'T'          , umass, 'U')
+      call grid_average_X2Y('S', aice_init, 'T'          , aiU  , 'U')
       call grid_average_X2Y('S', uocn     , grid_ocn_dynu, uocnU   , 'U')
       call grid_average_X2Y('S', vocn     , grid_ocn_dynv, vocnU   , 'U')
       call grid_average_X2Y('S', ss_tltx  , grid_ocn_dynu, ss_tltxU, 'U')

--- a/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_evp.F90
@@ -317,22 +317,22 @@
       ! convert fields from T to U grid
       !-----------------------------------------------------------------
 
-      call grid_average_X2Y('F', tmass    , 'T'          , umass   , 'U')
-      call grid_average_X2Y('F', aice_init, 'T'          , aiU     , 'U')
+      call grid_average_X2Y('S', tmass    , 'T'          , umass   , 'U')
+      call grid_average_X2Y('S', aice_init, 'T'          , aiU     , 'U')
       call grid_average_X2Y('S', uocn     , grid_ocn_dynu, uocnU   , 'U')
       call grid_average_X2Y('S', vocn     , grid_ocn_dynv, vocnU   , 'U')
       call grid_average_X2Y('S', ss_tltx  , grid_ocn_dynu, ss_tltxU, 'U')
       call grid_average_X2Y('S', ss_tlty  , grid_ocn_dynv, ss_tltyU, 'U')
 
       if (grid_ice == 'CD' .or. grid_ice == 'C') then
-         call grid_average_X2Y('F', tmass    , 'T'          , emass   , 'E')
-         call grid_average_X2Y('F', aice_init, 'T'          , aie     , 'E')
+         call grid_average_X2Y('S', tmass    , 'T'          , emass   , 'E')
+         call grid_average_X2Y('S', aice_init, 'T'          , aie     , 'E')
          call grid_average_X2Y('S', uocn     , grid_ocn_dynu, uocnE   , 'E')
          call grid_average_X2Y('S', vocn     , grid_ocn_dynv, vocnE   , 'E')
          call grid_average_X2Y('S', ss_tltx  , grid_ocn_dynu, ss_tltxE, 'E')
          call grid_average_X2Y('S', ss_tlty  , grid_ocn_dynv, ss_tltyE, 'E')
-         call grid_average_X2Y('F', tmass    , 'T'          , nmass   , 'N')
-         call grid_average_X2Y('F', aice_init, 'T'          , ain     , 'N')
+         call grid_average_X2Y('S', tmass    , 'T'          , nmass   , 'N')
+         call grid_average_X2Y('S', aice_init, 'T'          , ain     , 'N')
          call grid_average_X2Y('S', uocn     , grid_ocn_dynu, uocnN   , 'N')
          call grid_average_X2Y('S', vocn     , grid_ocn_dynv, vocnN   , 'N')
          call grid_average_X2Y('S', ss_tltx  , grid_ocn_dynu, ss_tltxN, 'N')

--- a/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
@@ -304,8 +304,8 @@
       ! convert fields from T to U grid
       !-----------------------------------------------------------------
 
-      call grid_average_X2Y('F',tmass    , 'T', umass, 'U')
-      call grid_average_X2Y('F',aice_init, 'T', aiU  , 'U')
+      call grid_average_X2Y('S',tmass    , 'T', umass, 'U')
+      call grid_average_X2Y('S',aice_init, 'T', aiU  , 'U')
       call grid_average_X2Y('S',uocn   , grid_ocn_dynu, uocnU   , 'U')
       call grid_average_X2Y('S',vocn   , grid_ocn_dynv, vocnU   , 'U')
       call grid_average_X2Y('S',ss_tltx, grid_ocn_dynu, ss_tltxU, 'U')

--- a/cicecore/cicedynB/general/ice_forcing.F90
+++ b/cicecore/cicedynB/general/ice_forcing.F90
@@ -4129,8 +4129,8 @@
 
              work1(:,:,:) = ocn_frc_m(:,:,:,n  ,m)
              work2(:,:,:) = ocn_frc_m(:,:,:,n+1,m)
-             call grid_average_X2Y('F',work1,'T',ocn_frc_m(:,:,:,n  ,m),'U')
-             call grid_average_X2Y('F',work2,'T',ocn_frc_m(:,:,:,n+1,m),'U')
+             call grid_average_X2Y('A',work1,'T',ocn_frc_m(:,:,:,n  ,m),'U')
+             call grid_average_X2Y('A',work2,'T',ocn_frc_m(:,:,:,n+1,m),'U')
 
           enddo               ! month loop
         enddo               ! field loop
@@ -4373,7 +4373,7 @@
       use ice_domain, only: nblocks
       use ice_domain_size, only: max_blocks
       use ice_flux, only: sst, uocn, vocn
-      use ice_grid, only: grid_average_X2Y, ANGLET
+      use ice_grid, only: ANGLET
 
       real (kind=dbl_kind), intent(in) :: &
          dt      ! time step

--- a/cicecore/cicedynB/general/ice_step_mod.F90
+++ b/cicecore/cicedynB/general/ice_step_mod.F90
@@ -189,12 +189,11 @@
           fswsfcn, fswintn, Sswabsn, Iswabsn, meltsliqn, meltsliq, &
           fswthrun, fswthrun_vdr, fswthrun_vdf, fswthrun_idr, fswthrun_idf
       use ice_blocks, only: block, get_block
-#ifdef CICE_IN_NEMO
       use ice_blocks, only: nx_block, ny_block
-#endif
       use ice_calendar, only: yday
       use ice_domain, only: blocks_ice
       use ice_domain_size, only: ncat, nilyr, nslyr, n_iso, n_aero
+      use ice_domain_size, only: max_blocks
       use ice_flux, only: frzmlt, sst, Tf, strocnxT, strocnyT, rside, fbot, Tbot, Tsnice, &
           meltsn, melttn, meltbn, congeln, snoicen, uatmT, vatmT, fside, &
           wind, rhoa, potT, Qa, zlvl, zlvs, strax, stray, flatn, fsensn, fsurfn, fcondtopn, &
@@ -207,7 +206,7 @@
           send_i2x_per_cat, fswthrun_ai, dsnow
       use ice_flux_bgc, only: dsnown, faero_atm, faero_ocn, fiso_atm, fiso_ocn, &
           Qa_iso, Qref_iso, fiso_evap, HDO_ocn, H2_16O_ocn, H2_18O_ocn
-      use ice_grid, only: lmask_n, lmask_s, tmask
+      use ice_grid, only: lmask_n, lmask_s, tmask, grid_average_X2Y
       use ice_state, only: aice, aicen, aicen_init, vicen_init, &
           vice, vicen, vsno, vsnon, trcrn, uvel, vvel, vsnon_init
 #ifdef CICE_IN_NEMO
@@ -250,9 +249,11 @@
 #endif
          tr_pond_lvl, tr_pond_topo, calc_Tsfc, highfreq, tr_snow
 
+      real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks) :: &
+         uvelT, &           ! T cell velocity, x component (m/s)
+         vvelT              ! T cell velocity, y component (m/s)
+
       real (kind=dbl_kind) :: &
-         uvel_center, &     ! cell-centered velocity, x component (m/s)
-         vvel_center, &     ! cell-centered velocity, y component (m/s)
          puny               ! a very small number
 
       real (kind=dbl_kind), dimension(n_aero,2,ncat) :: &
@@ -327,6 +328,14 @@
       enddo ! j
 #endif
 
+      if (highfreq) then ! include ice velocity in calculation of wind stress
+         call grid_average_X2Y('A', uvel, 'U', uvelT, 'T')
+         call grid_average_X2Y('A', vvel, 'U', vvelT, 'T')
+      else
+         uvelT = c0 ! not used
+         vvelT = c0
+      endif ! highfreq
+
       this_block = get_block(blocks_ice(iblk),iblk)
       ilo = this_block%ilo
       ihi = this_block%ihi
@@ -335,16 +344,6 @@
 
       do j = jlo, jhi
       do i = ilo, ihi
-
-         if (highfreq) then ! include ice velocity in calculation of wind stress
-            uvel_center = p25*(uvel(i,j  ,iblk) + uvel(i-1,j  ,iblk) & ! cell-centered velocity
-                             + uvel(i,j-1,iblk) + uvel(i-1,j-1,iblk))  ! assumes wind components
-            vvel_center = p25*(vvel(i,j  ,iblk) + vvel(i-1,j  ,iblk) & ! are also cell-centered
-                             + vvel(i,j-1,iblk) + vvel(i-1,j-1,iblk))
-         else
-            uvel_center = c0 ! not used
-            vvel_center = c0
-         endif ! highfreq
 
          if (tr_snow) then
             do n = 1, ncat
@@ -391,8 +390,8 @@
                       vicen        = vicen       (i,j,:,iblk), &
                       vsno         = vsno        (i,j,  iblk), &
                       vsnon        = vsnon       (i,j,:,iblk), &
-                      uvel         = uvel_center             , &
-                      vvel         = vvel_center             , &
+                      uvel         = uvelT       (i,j,  iblk), &
+                      vvel         = vvelT       (i,j,  iblk), &
                       Tsfc         = trcrn       (i,j,nt_Tsfc,:,iblk),                   &
                       zqsn         = trcrn       (i,j,nt_qsno:nt_qsno+nslyr-1,:,iblk),   &
                       zqin         = trcrn       (i,j,nt_qice:nt_qice+nilyr-1,:,iblk),   &


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update grid averaging for tmass, aice, uvelT, vvelT
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Everything runs, changes most results, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#658799554aafd24f9c2fd575b68b47b281b03027.  QC tests pass relative to current main (cice.tr502 is current main, #6587995
```
PASS cheyenne_intel_qcchk_gx1_144x1_medium_qc_qcchk compare cice.tr502 -1 -1 -1
PASS cheyenne_pgi_qcchk_gx1_144x1_medium_qc_qcchk compare cice.tr502 -1 -1 -1
PASS cheyenne_gnu_qcchk_gx1_144x1_medium_qc_qcchk compare cice.tr502 -1 -1 -1
```
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

- Update tmass and aice T2U mapping, switch from "F" to "S", F was backwards compatible but not correct (changes answers), closes #736 
- Update ocean forcing T2U averaging in ocn_data_ncar_init, change "F" to "A".
- Update uvelT, vvelT averaging in step_therm1, change from 4 point average to U2TA (changes answers for highfreq=.true.), closes #735
- Remove history grids not needed (i.e. ustr3Dz), see #660 
