### PR TITLE
More accurate calculation of areafact in remapping

### DIFF
--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -317,7 +317,7 @@
       !-------------------------------------------------------------------
 
       if (grid_ice == 'CD' .or. grid_ice == 'C') then
-         l_fixed_area = .false. !jlem temporary
+         l_fixed_area = .true.
       else
          l_fixed_area = .false.
       endif

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -2553,7 +2553,7 @@
             areafact(i,j,ng) = areatp
             !areafact(i,j,ng) = areafac_c(i,j)
 
-         elseif (ydl <= c0 .and. ydr <= c0 .and. ydm < c0) then
+         elseif (ydl <= c0 .and. ydr <= c0 .and. ydm <= c0) then ! Bill I also changed ydm < to <=
 
             ! compute areafac for quadrilateral cl-cr-dr-dl
             xpm = p25*(xcl + xcr + xdr + xdl)
@@ -2601,7 +2601,7 @@
             areafact(i,j,ng) = areatp
             !areafact(i,j,ng) = areafac_c(i,j)
 
-         elseif (ydl <= c0 .and. ydr <= c0 .and. ydm >= c0) then  ! rare
+         elseif (ydl <= c0 .and. ydr <= c0 .and. ydm > c0) then  ! rare ! Bill I also changed ydm >= to >
 
             ! compute areafac for quadrilateral cl-cr-dr-dl
             xpm = p25*(xcl + xcr + xdr + xdl)
@@ -2653,8 +2653,8 @@
          ! For these cases, one triangle is given the area factor associated
          !  with the adjacent corner, to avoid rare negative masses on curved grids.
 
-         elseif (ydl >= c0 .and. ydr < c0 .and. xic >= c0  &
-                                          .and. ydm >= c0) then
+         elseif (ydl > c0 .and. ydr < c0 .and. xic >= c0  &
+                                         .and. ydm >= c0) then
 
             ! compute areafac for left triangle cl-dl-ic
             xpm = p333*(xcl + xdl + xic)
@@ -2704,8 +2704,8 @@
             areafact(i,j,ng) = -areatp
             !areafact(i,j,ng) = -areafac_c(i,j)
 
-         elseif (ydl >= c0 .and. ydr < c0 .and. xic >= c0  &
-                                          .and. ydm < c0 ) then  ! less common
+         elseif (ydl > c0 .and. ydr < c0 .and. xic >= c0  &
+                                         .and. ydm < c0 ) then  ! less common
 
             ! compute areafac for left triangle cl-dl-ic
             xpm = p333*(xcl + xdl + xic)
@@ -2755,8 +2755,8 @@
             areafact(i,j,ng) = areatp
             !areafact(i,j,ng) = areafac_c(i,j)
 
-         elseif (ydl >= c0 .and. ydr < c0 .and. xic < c0   &
-                                          .and. ydm < c0) then
+         elseif (ydl > c0 .and. ydr < c0 .and. xic < c0   &
+                                         .and. ydm < c0) then
 
             ! compute areafac for right triangle ic-cr-dr
             xpm = p333*(xic + xcr + xdr)
@@ -2806,8 +2806,8 @@
             areafact(i,j,ng) = areatp
             !areafact(i,j,ng) = areafac_c(i,j)
 
-         elseif (ydl >= c0 .and. ydr < c0 .and. xic <  c0  &
-                                          .and. ydm >= c0) then  ! less common
+         elseif (ydl > c0 .and. ydr < c0 .and. xic <  c0  &
+                                         .and. ydm >= c0) then  ! less common
 
             ! compute areafac for right triangle ic-cr-dr
             xpm = p333*(xic + xcr + xdr)
@@ -2857,8 +2857,8 @@
             areafact(i,j,ng) = -areatp
             !areafact(i,j,ng) = -areafac_c(i,j)
 
-         elseif (ydl < c0 .and. ydr >= c0 .and. xic <  c0  &
-                                          .and. ydm >= c0) then
+         elseif (ydl < c0 .and. ydr > c0 .and. xic <  c0  &
+                                         .and. ydm >= c0) then
 
             ! compute areafac for right triangle ic-cr-dr
             xpm = p333*(xic + xcr + xdr)
@@ -2908,8 +2908,8 @@
             areafact(i,j,ng) = -areatp
             !areafact(i,j,ng) = -areafac_c(i,j)
 
-         elseif (ydl < c0 .and. ydr >= c0 .and. xic < c0  &
-                                          .and. ydm < c0) then ! less common
+         elseif (ydl < c0 .and. ydr > c0 .and. xic < c0  &
+                                         .and. ydm < c0) then ! less common
 
             ! compute areafac for right triangle ic-cr-dr
             xpm = p333*(xic + xcr + xdr)
@@ -2959,8 +2959,8 @@
             areafact(i,j,ng) = areatp
             !areafact(i,j,ng) = areafac_c(i,j)
 
-         elseif (ydl < c0 .and. ydr >= c0 .and. xic >= c0  &
-                                          .and. ydm <  c0) then
+         elseif (ydl < c0 .and. ydr > c0 .and. xic >= c0  &
+                                         .and. ydm <  c0) then
 
             ! compute areafac for left triangle cl-dl-ic
             xpm = p333*(xcl + xdl + xic)
