### PR TITLE
Added check for individual namelist variables

### DIFF
--- a/cicecore/cicedynB/analysis/ice_history.F90
+++ b/cicecore/cicedynB/analysis/ice_history.F90
@@ -102,7 +102,9 @@
       character (len=25) :: &
          cstr_gat, cstr_gau, cstr_gav, &     ! mask area name for t, u, v atm grid (ga)
          cstr_got, cstr_gou, cstr_gov        ! mask area name for t, u, v ocn grid (go)
-      character(len=char_len) :: description
+
+      character(len=char_len)      :: description
+      character(len=char_len_long) :: tmpstr2 ! for namelist check
 
       character(len=*), parameter :: subname = '(init_hist)'
 
@@ -239,11 +241,18 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=icefields_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: icefields_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: icefields_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
+
          close(nu_nml)
          call release_fileunit(nu_nml)
       endif

--- a/cicecore/cicedynB/analysis/ice_history_bgc.F90
+++ b/cicecore/cicedynB/analysis/ice_history_bgc.F90
@@ -283,6 +283,9 @@
           tr_bgc_DON,    tr_bgc_Fe,    tr_bgc_hum,   &
           skl_bgc, solve_zsal, z_tracers
 
+      character(len=char_len_long) :: &
+           tmpstr2 ! for namelist check
+
       character(len=*), parameter  :: subname = '(init_hist_bgc_2D)'
 
       call icepack_query_parameters(skl_bgc_out=skl_bgc, &
@@ -318,11 +321,18 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=icefields_bgc_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: icefields_bgc_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: icefields_bgc_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
+
          close(nu_nml)
          call release_fileunit(nu_nml)
       endif

--- a/cicecore/cicedynB/analysis/ice_history_drag.F90
+++ b/cicecore/cicedynB/analysis/ice_history_drag.F90
@@ -69,6 +69,8 @@
       integer (kind=int_kind) :: nml_error ! namelist i/o error flag
       logical (kind=log_kind) :: formdrag
 
+      character(len=char_len_long) :: tmpstr2 ! for namelist check
+
       character(len=*), parameter :: subname = '(init_hist_drag_2D)'
 
       call icepack_query_parameters(formdrag_out=formdrag)
@@ -94,11 +96,18 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=icefields_drag_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: icefields_drag_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: icefields_drag_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
+
          close(nu_nml)
          call release_fileunit(nu_nml)
       endif

--- a/cicecore/cicedynB/analysis/ice_history_mechred.F90
+++ b/cicecore/cicedynB/analysis/ice_history_mechred.F90
@@ -89,6 +89,7 @@
       integer (kind=int_kind) :: nml_error ! namelist i/o error flag
       real    (kind=dbl_kind) :: secday
       logical (kind=log_kind) :: tr_lvl
+      character(len=char_len_long) :: tmpstr2 ! for namelist check
 
       character(len=*), parameter :: subname = '(init_hist_mechred_2D)'
 
@@ -116,11 +117,18 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=icefields_mechred_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: icefields_mechred_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: icefields_mechred_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
+
          close(nu_nml)
          call release_fileunit(nu_nml)
       endif

--- a/cicecore/cicedynB/analysis/ice_history_pond.F90
+++ b/cicecore/cicedynB/analysis/ice_history_pond.F90
@@ -73,6 +73,7 @@
       integer (kind=int_kind) :: ns
       integer (kind=int_kind) :: nml_error ! namelist i/o error flag
       logical (kind=log_kind) :: tr_pond
+      character(len=char_len_long) :: tmpstr2 ! for namelist check
 
       character(len=*), parameter :: subname = '(init_hist_pond_2D)'
 
@@ -99,11 +100,18 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=icefields_pond_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: icefields_pond_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: icefields_pond_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
+
          close(nu_nml)
          call release_fileunit(nu_nml)
       endif

--- a/cicecore/cicedynB/analysis/ice_history_snow.F90
+++ b/cicecore/cicedynB/analysis/ice_history_snow.F90
@@ -77,6 +77,7 @@
       integer (kind=int_kind) :: nml_error ! namelist i/o error flag
       real    (kind=dbl_kind) :: rhofresh, secday
       logical (kind=log_kind) :: tr_snow
+      character(len=char_len_long) :: tmpstr2 ! for namelist check
       character(len=*), parameter :: subname = '(init_hist_snow_2D)'
 
       call icepack_query_tracer_flags(tr_snow_out=tr_snow)
@@ -105,11 +106,18 @@
             nml_error =  1
             do while (nml_error > 0)
                read(nu_nml, nml=icefields_snow_nml,iostat=nml_error)
+               ! check if error
+               if (nml_error /= 0) then
+                  ! backspace and re-read erroneous line
+                  backspace(nu_nml)
+                  read(nu_nml,fmt='(A)') tmpstr2
+                  
+                  call abort_ice(subname//'ERROR: icefields_snow_nml reading ' // &
+                       trim(tmpstr2), &
+                       file=__FILE__, line=__LINE__)
+               endif
             end do
-            if (nml_error /= 0) then
-               call abort_ice(subname//'ERROR: icefields_snow_nml reading ', &
-                  file=__FILE__, line=__LINE__)
-            endif
+
             close(nu_nml)
             call release_fileunit(nu_nml)
          endif

--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -182,7 +182,7 @@
 #ifdef CESMCOUPLED
       character (len=64) :: tmpstr
 #endif
-      character (len=128) :: tmpstr2
+      character (len=char_len_long) :: tmpstr2
 
       character(len=*), parameter :: subname='(input_data)'
 
@@ -629,11 +629,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=setup_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: setup_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: setup_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          write(nu_diag,*) subname,' Reading grid_nml'
          rewind(unit=nu_nml, iostat=nml_error)
@@ -644,11 +650,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=grid_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: grid_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: grid_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          write(nu_diag,*) subname,' Reading tracer_nml'
          rewind(unit=nu_nml, iostat=nml_error)
@@ -659,11 +671,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=tracer_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: tracer_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: tracer_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          write(nu_diag,*) subname,' Reading thermo_nml'
          rewind(unit=nu_nml, iostat=nml_error)
@@ -674,11 +692,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=thermo_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: thermo_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: thermo_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          write(nu_diag,*) subname,' Reading dynamics_nml'
          rewind(unit=nu_nml, iostat=nml_error)
@@ -689,11 +713,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=dynamics_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: dynamics_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: dynamics_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          write(nu_diag,*) subname,' Reading shortwave_nml'
          rewind(unit=nu_nml, iostat=nml_error)
@@ -704,11 +734,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=shortwave_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: shortwave_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: shortwave_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          write(nu_diag,*) subname,' Reading ponds_nml'
          rewind(unit=nu_nml, iostat=nml_error)
@@ -719,11 +755,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=ponds_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: ponds_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: ponds_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          write(nu_diag,*) subname,' Reading snow_nml'
          rewind(unit=nu_nml, iostat=nml_error)
@@ -734,11 +776,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=snow_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: snow_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: snow_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          write(nu_diag,*) subname,' Reading forcing_nml'
          rewind(unit=nu_nml, iostat=nml_error)
@@ -749,11 +797,17 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=forcing_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: forcing_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: forcing_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
 
          close(nu_nml)
          call release_fileunit(nu_nml)

--- a/cicecore/cicedynB/infrastructure/ice_domain.F90
+++ b/cicecore/cicedynB/infrastructure/ice_domain.F90
@@ -113,6 +113,9 @@
 
    integer (int_kind) :: &
       nml_error          ! namelist read error flag
+   
+   character(len=char_len_long) :: &
+      tmpstr2 ! for namelist check
 
    character(len=*), parameter :: subname = '(init_domain_blocks)'
 
@@ -180,11 +183,18 @@
       nml_error =  1
       do while (nml_error > 0)
          read(nu_nml, nml=domain_nml,iostat=nml_error)
+         ! check if error
+         if (nml_error /= 0) then
+            ! backspace and re-read erroneous line
+            backspace(nu_nml)
+            read(nu_nml,fmt='(A)') tmpstr2
+            
+            call abort_ice(subname//'ERROR: domain_nml reading ' // &
+                 trim(tmpstr2), &
+                 file=__FILE__, line=__LINE__)
+         endif
       end do
-      if (nml_error /= 0) then
-         call abort_ice(subname//'ERROR: domain_nml reading ', &
-            file=__FILE__, line=__LINE__)
-      endif
+
       close(nu_nml)
       call release_fileunit(nu_nml)
    endif

--- a/cicecore/shared/ice_init_column.F90
+++ b/cicecore/shared/ice_init_column.F90
@@ -1075,6 +1075,9 @@
          nml_error, & ! namelist i/o error flag
          abort_flag
 
+      character(len=char_len_long) :: &
+           tmpstr2 ! for namelist check
+
       character(len=*), parameter :: subname='(input_zbgc)'
 
       !-----------------------------------------------------------------
@@ -1320,11 +1323,18 @@
          nml_error =  1
          do while (nml_error > 0)
             read(nu_nml, nml=zbgc_nml,iostat=nml_error)
+            ! check if error
+            if (nml_error /= 0) then
+               ! backspace and re-read erroneous line
+               backspace(nu_nml)
+               read(nu_nml,fmt='(A)') tmpstr2
+
+               call abort_ice(subname//'ERROR: zbgc_nml reading ' // &
+                    trim(tmpstr2), &
+                    file=__FILE__, line=__LINE__)
+            endif
          end do
-         if (nml_error /= 0) then
-            call abort_ice(subname//'ERROR: zbgc_nml reading ', &
-               file=__FILE__, line=__LINE__)
-         endif
+
          close(nu_nml)
          call release_fileunit(nu_nml)
       endif


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
Added check for namelist variables
- [x] Developer(s): 
    David Hebert
- [ ] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
quick_suite passed. Only ran small test since this is a namliest check, not physics:
16 measured results of 16 total results
16 of 16 tests PASSED
0 of 16 tests PENDING
0 of 16 tests MISSING data
0 of 16 tests FAILED

- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please provide any additional information or relevant details below:
Issue #677 changed how namelists were read to allow random reading, and removed previous namelist checks. I added namelist checks back with these updates. I ran quick_suite, then introduced errors in each of the namelists and re-ran. That worked with my gnu compiler, logs show results like this:

 (abort_ice)ABORTED:
 (abort_ice) called from /home/hebert/git/daveh150_new/cicecore/cicedynB/analysis/ice_histo\
ry_drag.F90
 (abort_ice) line number          107
 (abort_ice) error = (init_hist_drag_2D)ERROR: icefields_drag_nml reading     test_icefields_drag_nml = .true.


 I think #677 was targed at NAG, does someone have NAG compiler to test with?  Thanks!