### PR TITLE
Rename sum to asum, as "sum" is also a generic Fortran function

### DIFF
--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -2939,7 +2939,7 @@
          indxi, indxj    ! compressed indices for cells with aicen > puny
 
       real (kind=dbl_kind) :: &
-         Tsfc, sum, hbar, abar, puny, rhos, Lfresh, rad_to_deg, rsnw_fall, dist_ratio, Tffresh
+         Tsfc, asum, hbar, abar, puny, rhos, Lfresh, rad_to_deg, rsnw_fall, dist_ratio, Tffresh
 
       real (kind=dbl_kind), dimension(ncat) :: &
          ainit, hinit    ! initial area, thickness
@@ -3075,7 +3075,7 @@
                        ! Note: the resulting average ice thickness
                        ! tends to be less than hbar due to the
                        ! nonlinear distribution of ice thicknesses
-            sum = c0
+            asum = c0
             do n = 1, ncat
                if (n < ncat) then
                   hinit(n) = p5*(hin_max(n-1) + hin_max(n)) ! m
@@ -3084,10 +3084,10 @@
                endif
                ! parabola, max at h=hbar, zero at h=0, 2*hbar
                ainit(n) = max(c0, (c2*hbar*hinit(n) - hinit(n)**2))
-               sum = sum + ainit(n)
+               asum = asum + ainit(n)
             enddo
             do n = 1, ncat
-               ainit(n) = ainit(n) / (sum + puny/ncat) ! normalize
+               ainit(n) = ainit(n) / (asum + puny/ncat) ! normalize
             enddo
 
          else


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ x ] Short (1 sentence) summary of your PR: 
Rename variable "sum" to "asum", as sum is also a generic Fortran function. Not an error, but better/more clear coding.

- [ x ] Developer(s): 
    @mhrib and Imke Sievers, DMI
- [ ] Suggest PR reviewers from list in the column to the right.
- [ x ] Please copy the PR test results link or provide a summary of testing completed below.
19 measured results of 19 total results
19 of 19 tests PASSED
0 of 19 tests PENDING
0 of 19 tests MISSING data
0 of 19 tests FAILED
- How much do the PR code changes differ from the unmodified code? 
    - [ x ] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [ x ] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [ x ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ x ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [ x ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ x ] No 
- [ x ] Please provide any additional information or relevant details below:

Using "sum" as a variable may be a bad coding practice, as "sum" is also a Fortran function.

bit-for-bit test:
------------------
md5sum's equal after a 1 month run using GX3/JRA55 forcing for unchanged code (org) and modified code (sum) started from `runtype="initial"` and `ice_data_conc='parabolic'`:
> md5sum */run/iced.2005-02-01-00000.nc
a1009b4220fbc25f810d96f9eb182cad  org/run/iced.2005-02-01-00000.nc
a1009b4220fbc25f810d96f9eb182cad  sum/run/iced.2005-02-01-00000.nc
