### PR TITLE
Modification of edge mask computation when l_fixed_area=T in horizontal remapping

### DIFF
--- a/cicecore/cicedyn/dynamics/ice_transport_driver.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_driver.F90
@@ -37,9 +37,6 @@
                      ! 'upwind' => 1st order donor cell scheme
                      ! 'remap' => remapping scheme
 
-      logical, parameter :: &
-         l_fixed_area = .false. ! if true, prescribe area flux across each edge
-
 ! NOTE: For remapping, hice and hsno are considered tracers.
 !       ntrace is not equal to ntrcr!
 
@@ -81,6 +78,7 @@
       use ice_state, only: trcr_depend
       use ice_timers, only: ice_timer_start, ice_timer_stop, timer_advect
       use ice_transport_remap, only: init_remap
+      use ice_grid, only: grid_ice
 
       integer (kind=int_kind) ::       &
          k, nt, nt1     ! tracer indices
@@ -236,7 +234,7 @@
       endif ! master_task
  1000 format (1x,a,2x,i6,2x,i6,2x,i4,4x,l4)
 
-      if (trim(advection)=='remap') call init_remap    ! grid quantities
+      if (trim(advection)=='remap') call init_remap (grid_ice) ! grid quantities
 
       call ice_timer_stop(timer_advect)  ! advection
 
@@ -545,7 +543,6 @@
           call horizontal_remap (dt,             ntrace,         &
                                  uvel   (:,:,:), vvel   (:,:,:), &
                                  aim  (:,:,:,:), trm(:,:,:,:,:), &
-                                 l_fixed_area,                   &
                                  tracer_type,    depend,         &
                                  has_dependents, integral_order, &
                                  l_dp_midpt,     grid_ice,       &
@@ -554,7 +551,6 @@
           call horizontal_remap (dt,             ntrace,         &
                                  uvel   (:,:,:), vvel   (:,:,:), &
                                  aim  (:,:,:,:), trm(:,:,:,:,:), &
-                                 l_fixed_area,                   &
                                  tracer_type,    depend,         &
                                  has_dependents, integral_order, &
                                  l_dp_midpt,     grid_ice)

--- a/cicecore/cicedyn/dynamics/ice_transport_driver.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_driver.F90
@@ -234,7 +234,7 @@
       endif ! master_task
  1000 format (1x,a,2x,i6,2x,i6,2x,i4,4x,l4)
 
-      if (trim(advection)=='remap') call init_remap (grid_ice) ! grid quantities
+      if (trim(advection)=='remap') call init_remap ! grid quantities
 
       call ice_timer_stop(timer_advect)  ! advection
 
@@ -545,7 +545,7 @@
                                  aim  (:,:,:,:), trm(:,:,:,:,:), &
                                  tracer_type,    depend,         &
                                  has_dependents, integral_order, &
-                                 l_dp_midpt,     grid_ice,       &
+                                 l_dp_midpt,                     &
                                  uvelE  (:,:,:), vvelN  (:,:,:))
       else
           call horizontal_remap (dt,             ntrace,         &
@@ -553,7 +553,7 @@
                                  aim  (:,:,:,:), trm(:,:,:,:,:), &
                                  tracer_type,    depend,         &
                                  has_dependents, integral_order, &
-                                 l_dp_midpt,     grid_ice)
+                                 l_dp_midpt)
       endif
 
       !-------------------------------------------------------------------

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1838,7 +1838,7 @@
       !     BL   |   BC   |   BR     (bottom left, center, right)
       !          |        |
       !
-      ! and the transport is across the edge between cells TC and TB.
+      ! and the transport is across the edge between cells TC and BC.
       !
       ! Departure points are scaled to a local coordinate system
       !  whose origin is at the midpoint of the edge.

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -317,7 +317,7 @@
       !-------------------------------------------------------------------
 
       if (grid_ice == 'CD' .or. grid_ice == 'C') then
-         l_fixed_area = .true.
+         l_fixed_area = .false. !jlem temporary
       else
          l_fixed_area = .false.
       endif

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1951,21 +1951,9 @@
       ! Compute mask for edges with nonzero departure areas
       !-------------------------------------------------------------------
 
