### PR TITLE
cicecore: correct initial condition metadata

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_binary/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_binary/ice_history_write.F90
@@ -158,6 +158,7 @@
                trim(avail_hist_fields(n)%vcomment)
 
             if (histfreq(ns) == '1' .or. .not. hist_avg         &
+                .or. write_ic                                   &
                 .or. n==n_divu(ns)      .or. n==n_shear(ns)     &  ! snapshots
                 .or. n==n_sig1(ns)      .or. n==n_sig2(ns)      &
                 .or. n==n_sigP(ns)      .or. n==n_trsig(ns)     &
@@ -186,7 +187,7 @@
             write (nu_hdr, 994) nrec,trim(avail_hist_fields(n)%vname), &
                trim(avail_hist_fields(n)%vdesc),trim(avail_hist_fields(n)%vunit),nn
 
-            if (histfreq(ns) == '1' .or. .not. hist_avg) then
+            if (histfreq(ns) == '1' .or. .not. hist_avg .or. write_ic) then
                write (nu_hdr, 996) nrec,trim(avail_hist_fields(n)%vname), &
                   'time_rep','instantaneous'
             else
@@ -210,7 +211,7 @@
             write (nu_hdr, 993) nrec,trim(avail_hist_fields(n)%vname), &
                trim(avail_hist_fields(n)%vdesc),trim(avail_hist_fields(n)%vunit),k
 
-            if (histfreq(ns) == '1' .or. .not. hist_avg) then
+            if (histfreq(ns) == '1' .or. .not. hist_avg .or. write_ic) then
                write (nu_hdr, 996) nrec,trim(avail_hist_fields(n)%vname), &
                   'time_rep','instantaneous'
             else
@@ -234,7 +235,7 @@
             write (nu_hdr, 993) nrec,trim(avail_hist_fields(n)%vname), &
                trim(avail_hist_fields(n)%vdesc),trim(avail_hist_fields(n)%vunit),nn,k
 
-            if (histfreq(ns) == '1' .or. .not. hist_avg) then
+            if (histfreq(ns) == '1' .or. .not. hist_avg .or. write_ic) then
                write (nu_hdr, 996) nrec,trim(avail_hist_fields(n)%vname), &
                   'time_rep','instantaneous'
             else
@@ -258,7 +259,7 @@
             write (nu_hdr, 993) nrec,trim(avail_hist_fields(n)%vname), &
                trim(avail_hist_fields(n)%vdesc),trim(avail_hist_fields(n)%vunit),nn,k
 
-            if (histfreq(ns) == '1' .or. .not. hist_avg) then
+            if (histfreq(ns) == '1' .or. .not. hist_avg .or. write_ic) then
                write (nu_hdr, 996) nrec,trim(avail_hist_fields(n)%vname), &
                   'time_rep','instantaneous'
             else
@@ -282,7 +283,7 @@
             write (nu_hdr, 993) nrec,trim(avail_hist_fields(n)%vname), &
                trim(avail_hist_fields(n)%vdesc),trim(avail_hist_fields(n)%vunit),nn,k
 
-            if (histfreq(ns) == '1' .or. .not. hist_avg) then
+            if (histfreq(ns) == '1' .or. .not. hist_avg .or. write_ic) then
                write (nu_hdr, 996) nrec,trim(avail_hist_fields(n)%vname), &
                   'time_rep','instantaneous'
             else
@@ -307,7 +308,7 @@
             write (nu_hdr, 993) nrec,trim(avail_hist_fields(n)%vname), &
                trim(avail_hist_fields(n)%vdesc),trim(avail_hist_fields(n)%vunit),nn,k
 
-            if (histfreq(ns) == '1' .or. .not. hist_avg) then
+            if (histfreq(ns) == '1' .or. .not. hist_avg .or. write_ic) then
                write (nu_hdr, 996) nrec,trim(avail_hist_fields(n)%vname), &
                   'time_rep','instantaneous'
             else
@@ -333,7 +334,7 @@
             write (nu_hdr, 993) nrec,trim(avail_hist_fields(n)%vname), &
                trim(avail_hist_fields(n)%vdesc),trim(avail_hist_fields(n)%vunit),nn,k
 
-            if (histfreq(ns) == '1' .or. .not. hist_avg) then
+            if (histfreq(ns) == '1' .or. .not. hist_avg .or. write_ic) then
                write (nu_hdr, 996) nrec,trim(avail_hist_fields(n)%vname), &
                   'time_rep','instantaneous'
             else
@@ -359,7 +360,7 @@
             write (nu_hdr, 993) nrec,trim(avail_hist_fields(n)%vname), &
                trim(avail_hist_fields(n)%vdesc),trim(avail_hist_fields(n)%vunit),nn,k
 
-            if (histfreq(ns) == '1' .or. .not. hist_avg) then
+            if (histfreq(ns) == '1' .or. .not. hist_avg .or. write_ic) then
                write (nu_hdr, 996) nrec,trim(avail_hist_fields(n)%vname), &
                   'time_rep','instantaneous'
             else

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -159,7 +159,7 @@
       ! define dimensions
       !-----------------------------------------------------------------
 
-        if (hist_avg) then
+        if (hist_avg .and. .not. write_ic) then
           status = nf90_def_dim(ncid,'d2',2,boundid)
           if (status /= nf90_noerr) call abort_ice(subname// &
              'ERROR: defining dim d2')
@@ -241,7 +241,7 @@
            call abort_ice(subname//'ERROR: invalid calendar settings')
         endif
 
-        if (hist_avg) then
+        if (hist_avg .and. .not. write_ic) then
           status = nf90_put_att(ncid,varid,'bounds','time_bounds')
           if (status /= nf90_noerr) call abort_ice(subname// &
                       'ERROR: time bounds')
@@ -251,7 +251,7 @@
       ! Define attributes for time bounds if hist_avg is true
       !-----------------------------------------------------------------
 
-        if (hist_avg) then
+        if (hist_avg .and. .not. write_ic) then
           dimid(1) = boundid
           dimid(2) = timid
           status = nf90_def_var(ncid,'time_bounds',lprecision,dimid(1:2),varid)
@@ -745,7 +745,7 @@
       ! write time_bounds info
       !-----------------------------------------------------------------
 
-        if (hist_avg) then
+        if (hist_avg .and. .not. write_ic) then
           status = nf90_inq_varid(ncid,'time_bounds',varid)
           if (status /= nf90_noerr) call abort_ice(subname// &
                         'ERROR: getting time_bounds id')
@@ -1236,7 +1236,7 @@
       subroutine ice_write_hist_attrs(ncid, varid, hfield, ns)
 
       use ice_kinds_mod
-      use ice_calendar, only: histfreq, histfreq_n
+      use ice_calendar, only: histfreq, histfreq_n, write_ic
       use ice_history_shared, only: ice_hist_field, history_precision, &
           hist_avg
 #ifdef USE_NETCDF
@@ -1279,7 +1279,7 @@
       call ice_write_hist_fill(ncid,varid,hfield%vname,history_precision)
 
       ! Add cell_methods attribute to variables if averaged
-      if (hist_avg) then
+      if (hist_avg .and. .not. write_ic) then
          if    (TRIM(hfield%vname(1:4))/='sig1' &
            .and.TRIM(hfield%vname(1:4))/='sig2' &
            .and.TRIM(hfield%vname(1:9))/='sistreave' &
@@ -1293,6 +1293,7 @@
 
       if ((histfreq(ns) == '1' .and. histfreq_n(ns) == 1) &
           .or..not. hist_avg                              &
+          .or. write_ic                                   &
           .or.TRIM(hfield%vname(1:4))=='divu' &
           .or.TRIM(hfield%vname(1:5))=='shear' &
           .or.TRIM(hfield%vname(1:4))=='sig1' &

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -195,7 +195,7 @@
       ! define dimensions
       !-----------------------------------------------------------------
 
-        if (hist_avg) then
+        if (hist_avg .and. .not. write_ic) then
           status = pio_def_dim(File,'d2',2,boundid)
         endif
 
@@ -233,12 +233,12 @@
            call abort_ice(subname//'ERROR: invalid calendar settings')
         endif
 
-        if (hist_avg) then
+        if (hist_avg .and. .not. write_ic) then
           status = pio_put_att(File,varid,'bounds','time_bounds')
         endif
 
         ! Define attributes for time_bounds if hist_avg is true
-        if (hist_avg) then
+        if (hist_avg .and. .not. write_ic) then
           dimid2(1) = boundid
           dimid2(2) = timid
           status = pio_def_var(File,'time_bounds',pio_double,dimid2,varid)
@@ -702,7 +702,7 @@
       ! write time_bounds info
       !-----------------------------------------------------------------
 
-        if (hist_avg) then
+        if (hist_avg .and. .not. write_ic) then
           status = pio_inq_varid(File,'time_bounds',varid)
           time_bounds=(/time_beg(ns),time_end(ns)/)
           bnd_start  = (/1,1/)
@@ -1219,7 +1219,7 @@
       subroutine ice_write_hist_attrs(File, varid, hfield, ns)
 
       use ice_kinds_mod
-      use ice_calendar, only: histfreq, histfreq_n
+      use ice_calendar, only: histfreq, histfreq_n, write_ic
       use ice_history_shared, only: ice_hist_field, history_precision, &
           hist_avg
       use ice_pio
@@ -1250,7 +1250,7 @@
       call ice_write_hist_fill(File,varid,hfield%vname,history_precision)
 
       ! Add cell_methods attribute to variables if averaged
-      if (hist_avg) then
+      if (hist_avg .and. .not. write_ic) then
          if    (TRIM(hfield%vname(1:4))/='sig1' &
            .and.TRIM(hfield%vname(1:4))/='sig2' &
            .and.TRIM(hfield%vname(1:9))/='sistreave' &
@@ -1262,6 +1262,7 @@
 
       if ((histfreq(ns) == '1' .and. histfreq_n(ns) == 1) &
           .or..not. hist_avg                              &
+          .or. write_ic                                   &
           .or.TRIM(hfield%vname(1:4))=='divu' &
           .or.TRIM(hfield%vname(1:5))=='shear' &
           .or.TRIM(hfield%vname(1:4))=='sig1' &

--- a/cicecore/drivers/direct/nemo_concepts/CICE_InitMod.F90
+++ b/cicecore/drivers/direct/nemo_concepts/CICE_InitMod.F90
@@ -185,6 +185,8 @@
       if (trim(runtype) == 'continue' .or. restart) &
          call init_shortwave    ! initialize radiative transfer
 
+      if (write_ic) call accum_hist(dt) ! write initial conditions
+
       ! determine the time and date at the end of the first timestep
       call advance_timestep()
 
@@ -214,8 +216,6 @@
 
       call init_flux_atm        ! initialize atmosphere fluxes sent to coupler
       call init_flux_ocn        ! initialize ocean fluxes sent to coupler
-
-      if (write_ic) call accum_hist(dt) ! write initial conditions
 
       end subroutine cice_init
 

--- a/cicecore/drivers/standalone/cice/CICE_InitMod.F90
+++ b/cicecore/drivers/standalone/cice/CICE_InitMod.F90
@@ -199,6 +199,8 @@
       if (trim(runtype) == 'continue' .or. restart) &
          call init_shortwave    ! initialize radiative transfer
 
+      if (write_ic) call accum_hist(dt) ! write initial conditions
+
 ! tcraig, use advance_timestep here
 !      istep  = istep  + 1    ! update time step counters
 !      istep1 = istep1 + 1
@@ -242,8 +244,6 @@
 
       call init_flux_atm        ! initialize atmosphere fluxes sent to coupler
       call init_flux_ocn        ! initialize ocean fluxes sent to coupler
-
-      if (write_ic) call accum_hist(dt) ! write initial conditions
 
       if (my_task == master_task) then
          call ice_memusage_print(nu_diag,subname//':end')


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR:
    Make the initial condition metadata more correct by writing it at the initial time and not marking its variables as averaged.
- [x] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
   I did not run the test suite, as this only changes `history` output and the our regression test compare the restarts, not the history output. I checked the following:
  - that the initial condition is now written with the correct date/time in the file name (the model initialization date/time)
  - that the `time` netCDF variable in the initial condition has value zero and no `bounds` attribute
  - that the `time_bounds`  variable is not written in the initial condition
  - that the variable in the initial condition have `time_rep = "instantaneous"` and no `cell_method` attribute.
  - that the rest of the outputs variables, both for the initial condition and the simulation output, are unchanged. The history files can't be compared with `cmp` since the time of the run is written as a global `:history` attribute, but I used something like 

~~~bash
 diff <(ncdump  history/iceh_01h.2005-01-01-03600.nc) <(ncdump  history-ic-fixed/iceh_01h.2005-01-01-03600.nc)
~~~

to verify that the only difference is this global `history` attribute.

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit (expect for  changes described above)
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [x] Please provide any additional information or relevant details below:

I reported these two issues initially in https://github.com/CICE-Consortium/CICE/issues/567#issuecomment-831514316:

> [...] this leads to the initial condition being written _after_ the first time step...
> 
> Another minor thing I noticed: when using `hist_avg = .true.`, the initial condition is also written as being "averaged" from "time = 0" to "time = after the first time step", which is kind of weird...

I can remove the changes to the standalone driver if we do not agree on that, but in my opinion it does not break anything and makes the history output more correct so I felt it was better to just do it there also.

Full commit messages follow.

---

~~~
[PATCH 1/2] ice_history_write: fix initial condition metadata under 'hist_avg'

When writing averaged history outputs (hist_avg=.true.), this setting
also affects the initial condition. Even if the actual data variables
written to the initial condition are not averaged (they are taken
more or less directly from the restart or the hard-coded defaults,
modulo aggregation over categories), their attributes ('cell_method' and
'time_rep') imply they are averaged, and the 'bound' attribute of the
'time' variable refers to the 'time_bounds' variable.

Make the metadata of the initial condition more correct by:
- not writing the 'time_bounds' (and the corresponding 'd2' dimension)
- not writing the 'bounds' attribute of the 'time' variable
- not writing the 'cell_method' attributes of each variable
- writing the 'time_rep' attribute of each variable as 'instantaneous'
instead of 'averaged'.

Do this by checking 'write_ic' at all places where we check for the
value of 'hist_avg' to write the above variables and attributes in each
of the 3 IO backends (binary, netcdf, pio2).
~~~

~~~
[PATCH 2/2] drivers/{nemo_concepts,standalone}: write initial condition at initial time

In CICE_InitMod::cice_init, we call ice_calendar::advance_timestep
before writing the initial condition, such that the 'time' variable in
the initial condition is not zero; it has a value of 1*dt (the model
time step). The initial condition filename also reflects this, since
'msec' (model seconds) also has a value of 1*dt and is used in
ice_history_shared::construct_filename. This leads to the initial
condition filename not corresponding to the model initialization
date/time but rather 1*dt later.

Fix that by calling 'accum_hist' to write the initial condition _before_
calling 'advance_timestep'.
~~~