### PR TITLE
Split N/E grid computation out of Tlonlat, create NElonlat subroutine.

### DIFF
--- a/configuration/scripts/options/set_nml.gx3nc
+++ b/configuration/scripts/options/set_nml.gx3nc
@@ -1,0 +1,3 @@
+grid_format = 'nc'
+grid_file   = 'ICE_MACHINE_INPUTDATA/CICE_data/grid/gx3/grid_gx3t.nc'
+kmt_file    = 'ICE_MACHINE_INPUTDATA/CICE_data/grid/gx3/kmt_gx3t.nc'

--- a/configuration/scripts/tests/base_suite.ts
+++ b/configuration/scripts/tests/base_suite.ts
@@ -4,6 +4,7 @@ smoke          gx3     1x1        debug,diag1,run2day
 smoke          gx3     1x4        debug,diag1,run2day
 smoke          gx3     4x1        debug,diag1,run5day
 restart        gx3     8x2        debug
+restart        gx3     8x2        debug,gx3nc
 smoke          gx3     8x2        diag24,run1year,medium
 smoke          gx3     7x2        diag1,bigdiag,run1day,diagpt1
 decomp         gx3     4x2x25x29x5  none
@@ -14,6 +15,7 @@ restart        gx1    40x4        droundrobin,medium
 restart        tx1    40x4        dsectrobin,medium
 restart        tx1    40x4        dsectrobin,medium,jra55do
 restart        gx3     4x4        none
+restart        gx3     4x4        gx3nc
 restart        gx3    10x4        maskhalo
 restart        gx3     6x2        alt01
 restart        gx3     8x2        alt02


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Split N/E grid computation out of Tlonlat, create NElonlat subroutine.
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    early tests show bit-for-bit, running full test suite now
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:

Closes https://github.com/CICE-Consortium/CICE/issues/897

When TLON, TLAT, ANGLET are on the CICE grid, Tlonlat is NOT called.  This meant N and E grid info was never computed.  This would fail during history writing with invalid values in N and E grid arrays.  And it would also cause problem if the C-grid were run with this type of CICE grid.

There are no test grids that have TLON, TLAT, ANGLET on them, so this error was not found in standard test suites.  This was detected by users.

Also fixes some indentation and write statements.

