### PR TITLE
Namelist option for time axis position.

### DIFF
--- a/cicecore/cicedyn/analysis/ice_history_shared.F90
+++ b/cicecore/cicedyn/analysis/ice_history_shared.F90
@@ -132,6 +132,8 @@
                                        time_end(max_nstrm), &
                                        time_bounds(2)
 
+      character (len=char_len), public :: hist_time_axis
+
       real (kind=dbl_kind), allocatable, public :: &
          a2D (:,:,:,:)    , & ! field accumulations/averages, 2D
          a3Dz(:,:,:,:,:)  , & ! field accumulations/averages, 3D vertical

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -1575,7 +1575,8 @@
       endif
 
       if(trim(hist_time_axis) /= 'begin' .and. trim(hist_time_axis) /= 'middle' .and. trim(hist_time_axis) /= 'end') then
-         write (nu_diag,*) subname//' WARNING: hist_time_axis set to default end '
+         write (nu_diag,*) subname//' ERROR: hist_time_axis value not valid = '//trim(hist_time_axis)
+         abort_list = trim(abort_list)//":29"
       endif
 
       if(dumpfreq_base /= 'init' .and. dumpfreq_base /= 'zero') then

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -325,7 +325,7 @@
       histfreq_base = 'zero' ! output frequency reference date
       hist_avg(:) = .true.   ! if true, write time-averages (not snapshots)
       history_format = 'default' ! history file format
-      hist_time_axis = 'end' ! History file time axis interval position
+      hist_time_axis = 'end' ! History file time axis averaging interval position
 
       history_dir  = './'    ! write to executable dir for default
       history_file = 'iceh'  ! history file name prefix

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -81,7 +81,7 @@
           runid, runtype, use_restart_time, restart_format, lcdf64
       use ice_history_shared, only: hist_avg, history_dir, history_file, &
                              incond_dir, incond_file, version_name, &
-                             history_precision, history_format
+                             history_precision, history_format, hist_time_axis
       use ice_flux, only: update_ocn_f, l_mpond_fresh
       use ice_flux, only: default_season
       use ice_flux_bgc, only: cpl_bgc
@@ -185,6 +185,7 @@
         restart_ext,    use_restart_time, restart_format, lcdf64,       &
         pointer_file,   dumpfreq,       dumpfreq_n,      dump_last,     &
         diagfreq,       diag_type,      diag_file,       history_format,&
+        hist_time_axis,                                                 &
         print_global,   print_points,   latpnt,          lonpnt,        &
         debug_forcing,  histfreq,       histfreq_n,      hist_avg,      &
         history_dir,    history_file,   history_precision, cpl_bgc,     &
@@ -324,6 +325,8 @@
       histfreq_base = 'zero' ! output frequency reference date
       hist_avg(:) = .true.   ! if true, write time-averages (not snapshots)
       history_format = 'default' ! history file format
+      hist_time_axis = 'end' ! History file time axis interval position
+
       history_dir  = './'    ! write to executable dir for default
       history_file = 'iceh'  ! history file name prefix
       history_precision = 4  ! precision of history files
@@ -906,6 +909,7 @@
       call broadcast_scalar(history_file,         master_task)
       call broadcast_scalar(history_precision,    master_task)
       call broadcast_scalar(history_format,       master_task)
+      call broadcast_scalar(hist_time_axis,       master_task)
       call broadcast_scalar(write_ic,             master_task)
       call broadcast_scalar(cpl_bgc,              master_task)
       call broadcast_scalar(incond_dir,           master_task)
@@ -2316,6 +2320,7 @@
          write(nu_diag,1031) ' history_file     = ', trim(history_file)
          write(nu_diag,1021) ' history_precision= ', history_precision
          write(nu_diag,1031) ' history_format   = ', trim(history_format)
+         write(nu_diag,1031) ' hist_time_axis   = ', trim(hist_time_axis)
          if (write_ic) then
             write(nu_diag,1039) ' Initial condition will be written in ', &
                                trim(incond_dir)

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -1574,6 +1574,10 @@
          abort_list = trim(abort_list)//":24"
       endif
 
+      if(trim(hist_time_axis) /= 'begin' .and. trim(hist_time_axis) /= 'middle' .and. trim(hist_time_axis) /= 'end') then
+         write (nu_diag,*) subname//' WARNING: hist_time_axis set to default end '
+      endif
+
       if(dumpfreq_base /= 'init' .and. dumpfreq_base /= 'zero') then
          write (nu_diag,*) subname//' ERROR: bad value for dumpfreq_base, allowed values: init, zero'
          abort_list = trim(abort_list)//":25"

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -747,13 +747,12 @@
       !-----------------------------------------------------------------
       ! write time variable
       !-----------------------------------------------------------------
