### PR TITLE
ice_dyn_evp: pass 'grid_location' for LKD seabed stress on C grid

### DIFF
--- a/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
@@ -763,12 +763,14 @@
                                                  icellE    (iblk),                 &
                                                  indxEi  (:,iblk), indxEj(:,iblk), &
                                                  vice  (:,:,iblk), aice(:,:,iblk), &
-                                                 hwater(:,:,iblk), TbE (:,:,iblk))
+                                                 hwater(:,:,iblk), TbE (:,:,iblk), &
+                                                 grid_location='E')
                   call seabed_stress_factor_LKD (nx_block        , ny_block,       &
                                                  icellN    (iblk),                 &
                                                  indxNi  (:,iblk), indxNj(:,iblk), &
                                                  vice  (:,:,iblk), aice(:,:,iblk), &
-                                                 hwater(:,:,iblk), TbN (:,:,iblk))
+                                                 hwater(:,:,iblk), TbN (:,:,iblk), &
+                                                 grid_location='N')
                enddo
                !$OMP END PARALLEL DO
 

--- a/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
@@ -1289,7 +1289,7 @@
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(inout) :: &
          TbU           ! seabed stress factor at 'grid_location' (N/m^2)
 
-      character(len=*), optional, intent(inout) :: &
+      character(len=*), optional, intent(in) :: &
          grid_location ! grid location (U, E, N), U assumed if not present
 
       real (kind=dbl_kind) :: &


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    title
- [X] Developer(s): 
    me
- [x] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    base suite is bit for bit since it does not contain any test with the C grid and the LKD seabed stress (nor does any other test suite). https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#2d5104077f9318cbd0ef655c87f2ca6aa0d95832
~~~
361 measured results of 361 total results
361 of 361 tests PASSED
0 of 361 tests PENDING
0 of 361 tests MISSING data
0 of 361 tests FAILED
~~~

I ran the QC test with `-s gridc,seabedLKD` and the 2-stage test passed but not the quadratic skill test:

~~~
$ /home/phb001/code/cice/configuration/scripts/tests/QC/cice.t-test.py \
~/data/ppp6/cice/runs/ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD.base \
~/data/ppp6/cice/runs/ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD.test
INFO:__main__:Running QC test on the following directories:
INFO:__main__:  /home/phb001/data/ppp6/cice/runs/ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD.base/
INFO:__main__:  /home/phb001/data/ppp6/cice/runs/ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD.test
INFO:__main__:Number of files: 1825
INFO:__main__:2 Stage Test Passed
INFO:__main__:Quadratic Skill Test Failed for Northern Hemisphere
INFO:__main__:Quadratic Skill Test Failed for Southern Hemisphere
INFO:__main__:Creating map of the data (ice_thickness_ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD.base.png)
INFO:__main__:Creating map of the data (ice_thickness_ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD.te.png)
INFO:__main__:Creating map of the data (ice_thickness_ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD.base_minus_ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD.te.png)
INFO:__main__:
ERROR:__main__:Quality Control Test FAILED
~~~

Here is the map of the difference:

![ice_thickness_ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD base_minus_ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD te](https://github.com/CICE-Consortium/CICE/assets/44212482/05c5fe0e-d5e6-4a00-a38a-8097b1651eca)

the thickness field for current code:

![ice_thickness_ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD base](https://github.com/CICE-Consortium/CICE/assets/44212482/c2916f2d-c9b2-4b6a-9890-176cd0ac3434)

and the modified code:

![ice_thickness_ppp6_intel_smoke_gx1_80x1_gridc_medium_qc_seabedLKD te](https://github.com/CICE-Consortium/CICE/assets/44212482/48cc81f3-7cfb-49b3-bb78-227d1cc51587)



- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

When the C grid support was added in 078aab48 (Merge cgridDEV branch including C grid implementation and other fixes (#715), 2022-05-10), subroutine ice_dyn_shared::seabed_stress_factor_LKD gained a 'grid_location' optional argument to indicate where to compute intermediate quantities and the seabed stress itself (originally added in 0f9f48b9 (ice_dyn_shared: add optional 'grid_location' argument to seabed_stress_factor_LKD, 2021-11-17)). This argument was however forgotten in ice_dyn_evp::evp when this subroutine was adapted for the C grid in 48c07c66 (ice_dyn_evp: compute seabed stress factor at CD-grid locations, 2021-11-17), such that currently the seabed stress is not computed at the correct grid location for the C and CD grids.

Fix that by correctly passing the 'grid_location' argument. Note that the dummy argument is incorrectly declared as 'intent(inout)' in the subroutine, so change that to 'intent(in)' so we can pass in character constants.

Closes: https://github.com/CICE-Consortium/CICE/issues/891