-      if (l_fixed_area) then
-         icellsd = 0
+      icellsd = 0
+      if (trim(edge) == 'north') then
          do j = jb, je
-         do i = ib, ie
-            if (edgearea(i,j) /= c0) then
-               icellsd = icellsd + 1
-               indxid(icellsd) = i
-               indxjd(icellsd) = j
-            endif
-         enddo
-         enddo
-      else
-         icellsd = 0
-         if (trim(edge) == 'north') then
-            do j = jb, je
             do i = ib, ie
                if (dpx(i-1,j)/=c0 .or. dpy(i-1,j)/=c0   &
                                   .or.                  &
@@ -1975,9 +1963,9 @@
                   indxjd(icellsd) = j
                endif
             enddo
-            enddo
-         else       ! east edge
-            do j = jb, je
+         enddo
+      else       ! east edge
+         do j = jb, je
             do i = ib, ie
                if (dpx(i,j-1)/=c0 .or. dpy(i,j-1)/=c0   &
                                   .or.                  &
@@ -1987,9 +1975,8 @@
                   indxjd(icellsd) = j
                endif
             enddo
-            enddo
-         endif       ! edge = north/east
-      endif          ! l_fixed_area
+         enddo
+      endif       ! edge = north/east
 
       !-------------------------------------------------------------------
       ! Scale the departure points

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -384,18 +384,6 @@
       character (len=char_len_long), intent(in) :: &
          grid_ice ! ice grid, B, C, etc
 
-      !-------------------------------------------------------------------
-      ! If l_fixed_area is true, the area of each departure region is
-      !  computed in advance (e.g., by taking the divergence of the
-      !  velocity field and passed to locate_triangles.  The departure
-      !  regions are adjusted to obtain the desired area.
-      ! If false, edgearea is computed in locate_triangles and passed out.
-      !-------------------------------------------------------------------
-
-!      logical, intent(in) ::    &
-!         l_fixed_area       ! if true, edgearea_e and edgearea_n are prescribed
-                            ! if false, edgearea is computed here and passed out
-
       integer (kind=int_kind), dimension (ntrace), intent(in) :: &
          tracer_type    , & ! = 1, 2, or 3 (see comments above)
          depend             ! tracer dependencies (see above)

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1954,27 +1954,27 @@
       icellsd = 0
       if (trim(edge) == 'north') then
          do j = jb, je
-            do i = ib, ie
-               if (dpx(i-1,j)/=c0 .or. dpy(i-1,j)/=c0   &
-                                  .or.                  &
-                     dpx(i,j)/=c0 .or.   dpy(i,j)/=c0) then
-                  icellsd = icellsd + 1
-                  indxid(icellsd) = i
-                  indxjd(icellsd) = j
-               endif
-            enddo
+         do i = ib, ie
+            if (dpx(i-1,j)/=c0 .or. dpy(i-1,j)/=c0   &
+                               .or.                  &
+                  dpx(i,j)/=c0 .or.   dpy(i,j)/=c0) then
+               icellsd = icellsd + 1
+               indxid(icellsd) = i
+               indxjd(icellsd) = j
+            endif
+         enddo
          enddo
       else       ! east edge
          do j = jb, je
-            do i = ib, ie
-               if (dpx(i,j-1)/=c0 .or. dpy(i,j-1)/=c0   &
-                                  .or.                  &
-                     dpx(i,j)/=c0 .or.   dpy(i,j)/=c0) then
-                  icellsd = icellsd + 1
-                  indxid(icellsd) = i
-                  indxjd(icellsd) = j
-               endif
-            enddo
+         do i = ib, ie
+            if (dpx(i,j-1)/=c0 .or. dpy(i,j-1)/=c0   &
+                               .or.                  &
+                  dpx(i,j)/=c0 .or.   dpy(i,j)/=c0) then
+               icellsd = icellsd + 1
+               indxid(icellsd) = i
+               indxjd(icellsd) = j
+            endif
+         enddo
          enddo
       endif       ! edge = north/east
 

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -42,6 +42,7 @@
       use ice_exit, only: abort_ice
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
       use icepack_intfc, only: icepack_query_parameters
+      use ice_grid, only : grid_ice
 
       implicit none
       private
@@ -59,6 +60,8 @@
 
       logical :: &
          l_fixed_area ! if true, prescribe area flux across each edge
+                      ! if false, area flux is determined internally
+                      ! and is passed out
 
       logical (kind=log_kind), parameter :: bugcheck = .false.
 
@@ -256,15 +259,12 @@
 !
 ! author William H. Lipscomb, LANL
 
-      subroutine init_remap (grid_ice)
+      subroutine init_remap
 
       use ice_domain, only: nblocks
       use ice_grid, only: xav, yav, xxav, yyav
 !                          dxT, dyT, xyav, &
 !                          xxxav, xxyav, xyyav, yyyav
-
-      character (len=char_len_long), intent(in) :: &
-         grid_ice ! ice grid, B, C, etc
 
       integer (kind=int_kind) ::     &
         i, j, iblk     ! standard indices
@@ -348,7 +348,7 @@
                                    tracer_type,    depend,   &
                                    has_dependents,           &
                                    integral_order,           &
-                                   l_dp_midpt,     grid_ice, &
+                                   l_dp_midpt,               &
                                    uvelE,          vvelN)
 
       use ice_boundary, only: ice_halo, ice_HaloMask, ice_HaloUpdate, &
@@ -380,9 +380,6 @@
 
       real (kind=dbl_kind), intent(inout), dimension (nx_block,ny_block,ntrace,ncat,max_blocks) :: &
          tm       ! mean tracer values in each grid cell
-
-      character (len=char_len_long), intent(in) :: &
-         grid_ice ! ice grid, B, C, etc
 
       integer (kind=int_kind), dimension (ntrace), intent(in) :: &
          tracer_type    , & ! = 1, 2, or 3 (see comments above)
@@ -732,8 +729,7 @@
                                dxu   (:,:,iblk),  dyu(:,:,iblk),      &
                                xp    (:,:,:,:),   yp (:,:,:,:),       &
                                iflux,             jflux,              &
-                               triarea,                               &
-                               l_fixed_area,      edgearea_e(:,:))
+                               triarea,           edgearea_e(:,:))
 
          !-------------------------------------------------------------------
          ! Given triangle vertices, compute coordinates of triangle points
