### PR TITLE
doc: improve "Quick Start" section

### DIFF
--- a/doc/source/intro/quickstart.rst
+++ b/doc/source/intro/quickstart.rst
@@ -6,13 +6,14 @@
 Quick Start
 ===========
 
-Download the model from the CICE-Consortium repository, 
-    https://github.com/CICE-Consortium/CICE
+Clone the model from the CICE-Consortium repository::
 
-Instructions for working in github with CICE (and Icepack) can be
-found in the `CICE Git and Workflow Guide <https://github.com/CICE-Consortium/About-Us/wiki/Git-Workflow-Guidance>`_.
+  git clone --recurse-submodules https://github.com/CICE-Consortium/CICE
 
-You will probably have to download some inputdata, see the `CICE wiki <https://github.com/cice-consortium/CICE/wiki>`_ or :ref:`force`.
+Instructions for working with Git and GitHub with CICE (and Icepack) can be
+found in the `CICE Git Workflow Guide <https://github.com/CICE-Consortium/About-Us/wiki/Git-Workflow-Guide>`_.
+
+You will probably have to download some input data, see the `CICE wiki <https://github.com/cice-consortium/CICE/wiki>`_ or :ref:`force`.
 
 Software requirements are noted in this :ref:`software` section.
 


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    no tests needed.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

These are some improvements to the quick start section after comments by @dupontf when he followed the instructions to use CICE6.

- mention cloning with `--recurse-submodules`
- fix the link to the Git Workflow Guide.
- improve the wording a bit