### PR TITLE
Fix for mesh check in CESM driver

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -583,7 +583,7 @@ contains
     real(dbl_kind)               :: diff_lon
     real(dbl_kind)               :: diff_lat
     real(dbl_kind)               :: rad_to_deg
-    real(dbl_kind)               :: tmplon, eps_imesh
+    real(dbl_kind)               :: eps_imesh
     logical                      :: isPresent, isSet
     logical                      :: mask_error
     integer                      :: mask_internal
@@ -643,7 +643,7 @@ contains
                diff_lon = diff_lon - c360
              endif
              if (abs(diff_lon) > eps_imesh ) then
-                write(6,100)n,lonMesh(n),tmplon, diff_lon
+                write(6,100)n,lonMesh(n),lon(n), diff_lon
                 !call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)
              end if
              diff_lat = abs(latMesh(n) - lat(n))

--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -638,7 +638,7 @@ contains
              lat(n) = tlat(i,j,iblk)*rad_to_deg
 
              ! error check differences between internally generated lons and those read in
-             diff_lon = abs(mod(lonMesh(n) - lon(n),360.0))
+             diff_lon = mod(abs(lonMesh(n) - lon(n)),360.0)
              if (diff_lon > c180) then
                diff_lon = diff_lon - c360
              endif

--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -559,7 +559,7 @@ contains
 
     ! Check CICE mesh
 
-    use ice_constants, only : c1,c0,c2,c360
+    use ice_constants, only : c1,c0,c180,c360
     use ice_grid     , only : tlon, tlat, hm
 
     ! input/output parameters
@@ -637,12 +637,12 @@ contains
              lon(n) = tlon(i,j,iblk)*rad_to_deg
              lat(n) = tlat(i,j,iblk)*rad_to_deg
 
-             tmplon = lon(n)
-             if(tmplon < c0)tmplon = tmplon + c360
-
              ! error check differences between internally generated lons and those read in
-             diff_lon = abs(mod(c2*c360+lonMesh(n),c360) - mod(c2*c360+lon(n),c360))
-             if (diff_lon > eps_imesh ) then
+             diff_lon = abs(mod(lonMesh(n) - lon(n),360.0))
+             if (diff_lon > c180) then
+               diff_lon = diff_lon - c360
+             endif
+             if (abs(diff_lon) > eps_imesh ) then
                 write(6,100)n,lonMesh(n),tmplon, diff_lon
                 !call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)
              end if

--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -559,7 +559,7 @@ contains
 
     ! Check CICE mesh
 
-    use ice_constants, only : c1,c0,c360
+    use ice_constants, only : c1,c0,c2,c360
     use ice_grid     , only : tlon, tlat, hm
 
     ! input/output parameters
@@ -641,7 +641,7 @@ contains
              if(tmplon < c0)tmplon = tmplon + c360
 
              ! error check differences between internally generated lons and those read in
-             diff_lon = abs(mod(lonMesh(n) - tmplon,360.0))
+             diff_lon = abs(mod(c2*c360+lonMesh(n),c360) - mod(c2*c360+lon(n),c360))
              if (diff_lon > eps_imesh ) then
                 write(6,100)n,lonMesh(n),tmplon, diff_lon
                 !call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)

--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -644,12 +644,12 @@ contains
              endif
              if (abs(diff_lon) > eps_imesh ) then
                 write(6,100)n,lonMesh(n),lon(n), diff_lon
-                !call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)
+                call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)
              end if
              diff_lat = abs(latMesh(n) - lat(n))
              if (diff_lat > eps_imesh) then
                 write(6,101)n,latMesh(n),lat(n), diff_lat
-                !call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)
+                call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)
              end if
           enddo
        enddo


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Fix mesh check when comparing CICE longitude to mesh longitude.
- [X] Developer(s): 
@jedwards4b (J. Edwards)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Only impacts NUOPC/CMEPS driver. Tested in CESM and UFS. Just changes the log output.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
It was something weird with the mod function where it was not detecting that 359.9 and 0. were the same.