@@ -792,8 +788,7 @@
                                dxu   (:,:,iblk),  dyu (:,:,iblk),     &
                                xp    (:,:,:,:),   yp(:,:,:,:),        &
                                iflux,             jflux,              &
-                               triarea,                               &
-                               l_fixed_area,      edgearea_n(:,:))
+                               triarea,           edgearea_n(:,:))
 
          call triangle_coordinates (nx_block,        ny_block,         &
                                     integral_order,  icellsng(:,iblk), &
@@ -1712,8 +1707,7 @@
                                    dxu,          dyu,        &
                                    xp,           yp,         &
                                    iflux,        jflux,      &
-                                   triarea,                  &
-                                   l_fixed_area, edgearea)
+                                   triarea,      edgearea)
 
       integer (kind=int_kind), intent(in) ::   &
          nx_block, ny_block, & ! block dimensions
@@ -1745,12 +1739,6 @@
       integer (kind=int_kind), dimension (nx_block*ny_block,ngroups), intent(out) :: &
          indxi        , & ! compressed index in i-direction
          indxj            ! compressed index in j-direction
-
-      logical, intent(in) ::   &
-         l_fixed_area     ! if true, the area of each departure region is
-                          !  passed in as edgearea
-                          ! if false, edgearea if determined internally
-                          !  and is passed out
 
       real (kind=dbl_kind), dimension(nx_block,ny_block), intent(inout) ::   &
          edgearea         ! area of departure region for each edge

--- a/doc/source/science_guide/sg_horiztrans.rst
+++ b/doc/source/science_guide/sg_horiztrans.rst
@@ -477,15 +477,9 @@ Remote Sensing Center (Norway), who applied an earlier version of the
 CICE remapping scheme to an ocean model. The implementation in CICE
 is somewhat more general, allowing for departure regions lying on both
 sides of a cell edge. The extra triangle is constrained to lie in one
