### PR TITLE
Fix readthedocs pdf, update documentation

### DIFF
--- a/doc/source/science_guide/sg_dynamics.rst
+++ b/doc/source/science_guide/sg_dynamics.rst
@@ -237,15 +237,15 @@ In the VP approach, equation :eq:`momsys` is discretized implicitly using a Back
 and stresses are not computed explicitly:
 
 .. math::
-  \begin{align}
+  \begin{aligned}
   m\frac{(u^{n}-u^{n-1})}{\Delta t} &= \frac{\partial \sigma_{1j}^n}{\partial x_j}
   - \tau_{w,x}^n + \tau_{b,x}^n +  mfv^n
    + r_{x}^n,
   \\
   m\frac{(v^{n}-v^{n-1})}{\Delta t} &= \frac{\partial \sigma^{n} _{2j}}{\partial x_j}
-  - \tau_{w,y}^n + \tau_{b,y}^n   -mfu^{n}
+  - \tau_{w,y}^n + \tau_{b,y}^n -  mfu^{n}
    + r_{y}^n
-  \end{align}
+  \end{aligned}
   :label: u_sit
 
 where :math:`r = (r_x,r_y)` contains all terms that do not depend on the velocities :math:`u^n, v^n` (namely the sea surface tilt and the wind stress).
@@ -297,7 +297,7 @@ The Hibler-Bryan form for the ice-ocean stress :cite:`Hibler87`
 is included in **ice\_dyn\_shared.F90** but is currently commented out,
 pending further testing.
 
-.. _seabed-stress:
+.. _seabedstress:
 
 Seabed stress
 ~~~~~~~~~~~~~


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update documentation to fix readthedocs pdf
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    no testing done
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

Recent changes to readthedocs fail documentation on latex/pdf errors.  This wasn't happening before.  We had some small latex errors that needed to be fixed.