### PR TITLE
Update stress12T calculation for C-grid

### DIFF
--- a/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
@@ -1779,6 +1779,7 @@
         shearTsqr , & ! strain rates squared at T point
         shearT    , & ! strain rate at T point
         DeltaT    , & ! delt at T point
+        uareaavgr , & ! 1 / uarea avg
         rep_prsT      ! replacement pressure at T point
 
       character(len=*), parameter :: subname = '(stressC_T)'
@@ -1805,17 +1806,19 @@
          ! U point values (Bouillon et al., 2013, Kimmritz et al., 2016
          !-----------------------------------------------------------------
 
+         uareaavgr = c1/(uarea(i,j)+uarea(i,j-1)+uarea(i-1,j-1)+uarea(i-1,j))
+
          shearTsqr = (shearU(i  ,j  )**2 * uarea(i  ,j  )  &
                     + shearU(i  ,j-1)**2 * uarea(i  ,j-1)  &
                     + shearU(i-1,j-1)**2 * uarea(i-1,j-1)  &
                     + shearU(i-1,j  )**2 * uarea(i-1,j  )) &
-                    / (uarea(i,j)+uarea(i,j-1)+uarea(i-1,j-1)+uarea(i-1,j))
+                    * uareaavgr
 
          shearT    = (shearU(i  ,j  )    * uarea(i  ,j  )  &
                     + shearU(i  ,j-1)    * uarea(i  ,j-1)  &
                     + shearU(i-1,j-1)    * uarea(i-1,j-1)  &
                     + shearU(i-1,j  )    * uarea(i-1,j  )) &
-                    / (uarea(i,j)+uarea(i,j-1)+uarea(i-1,j-1)+uarea(i-1,j))
+                    * uareaavgr
 
          DeltaT = sqrt(divT(i,j)**2 + e_factor*(tensionT(i,j)**2 + shearTsqr))
 


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update stress12T calculation for C-grid
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    All bit-for-bit on cheyenne full test suites, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#8a45b97c1d4bb49fe7cdad98ecb7ea39dbc4b30c
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

stress12T was zero.  Compute stress12T in subroutine stressC_T after computing estimate of shearT by averaging shearU.  See #707 for additional discussion and results.  This is just a diagnostic.

minor updates to some indentation and variable names.

closes #707