-but not both of the grid cells that share the edge. 
-
-The default value for the B grid is `l\_fixed\_area` = false. However, 
-idealized tests with the C grid have shown that prognostic fields such 
-as sea ice concentration exhibit a checkerboard pattern with 
-`l\_fixed\_area` = false. The logical `l\_fixed\_area` is therefore set 
-to true when using the C grid. The edge areas `edgearea\_e` and `edgearea\_n` 
-are in this case calculated with the C grid velocity components :math:`uvelE` 
-and :math:`vvelN`.
+but not both of the grid cells that share the edge. Since this option
+has yet to be fully tested in CICE, the current default is
+`l\_fixed\_area` = false.
 
 We made one other change in the scheme of :cite:`Dukowicz00` for
 locating triangles. In their paper, departure points are defined by

--- a/doc/source/science_guide/sg_horiztrans.rst
+++ b/doc/source/science_guide/sg_horiztrans.rst
@@ -39,7 +39,7 @@ remapping scheme of :cite:`Dukowicz00` as modified for sea ice by
 
 - The upwind scheme uses velocity points at the East and North face (i.e. :math:`uvelE=u` at the E point and :math:`vvelN=v` at  the N point) of a T gridcell.  As such, the prognostic C grid velocity components (:math:`uvelE` and :math:`vvelN`) can be passed directly to the upwind transport scheme.  If the upwind scheme is used with the B grid, the B grid velocities, :math:`uvelU` and :math:`vvelU` (respectively :math:`u` and :math:`v` at the U point) are interpolated to the E and N points first.  (Note however that the upwind scheme does not transport all potentially available tracers.)
 
-- The remapping scheme uses :math:`uvelU` and :math:`vvelU` if l_fixed_area is false and :math:`uvelE` and :math:`vvelN` if l_fixed_area is true.  l_fixed_area is hardcoded to false by default and further described below.  As such, the B grid velocities (:math:`uvelU` and :math:`vvelU`) are used directly in the remapping scheme, while the C grid velocities (:math:`uvelE` and :math:`vvelN`) are interpolated to U points first.  If l_fixed_area is changed to true, then the reverse is true.  The C grid velocities are used directly and the B grid velocities are interpolated.
+- Remapping is naturally a B-grid transport scheme as the corner (U point) velocity components :math:`uvelU` and :math:`vvelU` are used to calculate departure points. Nevertheless, the remapping scheme can also be used with the C grid by first interpolating :math:`uvelE` and :math:`vvelN` to the U points.
 
 The remapping scheme has several desirable features:
 
@@ -477,9 +477,15 @@ Remote Sensing Center (Norway), who applied an earlier version of the
 CICE remapping scheme to an ocean model. The implementation in CICE
 is somewhat more general, allowing for departure regions lying on both
 sides of a cell edge. The extra triangle is constrained to lie in one
-but not both of the grid cells that share the edge. Since this option
-has yet to be fully tested in CICE, the current default is
-`l\_fixed\_area` = false.
+but not both of the grid cells that share the edge. 
+
+The default value for the B grid is `l\_fixed\_area` = false. However, 
+idealized tests with the C grid have shown that prognostic fields such 
+as sea ice concentration exhibit a checkerboard pattern with 
+`l\_fixed\_area` = false. The logical `l\_fixed\_area` is therefore set 
+to true when using the C grid. The edge areas `edgearea\_e` and `edgearea\_n` 
+are in this case calculated with the C grid velocity components :math:`uvelE` 
+and :math:`vvelN`.
 
 We made one other change in the scheme of :cite:`Dukowicz00` for
 locating triangles. In their paper, departure points are defined by


### PR DESCRIPTION


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
   gx3, gx1 C grid simulations were previously crashing with horizontal remapping and  l_fixed_area=T. This modification corrects this problem. See issue #809 for details.
- [x] Developer(s): 
    @JFLemieux73 
- [x] Suggest PR reviewers from list in the column to the right.
    @eclare108213 
- [x] Please copy the PR test results link or provide a summary of testing completed below.

349 measured results of 349 total results
349 of 349 tests PASSED
0 of 349 tests PENDING
0 of 349 tests MISSING data
0 of 349 tests FAILED

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
    Another PR will follow and will add a test case. I will also modify the code so that l_fixed_area=T when the C grid (and remap) is used. See issue #832.
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [x] Yes
        - [ ] No 
- [x] Please provide any additional information or relevant details below:
