### PR TITLE
ice_init: do broadcast 'default_season'

### DIFF
--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -980,6 +980,7 @@
       call broadcast_scalar(albsnowi,             master_task)
       call broadcast_scalar(ahmax,                master_task)
       call broadcast_scalar(atmbndy,              master_task)
+      call broadcast_scalar(default_season,       master_task)
       call broadcast_scalar(fyear_init,           master_task)
       call broadcast_scalar(ycycle,               master_task)
       call broadcast_scalar(atm_data_format,      master_task)


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    title
- [x] Developer(s): 
    me
- [x] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Base suite is b4b with main on `robert_intel`:
~~~
349 measured results of 349 total results
349 of 349 tests PASSED
0 of 349 tests PENDING
0 of 349 tests MISSING data
0 of 349 tests FAILED
~~~
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit **(since no test in the base suite change `default_season`)**
    - [ ] different at roundoff level
    - [x] more substantial **if changing `default_season`**
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [x] Please provide any additional information or relevant details below:

When the 'default_season' namelist setting was added in 01494c75 (Nml settings (#208), 2018-10-19) to replace 'l_winter' and 'l_spring', a call to 'broadcast_scalar' was forgotten, such that the 'default_season' value from the namelist is only used on the first MPI process; all other processes get the hardcoded default value 'winter' defined in 'ice_init::input_data', resulting in different initialization across the grid for several variables if anything other than 'winter' is used in the namelist.

Fix that by broadcasting 'default_season' to all MPI procs.