### PR TITLE
ice_dyn_vp: use `global_sum_*` for bit-for-bit reproducibility

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
@@ -783,9 +783,6 @@
          stress_Pr,   & ! x,y-derivatives of the replacement pressure
          diag_rheo      ! contributions of the rhelogy term to the diagonal
 
-      real (kind=dbl_kind), dimension (max_blocks) :: &
-         L2norm       ! array used to compute l^2 norm of grid function
-
       real (kind=dbl_kind), dimension (ntot) :: &
          res        , & ! current residual
          res_old    , & ! previous residual
@@ -821,7 +818,6 @@
 
       ! Initialization
       res_num = 0
-      L2norm  = c0
       Fx = c0
       Fy = c0
 
@@ -901,8 +897,7 @@
                                indxui     (:,iblk), indxuj    (:,iblk), &
                                bx       (:,:,iblk), by      (:,:,iblk), &
                                Au       (:,:,iblk), Av      (:,:,iblk), &
-                               Fx       (:,:,iblk), Fy      (:,:,iblk), &
-                               L2norm       (iblk))
+                               Fx       (:,:,iblk), Fy      (:,:,iblk))
          enddo
          !$OMP END PARALLEL DO
          nlres_norm = sqrt(global_sum_prod(Fx(:,:,:), Fx(:,:,:), distrb_info, field_loc_NEcorner) + &
@@ -1968,8 +1963,7 @@
                                indxui     , indxuj  , &
                                bx         , by      , &
                                Au         , Av      , &
-                               Fx         , Fy      , &
-                               sum_squared)
+                               Fx         , Fy        )
 
       integer (kind=int_kind), intent(in) :: &
          nx_block, ny_block, & ! block dimensions
@@ -1989,9 +1983,6 @@
          Fx      , & ! x residual vector, Fx = bx - Au (N/m^2)
          Fy          ! y residual vector, Fy = by - Av (N/m^2)
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         sum_squared ! sum of squared residual vector components
-
       ! local variables
 
       integer (kind=int_kind) :: &
@@ -2000,12 +1991,8 @@
       character(len=*), parameter :: subname = '(residual_vec)'
 
       !-----------------------------------------------------------------
-      ! compute residual and sum its squared components
+      ! compute residual
       !-----------------------------------------------------------------
-
-      if (present(sum_squared)) then
-         sum_squared = c0
-      endif
 
       do ij = 1, icellu
          i = indxui(ij)
@@ -2013,9 +2000,6 @@
 
          Fx(i,j) = bx(i,j) - Au(i,j)
          Fy(i,j) = by(i,j) - Av(i,j)
-         if (present(sum_squared)) then
-            sum_squared = sum_squared + Fx(i,j)**2 + Fy(i,j)**2
-         endif
       enddo                     ! ij
 
       end subroutine residual_vec
@@ -2476,53 +2460,6 @@
       enddo                     ! ij
 
       end subroutine formDiag_step2
-
-!=======================================================================
-
-! Compute squared l^2 norm of a grid function (tpu,tpv)
-
-      subroutine calc_L2norm_squared (nx_block, ny_block, &
-                                      icellu  ,           &
-                                      indxui  , indxuj  , &
-                                      tpu     , tpv     , &
-                                      L2norm)
-
-      integer (kind=int_kind), intent(in) :: &
-         nx_block, ny_block, & ! block dimensions
-         icellu                ! total count when iceumask is true
-
-      integer (kind=int_kind), dimension (nx_block*ny_block), intent(in) :: &
-         indxui  , & ! compressed index in i-direction
-         indxuj      ! compressed index in j-direction
-
-      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
-         tpu     , & ! x-component of vector grid function
-         tpv         ! y-component of vector grid function
-
-      real (kind=dbl_kind), intent(out) :: &
-         L2norm      ! squared l^2 norm of vector grid function (tpu,tpv)
-
-      ! local variables
-
-      integer (kind=int_kind) :: &
-         i, j, ij
-
-      character(len=*), parameter :: subname = '(calc_L2norm_squared)'
-
-      !-----------------------------------------------------------------
-      ! compute squared l^2 norm of vector grid function (tpu,tpv)
-      !-----------------------------------------------------------------
-
-      L2norm = c0
-
-      do ij = 1, icellu
-         i = indxui(ij)
-         j = indxuj(ij)
-
-         L2norm = L2norm + tpu(i,j)**2 + tpv(i,j)**2
-      enddo ! ij
-
-      end subroutine calc_L2norm_squared
 
 !=======================================================================
 