+       
+        ltime2 = timesecs/secday ! hist_time_axis = 'end' (default)
 
-        if (trim(hist_time_axis) == 'begin') then
-           ltime2 = time_beg(ns)
-        elseif (trim(hist_time_axis) == 'middle') then
-           ltime2 = p5*(time_beg(ns)+time_end(ns))
-        else ! hist_time_axis == 'end' (default)
-           ltime2 = timesecs/secday
+        if (hist_avg(ns)) then
+           if (trim(hist_time_axis) == "begin" ) ltime2 = time_beg(ns)
+           if (trim(hist_time_axis) == "middle") ltime2 = p5*(time_beg(ns)+time_end(ns))
         endif
        
         status = nf90_inq_varid(ncid,'time',varid)

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -21,7 +21,7 @@
 
       module ice_history_write
 
-      use ice_constants, only: c0, c360, spval, spval_dbl
+      use ice_constants, only: c0, c360, p5, spval, spval_dbl
       use ice_fileunits, only: nu_diag
       use ice_exit, only: abort_ice
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
@@ -136,8 +136,6 @@
       if (history_precision == 8) lprecision = nf90_double
 
       if (my_task == master_task) then
-
-        ltime2 = timesecs/secday
 
         call construct_filename(ncfile(ns),'nc',ns)
 
@@ -750,6 +748,14 @@
       ! write time variable
       !-----------------------------------------------------------------
 
+        if (trim(hist_time_axis) == 'begin') then
+           ltime2 = time_beg(ns)
+        elseif (trim(hist_time_axis) == 'middle') then
+           ltime2 = p5*(time_beg(ns)+time_end(ns))
+        else ! hist_time_axis == 'end' (default)
+           ltime2 = timesecs/secday
+        endif
+       
         status = nf90_inq_varid(ncid,'time',varid)
         if (status /= nf90_noerr) call abort_ice(subname// &
                       'ERROR: getting time varid')

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -716,6 +716,12 @@
                          'ERROR: global attribute time_period_freq')
         endif
 
+        if (hist_avg(ns)) then
+           status = nf90_put_att(ncid,nf90_global,'time_axis_position',trim(hist_time_axis))
+           if (status /= nf90_noerr) call abort_ice(subname// &
+                         'ERROR: global attribute time axis position')
+        endif
+
         title = 'CF-1.0'
         status =  &
              nf90_put_att(ncid,nf90_global,'conventions',title)

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -750,6 +750,8 @@
        
         ltime2 = timesecs/secday ! hist_time_axis = 'end' (default)
 
+        ! Some coupled models require the time axis "stamp" to be in the middle
+        ! or even beginning of averaging interval.
         if (hist_avg(ns)) then
            if (trim(hist_time_axis) == "begin" ) ltime2 = time_beg(ns)
            if (trim(hist_time_axis) == "middle") ltime2 = p5*(time_beg(ns)+time_end(ns))

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -704,12 +704,11 @@
       ! write time variable
       !-----------------------------------------------------------------
 
-        if (trim(hist_time_axis) == 'begin') then
-           ltime2 = time_beg(ns)
-        elseif (trim(hist_time_axis) == 'middle') then
-           ltime2 = p5*(time_beg(ns)+time_end(ns))
-        else ! hist_time_axis == 'end' (default)
-           ltime2 = timesecs/secday
+        ltime2 = timesecs/secday ! hist_time_axis = 'end' (default)
+
+        if (hist_avg(ns)) then
+           if (trim(hist_time_axis) == "begin" ) ltime2 = time_beg(ns)
+           if (trim(hist_time_axis) == "middle") ltime2 = p5*(time_beg(ns)+time_end(ns))
         endif
        
         status = pio_inq_varid(File,'time',varid)

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -18,7 +18,7 @@
       module ice_history_write
 
       use ice_kinds_mod
-      use ice_constants, only: c0, c360, spval, spval_dbl
+      use ice_constants, only: c0, c360, p5, spval, spval_dbl
       use ice_fileunits, only: nu_diag
       use ice_exit, only: abort_ice
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
@@ -184,8 +184,6 @@
       call ice_pio_initdecomp(ndim3=nzilyr,    ndim4=ncat_hist, iodesc=iodesc4di, precision=history_precision)
       call ice_pio_initdecomp(ndim3=nzslyr,    ndim4=ncat_hist, iodesc=iodesc4ds, precision=history_precision)
       call ice_pio_initdecomp(ndim3=nfsd_hist, ndim4=ncat_hist, iodesc=iodesc4df, precision=history_precision)