@@ -3010,8 +3010,8 @@
             areafact(i,j,ng) = areatp
             !areafact(i,j,ng) = areafac_c(i,j)
 
-         elseif (ydl < c0 .and. ydr >= c0 .and. xic >= c0   &
-                                          .and. ydm >= c0) then  ! less common
+         elseif (ydl < c0 .and. ydr > c0 .and. xic >= c0   &
+                                         .and. ydm >= c0) then  ! less common
 
             ! compute areafac for left triangle cl-dl-ic
             xpm = p333*(xcl + xdl + xic)

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1762,6 +1762,8 @@
          ishift_br, jshift_br , & ! i,j indices of BR cell relative to edge
          ishift_tc, jshift_tc , & ! i,j indices of TC cell relative to edge
          ishift_bc, jshift_bc , & ! i,j indices of BC cell relative to edge
+         is_l, js_l           , & ! index shifts for TL1 and BL2 for tri area consistency 
+         is_r, js_r           , & ! index shifts for TR1 and BR2 for tri area consistency 
          ise_tl, jse_tl       , & ! i,j of TL other edge relative to edge
          ise_bl, jse_bl       , & ! i,j of BL other edge relative to edge
          ise_tr, jse_tr       , & ! i,j of TR other edge relative to edge
@@ -1906,6 +1908,13 @@
          ishift_bc =  0
          jshift_bc =  0
 
+         ! index shifts for TL1, BL2, TR1 and BR2 for triangle area consistency 
+
+         is_l = -1
+         js_l =  0
+         is_r = +1
+         js_r =  0
+
          ! index shifts for neighbor east edges
 
          ise_tl = -1
@@ -1949,6 +1958,13 @@
          jshift_tc =  0
          ishift_bc =  0
          jshift_bc =  0
+
+         ! index shifts for TL1, BL2, TR1 and BR2 for triangle area consistency 
+
+         is_l =  0
+         js_l = +1
+         is_r =  0
+         js_r = -1
 
          ! index shifts for neighbor north edges
 
@@ -2128,7 +2144,7 @@
             yp    (i,j,3,ng) = yic
             iflux   (i,j,ng) = i + ishift_tl
             jflux   (i,j,ng) = j + jshift_tl
-            areafact(i,j,ng) = areafac_ce(i+ise_tl,j+jse_tl)
+            areafact(i,j,ng) = areafac_c(i+is_l,j+js_l)
 
             ! BL1 (group 3)
 
@@ -2169,7 +2185,7 @@
             yp    (i,j,3,ng) = ydl
             iflux   (i,j,ng) = i + ishift_bl
             jflux   (i,j,ng) = j + jshift_bl
-            areafact(i,j,ng) = -areafac_ce(i+ise_bl,j+jse_bl)
+            areafact(i,j,ng) = -areafac_c(i+is_l,j+js_l)
 
          endif                  ! TL and BL triangles
 
@@ -2221,7 +2237,7 @@
             yp    (i,j,3,ng) = ydr
             iflux   (i,j,ng) = i + ishift_tr
             jflux   (i,j,ng) = j + jshift_tr
-            areafact(i,j,ng) = areafac_ce(i+ise_tr,j+jse_tr)
+            areafact(i,j,ng) = areafac_c(i+is_r,j+js_r)
 
             ! BR1 (group 3)
 
@@ -2262,7 +2278,7 @@
             yp    (i,j,3,ng) = yic
             iflux   (i,j,ng) = i + ishift_br
             jflux   (i,j,ng) = j + jshift_br
-            areafact(i,j,ng) = -areafac_ce(i+ise_br,j+jse_br)
+            areafact(i,j,ng) = -areafac_c(i+is_r,j+js_r)
 
          endif                  ! TR and BR triangles
 

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -2375,7 +2375,7 @@
                endif
                yicr = c0
 
-            elseif (xic < c0) then  ! fix ICL = IC
+            elseif (xic < c0 .and. xic > xcl) then  ! fix ICL = IC ! Bill please check this
 
                xicl = xic
                yicl = yic
@@ -2410,7 +2410,7 @@
                endif
                yicr = c0
 
-            elseif (xic >= c0) then  ! fix ICR = IR
+            elseif (xic >= c0 .and. xic < xcr) then  ! fix ICR = IR ! Bill please check this
 
                xicr = xic
                yicr = yic
@@ -3101,7 +3101,7 @@
                                      (xp(i,j,3,ng)-xp(i,j,1,ng)) )   &
                                    * areafact(i,j,ng)
 
-            if (abs(triarea(i,j,ng)) < eps16*areafac_c(i,j)) then ! jf ici
+            if (abs(triarea(i,j,ng)) < eps16*areafac_c(i,j)) then ! Bill please check this
                triarea(i,j,ng) = c0
             else
                icells(ng) = icells(ng) + 1
@@ -3120,7 +3120,7 @@
             do ij = 1, icellsd
                i = indxid(ij)
                j = indxjd(ij)