--- a/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_vp.F90
@@ -2914,6 +2914,7 @@
             call precondition(zetax2      , etax2          , &
                               Cb          , vrel           , &
                               umassdti    ,                  &
+                              halo_info_mask,                &
                               arnoldi_basis_x(:,:,:,initer), &
                               arnoldi_basis_y(:,:,:,initer), &
                               diagx       , diagy          , &
@@ -3109,12 +3110,18 @@
       subroutine pgmres (zetax2   , etax2   , &
                          Cb       , vrel    , &
                          umassdti ,           &
+                         halo_info_mask,      &
                          bx       , by      , &
                          diagx    , diagy   , &
                          tolerance, maxinner, &
                          maxouter ,           &
                          solx     , soly    , &
                          nbiter)
+
+      use ice_boundary, only: ice_HaloUpdate
+      use ice_domain, only: maskhalo_dyn, halo_info
+      use ice_fileunits, only: bfbflag
+      use ice_timers, only: ice_timer_start, ice_timer_stop, timer_bound
 
       real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks,4), intent(in) :: &
          zetax2   , & ! zetax2 = 2*zeta (bulk viscosity)
@@ -3124,6 +3131,9 @@
          vrel  , & ! coefficient for tauw
          Cb    , & ! seabed stress coefficient
          umassdti  ! mass of U-cell/dte (kg/m^2 s)
+
+      type (ice_halo), intent(in) :: &
+         halo_info_mask !  ghost cell update info for masked halo
 
       real (kind=dbl_kind), dimension(nx_block, ny_block, max_blocks), intent(in) :: &
          bx       , & ! Right hand side of the linear system (x components)
@@ -3293,14 +3303,29 @@
             call precondition(zetax2      , etax2          , &
                               Cb          , vrel           , &
                               umassdti    ,                  &
+                              halo_info_mask,                &
                               arnoldi_basis_x(:,:,:,initer), &
                               arnoldi_basis_y(:,:,:,initer), &
                               diagx       , diagy          , &
                               precond_type,                  &
                               workspace_x , workspace_y)
 
-            ! NOTE: halo updates for (workspace_x, workspace_y)
-            ! are skipped here for efficiency since this is just a preconditioner
+            ! Update workspace with boundary values
+            ! NOTE: skipped for efficiency since this is just a preconditioner
+            ! unless bfbflag is active            
+            if (bfbflag /= 'not') then
+               call stack_fields(workspace_x, workspace_y, fld2)
+               call ice_timer_start(timer_bound)
+               if (maskhalo_dyn) then
+                  call ice_HaloUpdate (fld2,               halo_info_mask, &
+                                       field_loc_NEcorner, field_type_vector)
+               else
+                  call ice_HaloUpdate (fld2,               halo_info, &
+                                       field_loc_NEcorner, field_type_vector)
+               endif
+               call ice_timer_stop(timer_bound)
+               call unstack_fields(fld2, workspace_x, workspace_y)
+            endif
 
             !$OMP PARALLEL DO PRIVATE(iblk)
             do iblk = 1, nblocks
@@ -3423,6 +3448,7 @@
          call precondition(zetax2      , etax2      , &
                            Cb          , vrel       , &
                            umassdti    ,              &
+                           halo_info_mask,            &
                            workspace_x , workspace_y, &
                            diagx       , diagy      , &
                            precond_type,              &
@@ -3489,6 +3515,7 @@
       subroutine precondition(zetax2      , etax2, &
                               Cb          , vrel , &
                               umassdti    ,        &
+                              halo_info_mask,      &
                               vx          , vy   , &
                               diagx       , diagy, &
                               precond_type,        &
@@ -3503,6 +3530,9 @@
          Cb    , & ! seabed stress coefficient
          umassdti  ! mass of U-cell/dte (kg/m^2 s)
 
+      type (ice_halo), intent(in) :: &
+         halo_info_mask !  ghost cell update info for masked halo
+         
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks), intent(in) :: &
          vx       , & ! input vector (x components)
          vy           ! input vector (y components)
@@ -3564,6 +3594,7 @@
          call pgmres (zetax2,    etax2   , &
                       Cb       , vrel    , &
                       umassdti ,           &
+                      halo_info_mask     , &
                       vx       , vy      , &
                       diagx    , diagy   , &
                       tolerance, maxinner, &

--- a/configuration/scripts/machines/env.ppp5_intel
+++ b/configuration/scripts/machines/env.ppp5_intel
@@ -18,6 +18,8 @@ source $ssmuse -d /fs/ssm/main/opt/intelcomp/inteloneapi-2022.1.2/intelcomp+mpi+
 # module load -s icc mpi
 setenv FOR_DUMP_CORE_FILE 1
 setenv I_MPI_DEBUG_COREDUMP 1
+# Stop being buggy
+setenv I_MPI_FABRICS ofi
 # NetCDF
 source $ssmuse -d main/opt/hdf5-netcdf4/serial/shared/inteloneapi-2022.1.2/01
 

--- a/configuration/scripts/machines/env.ppp5_intel
+++ b/configuration/scripts/machines/env.ppp5_intel
@@ -32,6 +32,7 @@ setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/ppp5/cice/runs/
 setenv ICE_MACHINE_INPUTDATA /space/hall5/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/ppp5/cice/baselines/
+setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT qsub
 setenv ICE_MACHINE_TPNODE 80 
 setenv ICE_MACHINE_ACCT unused

--- a/configuration/scripts/machines/env.ppp5_intel
+++ b/configuration/scripts/machines/env.ppp5_intel
@@ -18,6 +18,10 @@ source $ssmuse -d /fs/ssm/main/opt/intelcomp/inteloneapi-2022.1.2/intelcomp+mpi+
 # module load -s icc mpi
 setenv FOR_DUMP_CORE_FILE 1
 setenv I_MPI_DEBUG_COREDUMP 1
+# Reproducible collectives
+if (${ICE_BASEGEN} != ${ICE_SPVAL} || ${ICE_BASECOM} != ${ICE_SPVAL}) then
+  setenv I_MPI_CBWR 1
+endif
 # Stop being buggy
 setenv I_MPI_FABRICS ofi
 # NetCDF

--- a/configuration/scripts/machines/env.ppp6_gnu
+++ b/configuration/scripts/machines/env.ppp6_gnu
@@ -8,7 +8,7 @@ endif
 if ("$inp" != "-nomodules") then
 
 # OpenMPI
-source /usr/mpi/gcc/openmpi-4.1.2a1/bin/mpivars.csh
+setenv PATH "/home/phb001/.local_rhel-8-icelake-64_gcc/bin:$PATH"
 
 # OpenMP
 setenv OMP_STACKSIZE 64M

--- a/configuration/scripts/machines/env.ppp6_gnu
+++ b/configuration/scripts/machines/env.ppp6_gnu
@@ -21,6 +21,7 @@ setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/site6/cice/runs/
 setenv ICE_MACHINE_INPUTDATA /space/hall6/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/site6/cice/baselines/
+setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT qsub
 setenv ICE_MACHINE_TPNODE 80 
 setenv ICE_MACHINE_ACCT unused

--- a/configuration/scripts/machines/env.ppp6_gnu-impi
+++ b/configuration/scripts/machines/env.ppp6_gnu-impi
@@ -18,6 +18,8 @@ setenv I_MPI_F90 gfortran
 setenv I_MPI_FC gfortran
 setenv I_MPI_CC gcc
 setenv I_MPI_CXX g++
+# Stop being buggy
+setenv I_MPI_FABRICS ofi
 
 # OpenMP
 setenv OMP_STACKSIZE 64M

--- a/configuration/scripts/machines/env.ppp6_gnu-impi
+++ b/configuration/scripts/machines/env.ppp6_gnu-impi
@@ -18,6 +18,10 @@ setenv I_MPI_F90 gfortran
 setenv I_MPI_FC gfortran
 setenv I_MPI_CC gcc
 setenv I_MPI_CXX g++
+# Reproducible collectives
+if (${ICE_BASEGEN} != ${ICE_SPVAL} || ${ICE_BASECOM} != ${ICE_SPVAL}) then
+  setenv I_MPI_CBWR 1
+endif
 # Stop being buggy
 setenv I_MPI_FABRICS ofi
 

--- a/configuration/scripts/machines/env.ppp6_gnu-impi
+++ b/configuration/scripts/machines/env.ppp6_gnu-impi
@@ -30,6 +30,7 @@ setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/site6/cice/runs/
 setenv ICE_MACHINE_INPUTDATA /space/hall6/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/site6/cice/baselines/
+setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT qsub
 setenv ICE_MACHINE_TPNODE 80 
 setenv ICE_MACHINE_ACCT unused

--- a/configuration/scripts/machines/env.ppp6_intel
+++ b/configuration/scripts/machines/env.ppp6_intel
@@ -32,6 +32,7 @@ setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/ppp6/cice/runs/
 setenv ICE_MACHINE_INPUTDATA /space/hall6/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/ppp6/cice/baselines/
+setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT qsub
 setenv ICE_MACHINE_TPNODE 80 
 setenv ICE_MACHINE_ACCT unused

--- a/configuration/scripts/machines/env.ppp6_intel
+++ b/configuration/scripts/machines/env.ppp6_intel
@@ -18,6 +18,8 @@ source $ssmuse -d /fs/ssm/main/opt/intelcomp/inteloneapi-2022.1.2/intelcomp+mpi+
 # module load -s icc mpi
 setenv FOR_DUMP_CORE_FILE 1
 setenv I_MPI_DEBUG_COREDUMP 1
+# Stop being buggy
+setenv I_MPI_FABRICS ofi
 # NetCDF
 source $ssmuse -d main/opt/hdf5-netcdf4/serial/shared/inteloneapi-2022.1.2/01
 

--- a/configuration/scripts/machines/env.ppp6_intel
+++ b/configuration/scripts/machines/env.ppp6_intel
@@ -18,6 +18,10 @@ source $ssmuse -d /fs/ssm/main/opt/intelcomp/inteloneapi-2022.1.2/intelcomp+mpi+
 # module load -s icc mpi
 setenv FOR_DUMP_CORE_FILE 1
 setenv I_MPI_DEBUG_COREDUMP 1
+# Reproducible collectives
+if (${ICE_BASEGEN} != ${ICE_SPVAL} || ${ICE_BASECOM} != ${ICE_SPVAL}) then
+  setenv I_MPI_CBWR 1
+endif
 # Stop being buggy
 setenv I_MPI_FABRICS ofi
 # NetCDF

--- a/configuration/scripts/machines/env.ppp6_intel19
+++ b/configuration/scripts/machines/env.ppp6_intel19
@@ -17,6 +17,8 @@ setenv FOR_DUMP_CORE_FILE 1
 source $ssmuse -d /fs/ssm/hpco/exp/intelpsxe-impi-19.0.3.199
 setenv FI_PROVIDER verbs
 setenv I_MPI_DEBUG_COREDUMP 1
+# Stop being buggy
+setenv I_MPI_FABRICS ofi
 # NetCDF
 source $ssmuse -d hpco/exp/hdf5-netcdf4/serial/static/intel-19.0.3.199/02
 

--- a/configuration/scripts/machines/env.ppp6_intel19
+++ b/configuration/scripts/machines/env.ppp6_intel19
@@ -17,6 +17,10 @@ setenv FOR_DUMP_CORE_FILE 1
 source $ssmuse -d /fs/ssm/hpco/exp/intelpsxe-impi-19.0.3.199
 setenv FI_PROVIDER verbs
 setenv I_MPI_DEBUG_COREDUMP 1
+# Reproducible collectives
+if (${ICE_BASEGEN} != ${ICE_SPVAL} || ${ICE_BASECOM} != ${ICE_SPVAL}) then
+  setenv I_MPI_CBWR 1
+endif
 # Stop being buggy
 setenv I_MPI_FABRICS ofi
 # NetCDF

--- a/configuration/scripts/machines/env.ppp6_intel19
+++ b/configuration/scripts/machines/env.ppp6_intel19
@@ -31,6 +31,7 @@ setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/site6/cice/runs/
 setenv ICE_MACHINE_INPUTDATA /space/hall6/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/site6/cice/baselines/
+setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT "qsub"
 setenv ICE_MACHINE_TPNODE 80
 setenv ICE_MACHINE_ACCT P0000000

--- a/configuration/scripts/machines/env.robert_intel
+++ b/configuration/scripts/machines/env.robert_intel
@@ -18,6 +18,8 @@ source $ssmuse -d /fs/ssm/main/opt/intelcomp/inteloneapi-2022.1.2/intelcomp+mpi+
 # module load -s icc mpi
 setenv FOR_DUMP_CORE_FILE 1
 setenv I_MPI_DEBUG_COREDUMP 1
+# Stop being buggy
+setenv I_MPI_FABRICS ofi
 # NetCDF
 source $ssmuse -d main/opt/hdf5-netcdf4/serial/shared/inteloneapi-2022.1.2/01
 

--- a/configuration/scripts/machines/env.underhill_intel
+++ b/configuration/scripts/machines/env.underhill_intel
@@ -18,6 +18,8 @@ source $ssmuse -d /fs/ssm/main/opt/intelcomp/inteloneapi-2022.1.2/intelcomp+mpi+
 # module load -s icc mpi
 setenv FOR_DUMP_CORE_FILE 1
 setenv I_MPI_DEBUG_COREDUMP 1
+# Stop being buggy
+setenv I_MPI_FABRICS ofi
 # NetCDF
 source $ssmuse -d main/opt/hdf5-netcdf4/serial/shared/inteloneapi-2022.1.2/01
 

--- a/doc/source/cice_index.rst
+++ b/doc/source/cice_index.rst
@@ -72,7 +72,7 @@ either Celsius or Kelvin units).
    "awtvdf", "weighting factor for visible, diffuse albedo", "0.63282"
    "awtvdr", "weighting factor for visible, direct albedo", "0.00318"
    "**B**", "", ""
-   "bfb_flag", "for bit-for-bit reproducible diagnostics", ""
+   "bfbflag", "for bit-for-bit reproducible diagnostics, and reproducible outputs when using the VP solver", ""
    "bgc_data_dir", "data directory for bgc", ""
    "bgc_data_type", "source of silicate, nitrate data", ""
    "bgc_flux_type", "ice–ocean flux velocity", ""

--- a/doc/source/developer_guide/dg_other.rst
+++ b/doc/source/developer_guide/dg_other.rst
@@ -30,11 +30,11 @@ To run with an interactive debugger, the following general steps should be taken
 Reproducible Sums
 ----------------------
 
-Reproducible sums in the CICE diagnostics are set with the namelist `bfbflag`.
-CICE prognostics results do NOT depend on the global sum implementation.  The
+Reproducible sums in CICE are set with the namelist `bfbflag`.
+CICE prognostics results do NOT depend on the global sum implementation when using the default dynamics solver (EVP) or the EAP solver.  With these solvers, the
 results are bit-for-bit identical with any `bfbflag`.  The `bfbflag` only impacts
 the results and performance of the global diagnostics written to the CICE
-log file.  For best performance, the off (or lsum8 which is equivalent) setting is recommended.
+log file (for all dynamics solvers), as well as the model results when using the VP solver.  For best performance, the off (or lsum8 which is equivalent) setting is recommended.
 This will probably not produce bit-for-bit results with different decompositions.
 For bit-for-bit results, the reprosum setting is recommended.  This should be
 only slightly slower than the lsum8 implementation.

--- a/doc/source/science_guide/sg_dynamics.rst
+++ b/doc/source/science_guide/sg_dynamics.rst
@@ -92,8 +92,7 @@ dynamics into CICE is described in detail in
 
 The VP solver implementation mostly follows :cite:`Lemieux08`, with
 FGMRES :cite:`Saad93` as the linear solver and GMRES as the preconditioner.
-Note that the VP solver has not yet been tested on the ``tx1`` grid or with
-threading enabled.
+Note that the VP solver has not yet been tested on the ``tx1`` grid.
 
 The EVP, rEVP, EAP and VP approaches are all available with the B grid. However, at the moment, only the EVP and rEVP schemes are possible with the C grid.
 


### PR DESCRIPTION
I'm opening this PR as draft mainly so we can discuss the performance regression I'm hitting, hence I did not fill the whole PR template. I'll do that when we are ready to merge the code (if we do).

Summary:
I refactored the VP solver code so that global sums are computed using the existing CICE `global_sum_*` subroutines, so that bit-for-bit reproducibility can be achieved if desired using the existing `bfbflag` namelist settting.

My adventures in doing so are detailed at:
- https://github.com/phil-blain/CICE/issues/39#issuecomment-1125463055 and following
- https://github.com/phil-blain/CICE/issues/40#issuecomment-1184774930 and following

As you can see from the changes in the PR, each call to `global_sum` is replaced by two calls to `global_sum_prod`, one for the array holding X components and a second for the array holding Y components.

I used the  Intel VTune profiler to profile both the old and new code, compared them, and got these results: https://github.com/phil-blain/CICE/issues/40#issuecomment-1188260610.

Seeing that the time spent in the MPI_ALLREDUCE in the new code was twice that of the old code, I tried to refactor the code again to do the global sums for both dimensions at the same time: 
- code: https://github.com/phil-blain/CICE/compare/repro-vp-no-pairs...repro-vp
- results: https://github.com/phil-blain/CICE/issues/40#issuecomment-1261514528

but that did not really help, which was disappointing... 

So I guess I'd like to have some input from others :)