-
-      ltime2 = timesecs/secday
 
       ! option of turning on double precision history files
       lprecision = pio_real
@@ -706,6 +704,14 @@
       ! write time variable
       !-----------------------------------------------------------------
 
+        if (trim(hist_time_axis) == 'begin') then
+           ltime2 = time_beg(ns)
+        elseif (trim(hist_time_axis) == 'middle') then
+           ltime2 = p5*(time_beg(ns)+time_end(ns))
+        else ! hist_time_axis == 'end' (default)
+           ltime2 = timesecs/secday
+        endif
+       
         status = pio_inq_varid(File,'time',varid)
         status = pio_put_var(File,varid,(/1/),ltime2)
 

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -676,6 +676,9 @@
            status = pio_put_att(File,pio_global,'time_period_freq',trim(time_period_freq))
         endif
 
+        if (hist_avg(ns)) &
+           status = pio_put_att(File,pio_global,'time_axis_position',trim(hist_time_axis))
+
         title = 'CF-1.0'
         status =  &
              pio_put_att(File,pio_global,'conventions',trim(title))

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -706,6 +706,8 @@
 
         ltime2 = timesecs/secday ! hist_time_axis = 'end' (default)
 
+        ! Some coupled models require the time axis "stamp" to be in the middle
+        ! or even beginning of averaging interval.
         if (hist_avg(ns)) then
            if (trim(hist_time_axis) == "begin" ) ltime2 = time_beg(ns)
            if (trim(hist_time_axis) == "middle") ltime2 = p5*(time_beg(ns)+time_end(ns))

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -53,6 +53,7 @@
     history_file   = 'iceh'
     history_precision = 4
     history_format = 'default'
+    hist_time_axis = 'end'
     write_ic       = .true.
     incond_dir     = './history/'
     incond_file    = 'iceh_ic'

--- a/doc/source/cice_index.rst
+++ b/doc/source/cice_index.rst
@@ -322,6 +322,7 @@ either Celsius or Kelvin units).  Deprecated parameters are listed at the end.
    "history_file", "history output file prefix", ""
    "history_format", "history file format", ""
    "history_precision", "history output precision: 4 or 8 byte", "4"
+   "hist_time_axis", "history file time axis interval location: begin, middle, end", "end"
    "hm", "land/boundary mask, thickness (T-cell)", ""
    "hmix", "ocean mixed layer depth", "20. m"
    "hour", "hour of the year", ""

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -191,6 +191,7 @@ setup_nml
    "``history_format``", "``default``", "read/write history files in default format", "``default``"
    "", "``pio_pnetcdf``", "read/write restart files with pnetcdf in pio", ""
    "``history_precision``", "integer", "history file precision: 4 or 8 byte", "4"
+   "``hist_time_axis``","character","history file time axis interval location: begin, middle, end","end"
    "``ice_ic``", "``default``", "equal to internal", "``default``"
    "", "``internal``", "initial conditions set based on ice\_data\_type,conc,dist inputs", ""
    "", "``none``", "no ice", ""

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -1197,8 +1197,10 @@ with a given ``histfreq`` value, or if an element of ``histfreq_n`` is 0, then
 no file will be written at that frequency. The output period can be
 discerned from the filenames.  All history streams will be either instantaneous
 or averaged as specified by the ``hist_avg`` namelist setting and the frequency
-will be relative to a reference date specified by ``histfreq_base``.  More
-information about how the frequency is computed is found in :ref:`timemanager`.
+will be relative to a reference date specified by ``histfreq_base``.  Also, some
+Earth Sytem Models require the history file time axis to be centered in the averaging
+interval. The flag ``hist_time_axis`` will allow the user to chose ``begin``, ``middle``,
+or ``end``. More information about how the frequency is computed is found in :ref:`timemanager`.
 
 For example, in the namelist:
 

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -1200,7 +1200,8 @@ or averaged as specified by the ``hist_avg`` namelist setting and the frequency
 will be relative to a reference date specified by ``histfreq_base``.  Also, some
 Earth Sytem Models require the history file time axis to be centered in the averaging
 interval. The flag ``hist_time_axis`` will allow the user to chose ``begin``, ``middle``,
-or ``end``. More information about how the frequency is computed is found in :ref:`timemanager`.
+or ``end`` for the time stamp. More information about how the frequency is 
+computed is found in :ref:`timemanager`.
 
 For example, in the namelist:
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
Added a namelist option for time axis position.
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#2efc26cddef840801d5ed1e5322e6502f1120683
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:
This is a first attempt to address the need for issue #828 . The default behavior is hist_time_axis = 'end' (backward compatible) and is only used when hist_avg is true.