-               if (abs(areasum(i,j) - edgearea(i,j)) > eps13*areafac_c(i,j)) then ! jf ici
+               if (abs(areasum(i,j) - edgearea(i,j)) > eps13*areafac_c(i,j)) then ! Bill please check this
                   write(nu_diag,*) ''
                   write(nu_diag,*) 'Areas do not add up: m, i, j, edge =',   &
                            my_task, i, j, trim(edge)

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1927,17 +1927,18 @@
          jse_br =  0
 
          ! area scale factor
+         ! earea, narea valid on halo
 
-         do j = jlo-1, jhi
-         do i = ilo, ihi
+         do j = 1, ny_block
+         do i = 1, nx_block
             areafac_c(i,j) = narea(i,j)
          enddo
          enddo
 
          ! area scale factor for other edge (east)
          
-         do j = jlo-1, jhi+1
-            do i = ilo-1, ihi
+         do j = 1, ny_block
+         do i = 1, nx_block
             areafac_ce(i,j) = earea(i,j)
          enddo
          enddo
@@ -1978,17 +1979,18 @@
          jse_br = -1
 
          ! area scale factors
+         ! earea, narea valid on halo
 
-         do j = jlo, jhi
-         do i = ilo-1, ihi
+         do j = 1, ny_block
+         do i = 1, nx_block
             areafac_c(i,j) = earea(i,j)
          enddo
          enddo
 
          ! area scale factor for other edge (north)
 
-         do j = jlo-1, jhi
-         do i = ilo-1, ihi+1
+         do j = 1, ny_block
+         do i = 1, nx_block
             areafac_ce(i,j) = narea(i,j)
          enddo
          enddo

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -2348,7 +2348,7 @@
                area_c  = edgearea(i,j) - area1 - area2 - area3
 
                ! shift midpoint so that the area of remaining triangles = area_c
-               w1 = c2*area_c/areafac_c(i,j)    & ! jlem could be improved...
+               w1 = c2*area_c/areafac_c(i,j)    & ! jlem should this be modified?
                     + (xdr-xcl)*ydl + (xcr-xdl)*ydr
                w2 = (xdr-xdl)**2 + (ydr-ydl)**2
                w1 = w1/w2
@@ -2383,11 +2383,11 @@
                ydm = p5 *  ydr
 
                ! compute area of triangle adjacent to left corner
-               area4 = p5 * (xcl - xic) * ydl * areafac_l(i,j) ! jlem could be improved...
+               area4 = p5 * (xcl - xic) * ydl * areafac_l(i,j) ! jlem should this be modified?
                area_c  = edgearea(i,j) - area1 - area2 - area3 - area4
 
                ! shift midpoint so that area of remaining triangles = area_c
-               w1 = c2*area_c/areafac_c(i,j) + (xcr-xic)*ydr ! jlem could be improved...
+               w1 = c2*area_c/areafac_c(i,j) + (xcr-xic)*ydr ! jlem should this be modified?
                w2 = (xdr-xic)**2 + ydr**2
                w1 = w1/w2
                xdm = xdm + ydr*w1
@@ -2411,11 +2411,11 @@
                xdm = p5 * (xicr + xdl)
                ydm = p5 *  ydl
 
-               area4 = p5 * (xic - xcr) * ydr * areafac_r(i,j) ! jlem could be improved...
+               area4 = p5 * (xic - xcr) * ydr * areafac_r(i,j) ! jlem should this be modified?
                area_c  = edgearea(i,j) - area1 - area2 - area3 - area4
 
                ! shift midpoint so that area of remaining triangles = area_c
-               w1 = c2*area_c/areafac_c(i,j) + (xic-xcl)*ydl ! jlem could be improved...
+               w1 = c2*area_c/areafac_c(i,j) + (xic-xcl)*ydl ! jlem should this be modified?
                w2 = (xic-xdl)**2 + ydl**2
                w1 = w1/w2
                xdm = xdm - ydl*w1

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -32,7 +32,7 @@
       use ice_blocks, only: nx_block, ny_block
       use ice_calendar, only: istep1
       use ice_communicate, only: my_task
-      use ice_constants, only: c0, c1, c2, c12, p25, p333, p4, p5, p6, &
+      use ice_constants, only: c0, c1, c2, c12, p333, p4, p5, p6, &
           eps13, eps16, &
           field_loc_center, field_type_scalar, &
           field_loc_NEcorner, field_type_vector
@@ -1986,7 +1986,7 @@
          enddo
          enddo
 
-         ! area scale factor for ther edge (north)
+         ! area scale factor for other edge (north)
 
          do j = jb-1, je
          do i = ib, ie+1
@@ -2118,7 +2118,6 @@
             iflux   (i,j,ng) = i + ishift_tl
             jflux   (i,j,ng) = j + jshift_tl
             areafact(i,j,ng) = -areafac_ce(i+ise_tl,j+jse_tl)
-            !areafact(i,j,ng) = -areafac_l(i,j)
 
          elseif (yil < c0 .and. xdl < xcl .and. ydl < c0) then
 
@@ -2134,7 +2133,6 @@
             iflux   (i,j,ng) = i + ishift_bl
             jflux   (i,j,ng) = j + jshift_bl
             areafact(i,j,ng) = areafac_ce(i+ise_bl,j+jse_bl)
-            !areafact(i,j,ng) = areafac_l(i,j)
 
          elseif (yil < c0 .and. xdl < xcl .and. ydl >= c0) then
 
@@ -2150,7 +2148,6 @@
             iflux   (i,j,ng) = i + ishift_tl
             jflux   (i,j,ng) = j + jshift_tl
             areafact(i,j,ng) = areafac_ce(i+ise_tl,j+jse_tl)
-            !areafact(i,j,ng) = areafac_l(i,j)
 
             ! BL1 (group 3)
 
@@ -2164,7 +2161,6 @@
             iflux   (i,j,ng) = i + ishift_bl
             jflux   (i,j,ng) = j + jshift_bl
             areafact(i,j,ng) = areafac_ce(i+ise_bl,j+jse_bl)
-            !areafact(i,j,ng) = areafac_l(i,j)
 
          elseif (yil > c0 .and. xdl < xcl .and. ydl < c0) then
 
@@ -2180,7 +2176,6 @@
             iflux   (i,j,ng) = i + ishift_tl
             jflux   (i,j,ng) = j + jshift_tl
             areafact(i,j,ng) = -areafac_ce(i+ise_tl,j+jse_tl)
-            !areafact(i,j,ng) = -areafac_l(i,j)
 
             ! BL2 (group 1)
 
@@ -2194,7 +2189,6 @@
             iflux   (i,j,ng) = i + ishift_bl
             jflux   (i,j,ng) = j + jshift_bl
             areafact(i,j,ng) = -areafac_ce(i+ise_bl,j+jse_bl)
-            !areafact(i,j,ng) = -areafac_l(i,j)
 
          endif                  ! TL and BL triangles
 
@@ -2217,7 +2211,6 @@
             iflux   (i,j,ng) = i + ishift_tr
             jflux   (i,j,ng) = j + jshift_tr
             areafact(i,j,ng) = -areafac_ce(i+ise_tr,j+jse_tr)
-            !areafact(i,j,ng) = -areafac_r(i,j)
 
          elseif (yir < c0 .and. xdr >= xcr .and. ydr < c0) then
 
@@ -2233,7 +2226,6 @@
             iflux   (i,j,ng) = i + ishift_br
             jflux   (i,j,ng) = j + jshift_br
             areafact(i,j,ng) = areafac_ce(i+ise_br,j+jse_br)
-            !areafact(i,j,ng) = areafac_r(i,j)
 
          elseif (yir < c0 .and. xdr >= xcr  .and. ydr >= c0) then
 
@@ -2249,7 +2241,6 @@
             iflux   (i,j,ng) = i + ishift_tr
             jflux   (i,j,ng) = j + jshift_tr
             areafact(i,j,ng) = areafac_ce(i+ise_tr,j+jse_tr)
-            !areafact(i,j,ng) = areafac_r(i,j)
 
             ! BR1 (group 3)
 
@@ -2263,7 +2254,6 @@
             iflux   (i,j,ng) = i + ishift_br
             jflux   (i,j,ng) = j + jshift_br
             areafact(i,j,ng) = areafac_ce(i+ise_br,j+jse_br)
-            !areafact(i,j,ng) = areafac_r(i,j)
 
          elseif (yir > c0 .and. xdr >= xcr .and. ydr < c0) then
 
@@ -2279,7 +2269,6 @@
             iflux   (i,j,ng) = i + ishift_tr
             jflux   (i,j,ng) = j + jshift_tr
             areafact(i,j,ng) = -areafac_ce(i+ise_tr,j+jse_tr)
-            !areafact(i,j,ng) = -areafac_r(i,j)
 
             ! BR2 (group 2)
 
@@ -2293,7 +2282,6 @@
             iflux   (i,j,ng) = i + ishift_br
             jflux   (i,j,ng) = j + jshift_br
             areafact(i,j,ng) = -areafac_ce(i+ise_br,j+jse_br)
-            !areafact(i,j,ng) = -areafac_r(i,j)
 
          endif                  ! TR and BR triangles
 
@@ -2349,9 +2337,7 @@
             !  region so that the sum of all triangle areas is equal to the
             !  prescribed value.
             ! If two triangles are in one grid cell and one is in the other,
-            !  then compute the area of the lone triangle using an area factor
-            !  corresponding to the adjacent corner.  This is necessary to prevent
-            !  negative masses in some rare cases on curved grids.  Then adjust
+            !  then compute the area of the lone triangle. Then adjust
             !  the area of the remaining two-triangle region so that the sum of
             !  all triangle areas has the prescribed value.
             !-----------------------------------------------------------
@@ -2397,7 +2383,7 @@
                ydm = p5 *  ydr
 
                ! compute area of (lone) triangle adjacent to left corner
-               area4 = p5 * (xcl - xic) * ydl * areafac_c(i,j) ! Bill check this
+               area4 = p5 * (xcl - xic) * ydl * areafac_c(i,j)
                area_c  = edgearea(i,j) - area1 - area2 - area3 - area4
 
                ! shift midpoint so that area of remaining triangles = area_c
@@ -2426,7 +2412,7 @@
                ydm = p5 *  ydl
 
                ! compute area of (lone) triangle adjacent to right corner
-               area4 = p5 * (xic - xcr) * ydr * areafac_c(i,j) ! Bill check this
+               area4 = p5 * (xic - xcr) * ydr * areafac_c(i,j)
                area_c  = edgearea(i,j) - area1 - area2 - area3 - area4
 
                ! shift midpoint so that area of remaining triangles = area_c
@@ -2622,8 +2608,6 @@
             areafact(i,j,ng) = -areafac_c(i,j)
 
          ! Now consider cases where the two DPs lie in different grid cells
-         ! For these cases, one triangle is given the area factor associated
-         ! with the adjacent corner, to avoid rare negative masses on curved grids.
 
          elseif (ydl > c0 .and. ydr < c0 .and. xic >= c0  &
                                          .and. ydm >= c0) then
@@ -2652,7 +2636,7 @@
             yp    (i,j,3,ng) = ydr
             iflux   (i,j,ng) = i + ishift_bc
             jflux   (i,j,ng) = j + jshift_bc
-            areafact(i,j,ng) = areafac_c(i,j) ! Bill check this and see comments above
+            areafact(i,j,ng) = areafac_c(i,j)
 
             ! TC3b (group 6)
 
@@ -2694,7 +2678,7 @@
             yp    (i,j,3,ng) = ydr
             iflux   (i,j,ng) = i + ishift_bc
             jflux   (i,j,ng) = j + jshift_bc
-            areafact(i,j,ng) = areafac_c(i,j) ! Bill check this
+            areafact(i,j,ng) = areafac_c(i,j)
 
             ! BC3b (group 6)
 
@@ -2723,7 +2707,7 @@
             yp    (i,j,3,ng) = ydl
             iflux   (i,j,ng) = i + ishift_tc
             jflux   (i,j,ng) = j + jshift_tc
-            areafact(i,j,ng) = -areafac_c(i,j) ! Bill check this
+            areafact(i,j,ng) = -areafac_c(i,j)
 
             ! BC2b (group 5)
 
@@ -2765,7 +2749,7 @@
             yp    (i,j,3,ng) = ydl
             iflux   (i,j,ng) = i + ishift_tc
             jflux   (i,j,ng) = j + jshift_tc
-            areafact(i,j,ng) = -areafac_c(i,j) ! Bill check this
+            areafact(i,j,ng) = -areafac_c(i,j)
 
             ! BC2b (group 5)
 
@@ -2807,7 +2791,7 @@
             yp    (i,j,3,ng) = yicl
             iflux   (i,j,ng) = i + ishift_bc
             jflux   (i,j,ng) = j + jshift_bc
-            areafact(i,j,ng) = areafac_c(i,j) ! Bill check this
+            areafact(i,j,ng) = areafac_c(i,j)
 
             ! TC2b (group 5)
 
@@ -2849,7 +2833,7 @@
             yp    (i,j,3,ng) = yicl
             iflux   (i,j,ng) = i + ishift_bc
             jflux   (i,j,ng) = j + jshift_bc
-            areafact(i,j,ng) = areafac_c(i,j) ! Bill check this
+            areafact(i,j,ng) = areafac_c(i,j)
 
             ! TC2b (group 5)
 
@@ -2904,7 +2888,7 @@
             yp    (i,j,3,ng) = yicr
             iflux   (i,j,ng) = i + ishift_tc
             jflux   (i,j,ng) = j + jshift_tc
-            areafact(i,j,ng) = -areafac_c(i,j) ! Bill check this
+            areafact(i,j,ng) = -areafac_c(i,j)
 
             ! BC3b (group 6)
 
@@ -2946,7 +2930,7 @@
             yp    (i,j,3,ng) = yicr
             iflux   (i,j,ng) = i + ishift_tc
             jflux   (i,j,ng) = j + jshift_tc
-            areafact(i,j,ng) = -areafac_c(i,j) ! Bill check this
+            areafact(i,j,ng) = -areafac_c(i,j)
 
             ! TC3b (group 6)
 

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1762,8 +1762,8 @@
          ishift_br, jshift_br , & ! i,j indices of BR cell relative to edge
          ishift_tc, jshift_tc , & ! i,j indices of TC cell relative to edge
          ishift_bc, jshift_bc , & ! i,j indices of BC cell relative to edge
-         is_l, js_l           , & ! index shifts for TL1 and BL2 for tri area consistency 
-         is_r, js_r           , & ! index shifts for TR1 and BR2 for tri area consistency 
+         is_l, js_l           , & ! i,j shifts for TL1, BL2 for area consistency 
+         is_r, js_r           , & ! i,j shifts for TR1, BR2 for area consistency 
          ise_tl, jse_tl       , & ! i,j of TL other edge relative to edge
          ise_bl, jse_bl       , & ! i,j of BL other edge relative to edge
          ise_tr, jse_tr       , & ! i,j of TR other edge relative to edge
@@ -1908,11 +1908,11 @@
          ishift_bc =  0
          jshift_bc =  0
 
-         ! index shifts for TL1, BL2, TR1 and BR2 for triangle area consistency 
+         ! index shifts for TL1, BL2, TR1 and BR2 for area consistency 
 
          is_l = -1
          js_l =  0
-         is_r = +1
+         is_r =  1
          js_r =  0
 
          ! index shifts for neighbor east edges
@@ -1959,10 +1959,10 @@
          ishift_bc =  0
          jshift_bc =  0
 
-         ! index shifts for TL1, BL2, TR1 and BR2 for triangle area consistency 
+         ! index shifts for TL1, BL2, TR1 and BR2 for area consistency 
 
          is_l =  0
-         js_l = +1
+         js_l =  1
          is_r =  0
          js_r = -1
 

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -2553,7 +2553,7 @@
             areafact(i,j,ng) = areatp
             !areafact(i,j,ng) = areafac_c(i,j)
 
-         elseif (ydl < c0 .and. ydr < c0 .and. ydm < c0) then
+         elseif (ydl <= c0 .and. ydr <= c0 .and. ydm < c0) then
 
             ! compute areafac for quadrilateral cl-cr-dr-dl
             xpm = p25*(xcl + xcr + xdr + xdl)
@@ -2601,7 +2601,7 @@
             areafact(i,j,ng) = areatp
             !areafact(i,j,ng) = areafac_c(i,j)
 
-         elseif (ydl < c0 .and. ydr < c0 .and. ydm >= c0) then  ! rare
+         elseif (ydl <= c0 .and. ydr <= c0 .and. ydm >= c0) then  ! rare
 
             ! compute areafac for quadrilateral cl-cr-dr-dl
             xpm = p25*(xcl + xcr + xdr + xdl)

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1753,7 +1753,7 @@
 
       integer (kind=int_kind) ::   &
          i, j, ij, ic         , & ! horizontal indices
-         ib, ie, jb, je       , & ! limits for loops over edges
+         ib, jb               , & ! limits for loops for bugcheck
          ng, nv               , & ! triangle indices
          ishift   , jshift    , & ! differences between neighbor cells
          ishift_tl, jshift_tl , & ! i,j indices of TL cell relative to edge
@@ -1891,13 +1891,6 @@
 
       if (trim(edge) == 'north') then
 
-         ! loop size
-
-         ib = ilo
-         ie = ihi
-         jb = jlo - nghost            ! lowest j index is a ghost cell
-         je = jhi
-
          ! index shifts for neighbor cells
 
          ishift_tl = -1
@@ -1941,13 +1934,6 @@
          enddo
 
       else                      ! east edge
-
-         ! loop size
-
-         ib = ilo - nghost            ! lowest i index is a ghost cell
-         ie = ihi
-         jb = jlo
-         je = jhi
 
          ! index shifts for neighbor cells
 
@@ -1999,8 +1985,8 @@
 
       icellsd = 0
       if (trim(edge) == 'north') then
-         do j = jb, je
-         do i = ib, ie
+         do j = jlo-1, jhi
+         do i = ilo, ihi
             if (dpx(i-1,j)/=c0 .or. dpy(i-1,j)/=c0   &
                                .or.                  &
                   dpx(i,j)/=c0 .or.   dpy(i,j)/=c0) then
@@ -2011,8 +1997,8 @@
          enddo
          enddo
       else       ! east edge
-         do j = jb, je
-         do i = ib, ie
+         do j = jlo, jhi
+         do i = ilo-1, ihi
             if (dpx(i,j-1)/=c0 .or. dpy(i,j-1)/=c0   &
                                .or.                  &
                   dpx(i,j)/=c0 .or.   dpy(i,j)/=c0) then
@@ -2028,8 +2014,8 @@
       ! Scale the departure points
       !-------------------------------------------------------------------
 
-      do j = 1, je
-      do i = 1, ie
+      do j = 1, jhi
+      do i = 1, ihi
          dx(i,j) = dpx(i,j) / dxu(i,j)
          dy(i,j) = dpy(i,j) / dyu(i,j)
       enddo
@@ -3061,10 +3047,17 @@
       endif
 
       if (bugcheck) then
+         if (trim(edge) == 'north') then
+            ib = ilo
+            jb = jlo-1
+         else ! east edge
+            ib = ilo-1
+            jb = jlo
+         endif
          do ng = 1, ngroups
          do nv = 1, nvert
-            do j = jb, je
-            do i = ib, ie
+            do j = jb, jhi
+            do i = ib, ihi
                if (abs(triarea(i,j,ng)) > puny) then
                   if (abs(xp(i,j,nv,ng)) > p5+puny) then
                      write(nu_diag,*) ''

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -2099,6 +2099,13 @@
          !-------------------------------------------------------------------
          ! Locate triangles in TL cell (NW for north edge, NE for east edge)
          ! and BL cell (W for north edge, N for east edge).
+         ! 
+         ! areafact_c or areafac_ce (areafact_c for the other edge) are used
+         ! (with shifted indices) to make sure that a flux area on one edge 
+         ! is consistent with the analogous area on the other edge and to 
+         ! ensure that areas add up when using l_fixed_area = T. See PR #849 
+         ! for details.
+         !
          !-------------------------------------------------------------------
 
          if (yil > c0 .and. xdl < xcl .and. ydl >= c0) then

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1791,7 +1791,7 @@
          area1, area2 , & ! temporary triangle areas
          area3, area4 , & !
          area_c       , & ! center polygon area
-         areatp,      , & ! temporary area calculation
+         areatp       , & ! temporary area calculation
          areatplone   , & ! temporary area calculation for lone triangle
          xpm          , & ! mean value of x points
          puny         , & !
@@ -2385,13 +2385,13 @@
                ydm = p5 *  ydr
 
                ! compute area of (lone) triangle adjacent to left corner
-               xpm = p33*(xcl + xdl + xic)
+               xpm = p333*(xcl + xdl + xic)
                areatplone = areafacD(i,j)*xpm + areafac_c(i,j)
                area4 = p5 * (xcl - xic) * ydl * areatplone
                area_c  = edgearea(i,j) - area1 - area2 - area3 - area4
 
                ! compute areafac for right triangle ic-cr-dr
-               xpm = p33*(xic + xcr + xdr)
+               xpm = p333*(xic + xcr + xdr)
                areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
                ! shift midpoint so that area of remaining triangles = area_c
@@ -2420,13 +2420,13 @@
                ydm = p5 *  ydl
 
                ! compute area of (lone) triangle adjacent to right corner
-               xpm = p33*(xic + xcr + xdr)
+               xpm = p333*(xic + xcr + xdr)
                areatplone = areafacD(i,j)*xpm + areafac_c(i,j)
                area4 = p5 * (xic - xcr) * ydr * areatplone
                area_c  = edgearea(i,j) - area1 - area2 - area3 - area4
 
                ! compute areafac for left triangle cl-dl-ic
-               xpm = p33*(xcl + xdl + xic)
+               xpm = p333*(xcl + xdl + xic)
                areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
                ! shift midpoint so that area of remaining triangles = area_c
@@ -2657,7 +2657,7 @@
                                           .and. ydm >= c0) then
 
             ! compute areafac for left triangle cl-dl-ic
-            xpm = p33*(xcl + xdl + xic)
+            xpm = p333*(xcl + xdl + xic)
             areatp = areafacD(i,j)*xpm + areafac_c(i,j)                                                       
 
             ! TC1b (group 4)
@@ -2708,7 +2708,7 @@
                                           .and. ydm < c0 ) then  ! less common
 
             ! compute areafac for left triangle cl-dl-ic
-            xpm = p33*(xcl + xdl + xic)
+            xpm = p333*(xcl + xdl + xic)
             areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
             ! TC1b (group 4)
@@ -2759,7 +2759,7 @@
                                           .and. ydm < c0) then
 
             ! compute areafac for right triangle ic-cr-dr
-            xpm = p33*(xic + xcr + xdr)
+            xpm = p333*(xic + xcr + xdr)
             areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
             ! TC1b (group 4) lone triangle
@@ -2810,7 +2810,7 @@
                                           .and. ydm >= c0) then  ! less common
 
             ! compute areafac for right triangle ic-cr-dr
-            xpm = p33*(xic + xcr + xdr)
+            xpm = p333*(xic + xcr + xdr)
             areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
             ! TC1b (group 4) lone triangle
@@ -2861,7 +2861,7 @@
                                           .and. ydm >= c0) then
 
             ! compute areafac for right triangle ic-cr-dr
-            xpm = p33*(xic + xcr + xdr)
+            xpm = p333*(xic + xcr + xdr)
             areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
             ! BC1b (group 4) lone triangle
@@ -2912,7 +2912,7 @@
                                           .and. ydm < c0) then ! less common
 
             ! compute areafac for right triangle ic-cr-dr
-            xpm = p33*(xic + xcr + xdr)
+            xpm = p333*(xic + xcr + xdr)
             areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
             ! BC1b (group 4) lone triangle
@@ -2963,7 +2963,7 @@
                                           .and. ydm <  c0) then
 
             ! compute areafac for left triangle cl-dl-ic
-            xpm = p33*(xcl + xdl + xic)
+            xpm = p333*(xcl + xdl + xic)
             areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
             ! BC1b (group 4)
@@ -3014,7 +3014,7 @@
                                           .and. ydm >= c0) then  ! less common
 
             ! compute areafac for left triangle cl-dl-ic
-            xpm = p33*(xcl + xdl + xic)
+            xpm = p333*(xcl + xdl + xic)
             areatp = areafacD(i,j)*xpm + areafac_c(i,j)
 
             ! BC1b (group 4)

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -63,7 +63,7 @@
                       ! if false, area flux is determined internally
                       ! and is passed out
 
-      logical (kind=log_kind), parameter :: bugcheck = .true.
+      logical (kind=log_kind), parameter :: bugcheck = .false.
 
 !=======================================================================
 ! Here is some information about how the incremental remapping scheme
@@ -3008,7 +3008,7 @@
             do ij = 1, icellsd
                i = indxid(ij)
                j = indxjd(ij)
-               if (abs(areasum(i,j) - edgearea(i,j)) > eps13*areafac_c(i,j)) then
+               if ( abs(areasum(i,j) - edgearea(i,j)) > eps13*areafac_c(i,j) .and. abs(edgearea(i,j)) > c0 ) then
                   write(nu_diag,*) ''
                   write(nu_diag,*) 'Areas do not add up: m, i, j, edge =',   &
                            my_task, i, j, trim(edge)

--- a/cicecore/cicedyn/infrastructure/ice_grid.F90
+++ b/cicecore/cicedyn/infrastructure/ice_grid.F90
@@ -82,14 +82,14 @@
          dyE    , & ! height of E-cell through the middle (m)
          HTE    , & ! length of eastern edge of T-cell (m)
          HTN    , & ! length of northern edge of T-cell (m)
