### PR TITLE
Fix mesh mask check in nuopc/cmeps cap

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -668,13 +668,13 @@ contains
     n=0
     do iblk = 1, nblocks
        this_block = get_block(blocks_ice(iblk),iblk)
+       ilo = this_block%ilo
+       ihi = this_block%ihi
+       jlo = this_block%jlo
+       jhi = this_block%jhi
        do j = jlo, jhi
-          jlo = this_block%jlo
-          jhi = this_block%jhi
           do i = ilo, ihi
-             ilo = this_block%ilo
-             ihi = this_block%ihi
-             n = n+1
+             n = n + 1
              mask_internal = nint(hm(i,j,iblk),kind=dbl_kind)
              mask_file = model_mask(n)
              if (mask_internal /= mask_file) then


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Fixes bug in consistency check between supplied and internally generated mesh masks in the nuopc/cmeps cap. Closes #871.
- [x] Developer(s): 
    @dougiesquire
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    The original implementation of the check fails on our meshes, but the new implementation passes. No further testing has been done.
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [ ] Please provide any additional information or relevant details below:
