### PR TITLE
Fix for rare instabilities in basal stress.

### DIFF
--- a/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
@@ -1484,7 +1484,11 @@
             v_i = v_i - m_i**2
 
             mu_i    = log(m_i/sqrt(c1 + v_i/m_i**2)) ! parameters for the log-normal
-            sigma_i = sqrt(log(c1 + v_i/m_i**2))
+            if (v_i > 0.0) then
+              sigma_i = max(sqrt(log(c1 + v_i/m_i**2)), puny)
+            else
+              sigma_i = puny
+            endif
 
             ! max thickness associated with percentile of log-normal PDF
             ! x_kmax=x997 was obtained from an optimization procedure (Dupont et al.)


### PR DESCRIPTION
- Don't do log with v_i negative and don't let sigma_i be zero.
- For SIS2, I was having issues with thin new ice, 100% of the first category.


For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Fix for rare basal stress instability.
- [x] Developer(s): 
    Kate Hedstrom
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ENTER INFORMATION HERE 
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ x] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [ x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [ x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [ x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ x] No 
- [ ] Please provide any additional information or relevant details below:
