### PR TITLE
Add missing logical "timer_stats" into nuopc/dmi/ driver

### DIFF
--- a/cicecore/drivers/nuopc/dmi/CICE_FinalMod.F90
+++ b/cicecore/drivers/nuopc/dmi/CICE_FinalMod.F90
@@ -31,7 +31,8 @@
       subroutine CICE_Finalize
 
       use ice_restart_shared, only: runid
-      use ice_timers, only: ice_timer_stop, ice_timer_print_all, timer_total
+      use ice_timers, only: ice_timer_stop, ice_timer_print_all, &
+                            timer_total, timer_stats
 
       character(len=*), parameter :: subname = '(CICE_Finalize)'
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ x ] Short (1 sentence) summary of your PR: 
    Add missing logical "timer_stats" into DMI nuopc driver CICE_FinalMod
- [ x ] Developer(s): 
    @mhrib
- [ ] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ENTER INFORMATION HERE 
- How much do the PR code changes differ from the unmodified code? 
    - [ x ] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [ x ] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [ x ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ x ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [ x ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ x ] No 
- [ ] Please provide any additional information or relevant details below:
