### PR TITLE
Refactor strocnxT, strocnyT implementation

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_eap.F90
@@ -138,7 +138,7 @@
       use ice_flux, only: rdg_conv, strairxT, strairyT, &
           strairxU, strairyU, uocn, vocn, ss_tltx, ss_tlty, fmU, &
           strtltxU, strtltyU, strocnxU, strocnyU, strintxU, strintyU, taubxU, taubyU, &
-          strocnxT, strocnyT, strax, stray, &
+          strax, stray, &
           TbU, hwater, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
@@ -146,7 +146,7 @@
       use ice_grid, only: tmask, umask, dxT, dyT, dxhy, dyhx, cxp, cyp, cxm, cym, &
           tarear, uarear, grid_average_X2Y, iceumask, &
           grid_atm_dynu, grid_atm_dynv, grid_ocn_dynu, grid_ocn_dynv
-      use ice_state, only: aice, vice, vsno, uvel, vvel, divu, shear, &
+      use ice_state, only: aice, aiU, vice, vsno, uvel, vvel, divu, shear, &
           aice_init, aice0, aicen, vicen, strength
       use ice_timers, only: timer_dynamics, timer_bound, &
           ice_timer_start, ice_timer_stop
@@ -182,7 +182,6 @@
          wateryU    , & ! for ocean stress calculation, y (m/s)
          forcexU    , & ! work array: combined atm stress and ocn tilt, x
          forceyU    , & ! work array: combined atm stress and ocn tilt, y
-         aiU        , & ! ice fraction on u-grid
          umass      , & ! total mass of ice and snow (u grid)
          umassdti       ! mass of U-cell/dte (kg/m^2 s)
 
@@ -204,10 +203,6 @@
 
       type (block) :: &
          this_block     ! block information for current block
-
-      real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
-         work1      , & ! temporary
-         work2          ! temporary
 
       character(len=*), parameter :: subname = '(eap)'
 
@@ -566,27 +561,6 @@
 
       enddo
       !$OMP END PARALLEL DO
-
-      ! strocn computed on U, N, E as needed. Map strocn U divided by aiU to T
-      ! TODO: This should be done elsewhere as part of generalization?
-      ! conservation requires aiU be divided before averaging
-      work1 = c0
-      work2 = c0
-      !$OMP PARALLEL DO PRIVATE(iblk,ij,i,j)
-      do iblk = 1, nblocks
-      do ij = 1, icellu(iblk)
-         i = indxui(ij,iblk)
-         j = indxuj(ij,iblk)
-         work1(i,j,iblk) = strocnxU(i,j,iblk)/aiU(i,j,iblk)
-         work2(i,j,iblk) = strocnyU(i,j,iblk)/aiU(i,j,iblk)
-      enddo
-      enddo
-      call ice_HaloUpdate (work1,              halo_info, &
-                           field_loc_NEcorner, field_type_vector)
-      call ice_HaloUpdate (work2,              halo_info, &
-                           field_loc_NEcorner, field_type_vector)
-      call grid_average_X2Y('F', work1, 'U', strocnxT, 'T')    ! shift
-      call grid_average_X2Y('F', work2, 'U', strocnyT, 'T')
 
       call ice_timer_stop(timer_dynamics)    ! dynamics
 

--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -35,6 +35,16 @@
       ! Dynamics component
       ! All variables are assumed to be on the atm or ocn thermodynamic
       ! grid except as noted
+      !
+      ! scale_fluxes divides several of these by aice "in place", so
+      ! the state of some of these variables is not well defined.  In the
+      ! future, we need to refactor and add "_iavg" versions of the
+      ! fields to clearly differentiate fields that have been divided
+      ! by aice and others that are not.  The challenge is that we need
+      ! to go thru each field carefully to see which version is used.
+      ! For instance, in diagnostics, there are places where these
+      ! fields are multiplied by aice to compute things properly.
+      ! strocn[x,y]T_iavg is the first field defined using _iavg.
       !-----------------------------------------------------------------
 
       real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
@@ -56,14 +66,12 @@
 
        ! out to ocean          T-cell (kg/m s^2)
        ! Note, CICE_IN_NEMO uses strocnx and strocny for coupling
-         strocnxT_sf, & ! ice-ocean stress, x-direction at T points, per ice fraction (scaled flux)
-         strocnyT_sf    ! ice-ocean stress, y-direction at T points, per ice fraction (scaled flux)
+         strocnxT_iavg, & ! ice-ocean stress, x-direction at T points, per ice fraction (scaled flux)
+         strocnyT_iavg    ! ice-ocean stress, y-direction at T points, per ice fraction (scaled flux)
 
        ! diagnostic
 
       real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
-         strocnxT, & ! ice-ocean stress, x-direction at T points, computed at end of dynamics
-         strocnyT, & ! ice-ocean stress, y-direction at T points, computed at end of dynamics
          sig1    , & ! normalized principal stress component
          sig2    , & ! normalized principal stress component
          sigP    , & ! internal ice pressure (N/m)
@@ -391,10 +399,8 @@
          hwater     (nx_block,ny_block,max_blocks), & ! water depth for seabed stress calc (landfast ice)
          strairxT   (nx_block,ny_block,max_blocks), & ! stress on ice by air, x-direction
          strairyT   (nx_block,ny_block,max_blocks), & ! stress on ice by air, y-direction