-         tarea  , & ! area of T-cell (m^2)
-         uarea  , & ! area of U-cell (m^2)
-         narea  , & ! area of N-cell (m^2)
-         earea  , & ! area of E-cell (m^2)
-         tarear , & ! 1/tarea
-         uarear , & ! 1/uarea
-         narear , & ! 1/narea
-         earear , & ! 1/earea
+         tarea  , & ! area of T-cell (m^2), valid in halo
+         uarea  , & ! area of U-cell (m^2), valid in halo
+         narea  , & ! area of N-cell (m^2), valid in halo
+         earea  , & ! area of E-cell (m^2), valid in halo
+         tarear , & ! 1/tarea, valid in halo
+         uarear , & ! 1/uarea, valid in halo
+         narear , & ! 1/narea, valid in halo
+         earear , & ! 1/earea, valid in halo
          tarean , & ! area of NH T-cells
          tareas , & ! area of SH T-cells
          ULON   , & ! longitude of velocity pts, NE corner of T pts (radians)
@@ -101,7 +101,7 @@
          ELON   , & ! longitude of center of east face of T pts (radians)
          ELAT   , & ! latitude of center of east face of T pts (radians)
          ANGLE  , & ! for conversions between POP grid and lat/lon
-         ANGLET , & ! ANGLE converted to T-cells
+         ANGLET , & ! ANGLE converted to T-cells, valid in halo
          bathymetry      , & ! ocean depth, for grounding keels and bergs (m)
          ocn_gridcell_frac   ! only relevant for lat-lon grids
                              ! gridcell value of [1 - (land fraction)] (T-cell)
@@ -635,11 +635,23 @@
       call ice_HaloUpdate (uarea,              halo_info, &
                            field_loc_NEcorner, field_type_scalar, &
                            fillValue=c1,       tripoleOnly=.true.)
+      call ice_HaloUpdate (narea,              halo_info, &
+                           field_loc_Nface,    field_type_scalar, &
+                           fillValue=c1,       tripoleOnly=.true.)
+      call ice_HaloUpdate (earea,              halo_info, &
+                           field_loc_Eface,    field_type_scalar, &
+                           fillValue=c1,       tripoleOnly=.true.)
       call ice_HaloUpdate (tarear,             halo_info, &
                            field_loc_center,   field_type_scalar, &
                            fillValue=c1,       tripoleOnly=.true.)
       call ice_HaloUpdate (uarear,             halo_info, &
                            field_loc_NEcorner, field_type_scalar, &
+                           fillValue=c1,       tripoleOnly=.true.)
+      call ice_HaloUpdate (narear,             halo_info, &
+                           field_loc_Nface,    field_type_scalar, &
+                           fillValue=c1,       tripoleOnly=.true.)
+      call ice_HaloUpdate (earear,             halo_info, &
+                           field_loc_Eface,    field_type_scalar, &
                            fillValue=c1,       tripoleOnly=.true.)
 
       call ice_timer_stop(timer_bound)

--- a/doc/source/science_guide/sg_horiztrans.rst
+++ b/doc/source/science_guide/sg_horiztrans.rst
@@ -477,9 +477,16 @@ Remote Sensing Center (Norway), who applied an earlier version of the
 CICE remapping scheme to an ocean model. The implementation in CICE
 is somewhat more general, allowing for departure regions lying on both
 sides of a cell edge. The extra triangle is constrained to lie in one
-but not both of the grid cells that share the edge. Since this option
-has yet to be fully tested in CICE, the current default is
-`l\_fixed\_area` = false.
+but not both of the grid cells that share the edge.
+
+The default value for the B grid is `l\_fixed\_area` = false. However, 
+idealized tests with the C grid have shown that prognostic fields such 
+as sea ice concentration exhibit a checkerboard pattern with 
+`l\_fixed\_area` = false. The logical `l\_fixed\_area` is therefore set 
+to true when using the C grid. The edge areas `edgearea\_e` and `edgearea\_n` 
+are in this case calculated with the C grid velocity components :math:`uvelE` 
+and :math:`vvelN`.
+
 
 We made one other change in the scheme of :cite:`Dukowicz00` for
 locating triangles. In their paper, departure points are defined by


### PR DESCRIPTION
Hi everyone,

@apcraig please do not merge this...this is for the moment just for review. @eclare108213, @apcraig, @TillRasmussen and @dabail10 feel free to give me your comments. 

This is solution1. This could be temporary if we decide to go with the more complicated solution2 later. 

I have tested solution1 in gx3 and gx1 simulations (C-grid, l_fixed_area=T). These simulations ran fine for 4 years. Looks good.

@whlipscomb, I have modified the calculations for areafact. I am however not sure if areafac_l, areafac_r and areafac_c in the l_fixed_area section should be modified. I have added the comment: ! jlem should this be modified? where I am not sure what to do. Please let me know. 

For the moment the code calculates:

areafac_c(i,j) = p5*(areafac_l(i,j) + areafac_r(i,j))
areafacS (i,j) = areafac_r(i,j) + areafac_l(i,j)

This is redundant. I will remove one array after I get your comments. 
