### PR TITLE
Change to dealloc_grid in CICE_InitMod.F90

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/CICE_InitMod.F90
+++ b/cicecore/drivers/nuopc/cmeps/CICE_InitMod.F90
@@ -32,7 +32,7 @@ contains
 
     use ice_init          , only: input_data
     use ice_init_column   , only: input_zbgc, count_tracers
-    use ice_grid          , only: init_grid1, alloc_grid, dealloc_grid
+    use ice_grid          , only: init_grid1, alloc_grid
     use ice_domain        , only: init_domain_blocks
     use ice_arrays_column , only: alloc_arrays_column
     use ice_state         , only: alloc_state
@@ -86,6 +86,7 @@ contains
     use ice_forcing          , only: init_snowtable
     use ice_forcing_bgc      , only: get_forcing_bgc, get_atm_bgc
     use ice_forcing_bgc      , only: faero_default, alloc_forcing_bgc, fiso_default
+    use ice_grid             , only: dealloc_grid
     use ice_history          , only: init_hist, accum_hist
     use ice_restart_shared   , only: restart, runtype
     use ice_init             , only: input_data, init_state


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
The call to delloc_grid in cice_init2 was missing a use statement.
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
aux_cice 
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
This did not actually compile in CESM until I added a use statement.