-         strocnxT   (nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction
-         strocnyT   (nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction
-         strocnxT_sf(nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction, per ice area
-         strocnyT_sf(nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction, per ice area
+         strocnxT_iavg(nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction, per ice area
+         strocnyT_iavg(nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction, per ice area
          sig1       (nx_block,ny_block,max_blocks), & ! normalized principal stress component
          sig2       (nx_block,ny_block,max_blocks), & ! normalized principal stress component
          sigP       (nx_block,ny_block,max_blocks), & ! internal ice pressure (N/m)
@@ -769,8 +775,8 @@
       ! fluxes sent to ocean
       !-----------------------------------------------------------------
 
-      strocnxT_sf (:,:,:) = c0 ! ice-ocean stress, x-direction (T-cell)
-      strocnyT_sf (:,:,:) = c0 ! ice-ocean stress, y-direction (T-cell)
+      strocnxT_iavg (:,:,:) = c0 ! ice-ocean stress, x-direction (T-cell)
+      strocnyT_iavg (:,:,:) = c0 ! ice-ocean stress, y-direction (T-cell)
       fresh   (:,:,:) = c0
       fsalt   (:,:,:) = c0
       fpond   (:,:,:) = c0

--- a/cicecore/cicedynB/general/ice_flux.F90
+++ b/cicecore/cicedynB/general/ice_flux.F90
@@ -56,12 +56,14 @@
 
        ! out to ocean          T-cell (kg/m s^2)
        ! Note, CICE_IN_NEMO uses strocnx and strocny for coupling
-         strocnxT, & ! ice-ocean stress, x-direction at T points, per ice fraction
-         strocnyT    ! ice-ocean stress, y-direction at T points, per ice fraction
+         strocnxT_sf, & ! ice-ocean stress, x-direction at T points, per ice fraction (scaled flux)
+         strocnyT_sf    ! ice-ocean stress, y-direction at T points, per ice fraction (scaled flux)
 
        ! diagnostic
 
       real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
+         strocnxT, & ! ice-ocean stress, x-direction at T points, computed at end of dynamics
+         strocnyT, & ! ice-ocean stress, y-direction at T points, computed at end of dynamics
          sig1    , & ! normalized principal stress component
          sig2    , & ! normalized principal stress component
          sigP    , & ! internal ice pressure (N/m)
@@ -391,6 +393,8 @@
          strairyT   (nx_block,ny_block,max_blocks), & ! stress on ice by air, y-direction
          strocnxT   (nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction
          strocnyT   (nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction
+         strocnxT_sf(nx_block,ny_block,max_blocks), & ! ice-ocean stress, x-direction, per ice area
+         strocnyT_sf(nx_block,ny_block,max_blocks), & ! ice-ocean stress, y-direction, per ice area
          sig1       (nx_block,ny_block,max_blocks), & ! normalized principal stress component
          sig2       (nx_block,ny_block,max_blocks), & ! normalized principal stress component
          sigP       (nx_block,ny_block,max_blocks), & ! internal ice pressure (N/m)
@@ -765,8 +769,8 @@
       ! fluxes sent to ocean
       !-----------------------------------------------------------------
 
-      strocnxT(:,:,:) = c0    ! ice-ocean stress, x-direction (T-cell)
-      strocnyT(:,:,:) = c0    ! ice-ocean stress, y-direction (T-cell)
+      strocnxT_sf (:,:,:) = c0 ! ice-ocean stress, x-direction (T-cell)
+      strocnyT_sf (:,:,:) = c0 ! ice-ocean stress, y-direction (T-cell)
       fresh   (:,:,:) = c0
       fsalt   (:,:,:) = c0
       fpond   (:,:,:) = c0

--- a/cicecore/cicedynB/general/ice_state.F90
+++ b/cicecore/cicedynB/general/ice_state.F90
@@ -54,7 +54,8 @@
 
       real (kind=dbl_kind), dimension(:,:,:), allocatable, &
          public :: &
-         aice  , & ! concentration of ice
+         aice  , & ! concentration of ice on T grid
+         aiU   , & ! concentration of ice on U grid
          vice  , & ! volume per unit area of ice          (m)
          vsno      ! volume per unit area of snow         (m)
 
@@ -151,7 +152,8 @@
           file=__FILE__, line=__LINE__)
 
       allocate ( &
-         aice      (nx_block,ny_block,max_blocks) , & ! concentration of ice
+         aice      (nx_block,ny_block,max_blocks) , & ! concentration of ice T grid
+         aiU       (nx_block,ny_block,max_blocks) , & ! concentration of ice U grid
          vice      (nx_block,ny_block,max_blocks) , & ! volume per unit area of ice (m)
          vsno      (nx_block,ny_block,max_blocks) , & ! volume per unit area of snow (m)
          aice0     (nx_block,ny_block,max_blocks) , & ! concentration of open water

--- a/cicecore/cicedynB/general/ice_step_mod.F90
+++ b/cicecore/cicedynB/general/ice_step_mod.F90
@@ -1015,11 +1015,15 @@
       call grid_average_X2Y('F', work2, 'U', strocnyT_sf, 'T')
 
 ! correct version?
-!      call grid_average_X2Y('F', strocnxU, 'U', strocnxT, 'T')    ! shift
-!      call grid_average_X2Y('F', strocnyU, 'U', strocnyT, 'T')
-! current version
-      strocnxT = strocnxT_sf
-      strocnyT = strocnyT_sf
+      call ice_HaloUpdate (strocnxU,           halo_info, &
+                           field_loc_NEcorner, field_type_vector)
+      call ice_HaloUpdate (strocnyU,           halo_info, &
+                           field_loc_NEcorner, field_type_vector)
+      call grid_average_X2Y('F', strocnxU, 'U', strocnxT, 'T')    ! shift
+      call grid_average_X2Y('F', strocnyU, 'U', strocnyT, 'T')
+! older version
+!      strocnxT = strocnxT_sf
+!      strocnyT = strocnyT_sf
 
       !-----------------------------------------------------------------
       ! Horizontal ice transport

--- a/cicecore/cicedynB/infrastructure/ice_restart_driver.F90
+++ b/cicecore/cicedynB/infrastructure/ice_restart_driver.F90
@@ -56,7 +56,7 @@
       use ice_domain, only: nblocks
       use ice_domain_size, only: nilyr, nslyr, ncat, max_blocks
       use ice_flux, only: scale_factor, swvdr, swvdf, swidr, swidf, &
-          strocnxT, strocnyT, sst, frzmlt, &
+          strocnxT_iavg, strocnyT_iavg, sst, frzmlt, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4, &
@@ -175,8 +175,8 @@
       !-----------------------------------------------------------------
       ! ocean stress (for bottom heat flux in thermo)
       !-----------------------------------------------------------------
-      call write_restart_field(nu_dump,0,strocnxT,'ruf8','strocnxT',1,diag)
-      call write_restart_field(nu_dump,0,strocnyT,'ruf8','strocnyT',1,diag)
+      call write_restart_field(nu_dump,0,strocnxT_iavg,'ruf8','strocnxT',1,diag)
+      call write_restart_field(nu_dump,0,strocnyT_iavg,'ruf8','strocnyT',1,diag)
 
       !-----------------------------------------------------------------
       ! internal stress
@@ -277,7 +277,7 @@
       use ice_domain_size, only: nilyr, nslyr, ncat, &
           max_blocks
       use ice_flux, only: scale_factor, swvdr, swvdf, swidr, swidf, &
-          strocnxT, strocnyT, sst, frzmlt, &
+          strocnxT_iavg, strocnyT_iavg, sst, frzmlt, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4, &
@@ -431,9 +431,9 @@
       if (my_task == master_task) &
            write(nu_diag,*) 'min/max ocean stress components'
 
-      call read_restart_field(nu_restart,0,strocnxT,'ruf8', &
+      call read_restart_field(nu_restart,0,strocnxT_iavg,'ruf8', &
            'strocnxT',1,diag,field_loc_center, field_type_vector)
-      call read_restart_field(nu_restart,0,strocnyT,'ruf8', &
+      call read_restart_field(nu_restart,0,strocnyT_iavg,'ruf8', &
            'strocnyT',1,diag,field_loc_center, field_type_vector)
 
       !-----------------------------------------------------------------
@@ -711,7 +711,7 @@
       use ice_domain_size, only: nilyr, nslyr, ncat, nx_global, ny_global, &
           max_blocks
       use ice_flux, only: scale_factor, swvdr, swvdf, swidr, swidf, &
-          strocnxT, strocnyT, sst, frzmlt, &
+          strocnxT_iavg, strocnyT_iavg, sst, frzmlt, &
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
@@ -876,9 +876,9 @@
       if (my_task == master_task) &
            write(nu_diag,*) 'min/max ocean stress components'
 
-      call ice_read(nu_restart,0,strocnxT,'ruf8',diag, &
+      call ice_read(nu_restart,0,strocnxT_iavg,'ruf8',diag, &
                        field_loc_center, field_type_vector)
-      call ice_read(nu_restart,0,strocnyT,'ruf8',diag, &
+      call ice_read(nu_restart,0,strocnyT_iavg,'ruf8',diag, &
                        field_loc_center, field_type_vector)
 
       !-----------------------------------------------------------------

--- a/cicecore/drivers/mct/cesm1/ice_import_export.F90
+++ b/cicecore/drivers/mct/cesm1/ice_import_export.F90
@@ -9,7 +9,7 @@ module ice_import_export
   use ice_constants     , only: field_type_vector, c100
   use ice_constants     , only: p001, p5
   use ice_blocks        , only: block, get_block, nx_block, ny_block
-  use ice_flux          , only: strairxT, strairyT, strocnxT, strocnyT
+  use ice_flux          , only: strairxT, strairyT, strocnxT_sf, strocnyT_sf
   use ice_flux          , only: alvdr, alidr, alvdf, alidf, Tref, Qref, Uref
   use ice_flux          , only: flat, fsens, flwout, evap, fswabs, fhocn, fswthru
   use ice_flux          , only: fresh, fsalt, zlvl, uatm, vatm, potT, Tair, Qa
@@ -571,8 +571,8 @@ contains
                              + workx*sin(ANGLET(i,j,iblk))
 
              ! ice/ocean stress (on POP T-grid:  convert to lat-lon)
-             workx = -strocnxT(i,j,iblk)                            ! N/m^2
-             worky = -strocnyT(i,j,iblk)                            ! N/m^2
+             workx = -strocnxT_sf(i,j,iblk)                            ! N/m^2
+             worky = -strocnyT_sf(i,j,iblk)                            ! N/m^2
              tauxo(i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) &
                              - worky*sin(ANGLET(i,j,iblk))
              tauyo(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) &

--- a/cicecore/drivers/mct/cesm1/ice_import_export.F90
+++ b/cicecore/drivers/mct/cesm1/ice_import_export.F90
@@ -9,7 +9,7 @@ module ice_import_export
   use ice_constants     , only: field_type_vector, c100
   use ice_constants     , only: p001, p5
   use ice_blocks        , only: block, get_block, nx_block, ny_block
-  use ice_flux          , only: strairxT, strairyT, strocnxT_sf, strocnyT_sf
+  use ice_flux          , only: strairxT, strairyT, strocnxT_iavg, strocnyT_iavg
   use ice_flux          , only: alvdr, alidr, alvdf, alidf, Tref, Qref, Uref
   use ice_flux          , only: flat, fsens, flwout, evap, fswabs, fhocn, fswthru
   use ice_flux          , only: fresh, fsalt, zlvl, uatm, vatm, potT, Tair, Qa
@@ -571,8 +571,8 @@ contains
                              + workx*sin(ANGLET(i,j,iblk))
 
              ! ice/ocean stress (on POP T-grid:  convert to lat-lon)
-             workx = -strocnxT_sf(i,j,iblk)                            ! N/m^2
-             worky = -strocnyT_sf(i,j,iblk)                            ! N/m^2
+             workx = -strocnxT_iavg(i,j,iblk)                       ! N/m^2
+             worky = -strocnyT_iavg(i,j,iblk)                       ! N/m^2
              tauxo(i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) &
                              - worky*sin(ANGLET(i,j,iblk))
              tauyo(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) &

--- a/cicecore/drivers/mct/cesm1/ice_prescribed_mod.F90
+++ b/cicecore/drivers/mct/cesm1/ice_prescribed_mod.F90
@@ -585,11 +585,11 @@ subroutine ice_prescribed_phys
    ! set non-computed fluxes, ice velocities, ice-ocn stresses to zero
    !--------------------------------------------------------------------
 
-   frzmlt    (:,:,:) = c0
-   uvel      (:,:,:) = c0
-   vvel      (:,:,:) = c0
-   strocnxT  (:,:,:) = c0
-   strocnyT  (:,:,:) = c0
+   frzmlt     (:,:,:) = c0
+   uvel       (:,:,:) = c0
+   vvel       (:,:,:) = c0
+   strocnxT_sf(:,:,:) = c0
+   strocnyT_sf(:,:,:) = c0
 
    !-----------------------------------------------------------------
    ! other atm and ocn fluxes

--- a/cicecore/drivers/mct/cesm1/ice_prescribed_mod.F90
+++ b/cicecore/drivers/mct/cesm1/ice_prescribed_mod.F90
@@ -585,11 +585,11 @@ subroutine ice_prescribed_phys
    ! set non-computed fluxes, ice velocities, ice-ocn stresses to zero
    !--------------------------------------------------------------------
 
-   frzmlt     (:,:,:) = c0
-   uvel       (:,:,:) = c0
-   vvel       (:,:,:) = c0
-   strocnxT_sf(:,:,:) = c0
-   strocnyT_sf(:,:,:) = c0
+   frzmlt       (:,:,:) = c0
+   uvel         (:,:,:) = c0
+   vvel         (:,:,:) = c0
+   strocnxT_iavg(:,:,:) = c0
+   strocnyT_iavg(:,:,:) = c0
 
    !-----------------------------------------------------------------
    ! other atm and ocn fluxes

--- a/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
@@ -10,7 +10,7 @@ module ice_import_export
   use ice_domain         , only : nblocks, blocks_ice, halo_info, distrb_info
   use ice_domain_size    , only : nx_global, ny_global, block_size_x, block_size_y, max_blocks, ncat
   use ice_exit           , only : abort_ice
-  use ice_flux           , only : strairxT, strairyT, strocnxT, strocnyT
+  use ice_flux           , only : strairxT, strairyT, strocnxT_sf, strocnyT_sf
   use ice_flux           , only : alvdr, alidr, alvdf, alidf, Tref, Qref, Uref
   use ice_flux           , only : flat, fsens, flwout, evap, fswabs, fhocn, fswthru
   use ice_flux           , only : fswthru_vdr, fswthru_vdf, fswthru_idr, fswthru_idf
@@ -914,8 +914,8 @@ contains
              tauya(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) + workx*sin(ANGLET(i,j,iblk))
 
              ! ice/ocean stress (on POP T-grid:  convert to lat-lon)
-             workx = -strocnxT(i,j,iblk)                            ! N/m^2
-             worky = -strocnyT(i,j,iblk)                            ! N/m^2
+             workx = -strocnxT_sf(i,j,iblk)                         ! N/m^2
+             worky = -strocnyT_sf(i,j,iblk)                         ! N/m^2
              tauxo(i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) - worky*sin(ANGLET(i,j,iblk))
              tauyo(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) + workx*sin(ANGLET(i,j,iblk))
           enddo

--- a/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
@@ -10,7 +10,7 @@ module ice_import_export
   use ice_domain         , only : nblocks, blocks_ice, halo_info, distrb_info
   use ice_domain_size    , only : nx_global, ny_global, block_size_x, block_size_y, max_blocks, ncat
   use ice_exit           , only : abort_ice
-  use ice_flux           , only : strairxT, strairyT, strocnxT_sf, strocnyT_sf
+  use ice_flux           , only : strairxT, strairyT, strocnxT_iavg, strocnyT_iavg
   use ice_flux           , only : alvdr, alidr, alvdf, alidf, Tref, Qref, Uref
   use ice_flux           , only : flat, fsens, flwout, evap, fswabs, fhocn, fswthru
   use ice_flux           , only : fswthru_vdr, fswthru_vdf, fswthru_idr, fswthru_idf
@@ -914,8 +914,8 @@ contains
              tauya(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) + workx*sin(ANGLET(i,j,iblk))
 
              ! ice/ocean stress (on POP T-grid:  convert to lat-lon)
-             workx = -strocnxT_sf(i,j,iblk)                         ! N/m^2
-             worky = -strocnyT_sf(i,j,iblk)                         ! N/m^2
+             workx = -strocnxT_iavg(i,j,iblk)                       ! N/m^2
+             worky = -strocnyT_iavg(i,j,iblk)                       ! N/m^2
              tauxo(i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) - worky*sin(ANGLET(i,j,iblk))
              tauyo(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) + workx*sin(ANGLET(i,j,iblk))
           enddo

--- a/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
@@ -472,11 +472,11 @@ contains
     ! set non-computed fluxes, ice velocities, ice-ocn stresses to zero
     !--------------------------------------------------------------------
 
-    frzmlt     (:,:,:) = c0
-    uvel       (:,:,:) = c0
-    vvel       (:,:,:) = c0
-    strocnxT_sf(:,:,:) = c0
-    strocnyT_sf(:,:,:) = c0
+    frzmlt       (:,:,:) = c0
+    uvel         (:,:,:) = c0
+    vvel         (:,:,:) = c0
+    strocnxT_iavg(:,:,:) = c0
+    strocnyT_iavg(:,:,:) = c0
 
     !-----------------------------------------------------------------
     ! other atm and ocn fluxes

--- a/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
@@ -472,11 +472,11 @@ contains
     ! set non-computed fluxes, ice velocities, ice-ocn stresses to zero
     !--------------------------------------------------------------------
 
-    frzmlt    (:,:,:) = c0
-    uvel      (:,:,:) = c0
-    vvel      (:,:,:) = c0
-    strocnxT  (:,:,:) = c0
-    strocnyT  (:,:,:) = c0
+    frzmlt     (:,:,:) = c0
+    uvel       (:,:,:) = c0
+    vvel       (:,:,:) = c0
+    strocnxT_sf(:,:,:) = c0
+    strocnyT_sf(:,:,:) = c0
 
     !-----------------------------------------------------------------
     ! other atm and ocn fluxes

--- a/cicecore/drivers/nuopc/dmi/cice_cap.info
+++ b/cicecore/drivers/nuopc/dmi/cice_cap.info
@@ -1023,8 +1023,8 @@ module cice_cap
           dataPtr_vice    (i1,j1,iblk) = vice(i,j,iblk)   ! sea ice volume
           dataPtr_vsno    (i1,j1,iblk) = vsno(i,j,iblk)   ! snow volume
           dataPtr_fswthru (i1,j1,iblk) = fswthru(i,j,iblk) ! short wave penetration through ice
-          ui = strocnxT_sf(i,j,iblk)
-          vj = strocnyT_sf(i,j,iblk)
+          ui = strocnxT_iavg(i,j,iblk)
+          vj = strocnyT_iavg(i,j,iblk)
           angT = ANGLET(i,j,iblk)
           dataPtr_strocnxT(i1,j1,iblk) =  ui*cos(-angT) + vj*sin(angT)  ! ice ocean stress
           dataPtr_strocnyT(i1,j1,iblk) = -ui*sin(angT)  + vj*cos(-angT)  ! ice ocean stress

--- a/cicecore/drivers/nuopc/dmi/cice_cap.info
+++ b/cicecore/drivers/nuopc/dmi/cice_cap.info
@@ -1023,8 +1023,8 @@ module cice_cap
           dataPtr_vice    (i1,j1,iblk) = vice(i,j,iblk)   ! sea ice volume
           dataPtr_vsno    (i1,j1,iblk) = vsno(i,j,iblk)   ! snow volume
           dataPtr_fswthru (i1,j1,iblk) = fswthru(i,j,iblk) ! short wave penetration through ice
-          ui = strocnxT(i,j,iblk)
-          vj = strocnyT(i,j,iblk)
+          ui = strocnxT_sf(i,j,iblk)
+          vj = strocnyT_sf(i,j,iblk)
           angT = ANGLET(i,j,iblk)
           dataPtr_strocnxT(i1,j1,iblk) =  ui*cos(-angT) + vj*sin(angT)  ! ice ocean stress
           dataPtr_strocnyT(i1,j1,iblk) = -ui*sin(angT)  + vj*cos(-angT)  ! ice ocean stress


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Refactor strocnxT, strocnyT implementation
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Bit-for-bit on cheyenne full test suite with 3 compilers if strocnxT and strocnyT computation is preserved, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#036f1f72d5ec5955fc0c8ba76843ea038a83d59a.  
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

- add aiU to ice_state
- migrate computation of strocnxT and strocnyT to ice_step, needed for thermodynamics, better code reuse.
- add strocnxT_iavg, strocnyT_iavg as coupling field, could be computed differently than the thermodynanics version, but didn't make that change here.  We will be migrating other coupling fields to use the _iavg naming convention over time.  The _iavg field is also passed into icepack as currently computed.
- Update the coupling layers to use the _iavg version of the fields.  See also #67.
- https://github.com/CICE-Consortium/CICE/issues/761 suggests the values of strocnxT, strocnyT maybe shouldn't be scaled for use in thermodynamics.  This commit **does not change** the values after some further discussion.
- These changes are bit-for-bit for a full test suite on cheyenne with 3 compilers without the change to strocnxT, strocnyT.

Closes #761
Also see #660 
