### PR TITLE
ice_history: allow per-stream suffix for history filenames

### DIFF
--- a/cicecore/cicedyn/analysis/ice_history_shared.F90
+++ b/cicecore/cicedyn/analysis/ice_history_shared.F90
@@ -58,7 +58,7 @@
          history_format
 
       character (len=char_len), public :: &
-         hist_str(max_nstrm)  ! appended to 'h' in filename when not 'x'
+         hist_suffix(max_nstrm)  ! appended to 'h' in filename when not 'x'
 
       !---------------------------------------------------------------
       ! Instructions for adding a field: (search for 'example')
@@ -764,7 +764,7 @@
            endif
 
            cstream = ''
-           if (hist_str(ns) /= 'x') cstream = hist_str(ns)
+           if (hist_suffix(ns) /= 'x') cstream = hist_suffix(ns)
 
            if (hist_avg(ns)) then    ! write averaged data
               if (histfreq(ns) == '1' .and. histfreq_n(ns) == 1)  then ! timestep

--- a/cicecore/cicedyn/analysis/ice_history_shared.F90
+++ b/cicecore/cicedyn/analysis/ice_history_shared.F90
@@ -57,6 +57,9 @@
       character (len=char_len), public :: &
          history_format
 
+      character (len=char_len), public :: &
+         hist_str(max_nstrm)  ! appended to 'h' in filename when not 'x'
+
       !---------------------------------------------------------------
       ! Instructions for adding a field: (search for 'example')
       !     Here or in ice_history_[process].F90:
@@ -761,9 +764,7 @@
            endif
 
            cstream = ''
-!echmod ! this was implemented for CESM but it breaks post-processing software
-!echmod ! of other groups (including RASM which uses CESMCOUPLED)
-!echmod         if (ns > 1) write(cstream,'(i1.1)') ns-1
+           if (hist_str(ns) /= 'x') cstream = hist_str(ns)
 
            if (hist_avg(ns)) then    ! write averaged data
               if (histfreq(ns) == '1' .and. histfreq_n(ns) == 1)  then ! timestep

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -79,7 +79,7 @@
       use ice_restart_shared, only: &
           restart, restart_ext, restart_coszen, restart_dir, restart_file, pointer_file, &
           runid, runtype, use_restart_time, restart_format, lcdf64
-      use ice_history_shared, only: hist_avg, history_dir, history_file, hist_str, &
+      use ice_history_shared, only: hist_avg, history_dir, history_file, hist_suffix, &
                              incond_dir, incond_file, version_name, &
                              history_precision, history_format, hist_time_axis
       use ice_flux, only: update_ocn_f, cpl_frazil, l_mpond_fresh
@@ -188,7 +188,7 @@
         hist_time_axis,                                                 &
         print_global,   print_points,   latpnt,          lonpnt,        &
         debug_forcing,  histfreq,       histfreq_n,      hist_avg,      &
-        hist_str,                                                       &
+        hist_suffix,                                                       &
         history_dir,    history_file,   history_precision, cpl_bgc,     &
         histfreq_base,  dumpfreq_base,  timer_stats,     memory_stats,  &
         conserv_check,  debug_model,    debug_model_step,               &
@@ -325,7 +325,7 @@
       histfreq_n(:) = 1      ! output frequency
       histfreq_base(:) = 'zero' ! output frequency reference date
       hist_avg(:) = .true.   ! if true, write time-averages (not snapshots)
-      hist_str(:) = 'x'      ! add nothing to 'h' in filename when 'x'
+      hist_suffix(:) = 'x'   ! appended to 'history_file' in filename when not 'x'
       history_format = 'default' ! history file format
       hist_time_axis = 'end' ! History file time axis averaging interval position
 
@@ -913,7 +913,7 @@
          call broadcast_scalar(histfreq_base(n),  master_task)
          call broadcast_scalar(dumpfreq(n),       master_task)
          call broadcast_scalar(dumpfreq_base(n),  master_task)
-         call broadcast_scalar(hist_str(n),       master_task)
+         call broadcast_scalar(hist_suffix(n),       master_task)
       enddo
       call broadcast_array(hist_avg,              master_task)
       call broadcast_array(histfreq_n,            master_task)
@@ -2358,7 +2358,7 @@
          write(nu_diag,1023) ' histfreq_n       = ', histfreq_n(:)
          write(nu_diag,1033) ' histfreq_base    = ', histfreq_base(:)
          write(nu_diag,*)    ' hist_avg         = ', hist_avg(:)
-         write(nu_diag,1033) ' hist_str         = ', hist_str(:)
+         write(nu_diag,1033) ' hist_suffix      = ', hist_suffix(:)
          write(nu_diag,1031) ' history_dir      = ', trim(history_dir)
          write(nu_diag,1031) ' history_file     = ', trim(history_file)
          write(nu_diag,1021) ' history_precision= ', history_precision

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -79,7 +79,7 @@
       use ice_restart_shared, only: &
           restart, restart_ext, restart_coszen, restart_dir, restart_file, pointer_file, &
           runid, runtype, use_restart_time, restart_format, lcdf64
-      use ice_history_shared, only: hist_avg, history_dir, history_file, &
+      use ice_history_shared, only: hist_avg, history_dir, history_file, hist_str, &
                              incond_dir, incond_file, version_name, &
                              history_precision, history_format, hist_time_axis
       use ice_flux, only: update_ocn_f, cpl_frazil, l_mpond_fresh
@@ -188,6 +188,7 @@
         hist_time_axis,                                                 &
         print_global,   print_points,   latpnt,          lonpnt,        &
         debug_forcing,  histfreq,       histfreq_n,      hist_avg,      &
+        hist_str,                                                       &
         history_dir,    history_file,   history_precision, cpl_bgc,     &
         histfreq_base,  dumpfreq_base,  timer_stats,     memory_stats,  &
         conserv_check,  debug_model,    debug_model_step,               &
@@ -324,6 +325,7 @@
       histfreq_n(:) = 1      ! output frequency
       histfreq_base(:) = 'zero' ! output frequency reference date
       hist_avg(:) = .true.   ! if true, write time-averages (not snapshots)
+      hist_str(:) = 'x'      ! add nothing to 'h' in filename when 'x'
       history_format = 'default' ! history file format
       hist_time_axis = 'end' ! History file time axis averaging interval position
 
@@ -911,6 +913,7 @@
          call broadcast_scalar(histfreq_base(n),  master_task)
          call broadcast_scalar(dumpfreq(n),       master_task)
          call broadcast_scalar(dumpfreq_base(n),  master_task)
+         call broadcast_scalar(hist_str(n),       master_task)
       enddo
       call broadcast_array(hist_avg,              master_task)
       call broadcast_array(histfreq_n,            master_task)
@@ -2355,6 +2358,7 @@
          write(nu_diag,1023) ' histfreq_n       = ', histfreq_n(:)
          write(nu_diag,1033) ' histfreq_base    = ', histfreq_base(:)
          write(nu_diag,*)    ' hist_avg         = ', hist_avg(:)
+         write(nu_diag,1033) ' hist_str         = ', hist_str(:)
          write(nu_diag,1031) ' history_dir      = ', trim(history_dir)
          write(nu_diag,1031) ' history_file     = ', trim(history_file)
          write(nu_diag,1021) ' history_precision= ', history_precision

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -49,7 +49,7 @@
     histfreq_n     =  1 , 1 , 1 , 1 , 1
     histfreq_base  = 'zero','zero','zero','zero','zero'
     hist_avg       = .true.,.true.,.true.,.true.,.true.
-    hist_str       = 'x','x','x','x','x'
+    hist_suffix    = 'x','x','x','x','x'
     history_dir    = './history/'
     history_file   = 'iceh'
     history_precision = 4

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -49,6 +49,7 @@
     histfreq_n     =  1 , 1 , 1 , 1 , 1
     histfreq_base  = 'zero','zero','zero','zero','zero'
     hist_avg       = .true.,.true.,.true.,.true.,.true.
+    hist_str       = 'x','x','x','x','x'
     history_dir    = './history/'
     history_file   = 'iceh'
     history_precision = 4

--- a/doc/source/cice_index.rst
+++ b/doc/source/cice_index.rst
@@ -325,7 +325,7 @@ section :ref:`tabnamelist`.
    "history_format", "history file format", ""
    "history_precision", "history output precision: 4 or 8 byte", "4"
    "hist_time_axis", "history file time axis interval location: begin, middle, end", "end"
-   "hist_str", "extension to h character in filename. x means no extension", "x,x,x,x,x"
+   "hist_suffix", "extension to h character in filename. x means no extension", "x,x,x,x,x"
    "hm", "land/boundary mask, thickness (T-cell)", ""
    "hmix", "ocean mixed layer depth", "20. m"
    "hour", "hour of the year", ""

--- a/doc/source/cice_index.rst
+++ b/doc/source/cice_index.rst
@@ -325,6 +325,7 @@ section :ref:`tabnamelist`.
    "history_format", "history file format", ""
    "history_precision", "history output precision: 4 or 8 byte", "4"
    "hist_time_axis", "history file time axis interval location: begin, middle, end", "end"
+   "hist_str", "extension to h character in filename. x means no extension", "x,x,x,x,x"
    "hm", "land/boundary mask, thickness (T-cell)", ""
    "hmix", "ocean mixed layer depth", "20. m"
    "hour", "hour of the year", ""

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -198,7 +198,7 @@ setup_nml
    "``history_format``", "``default``", "read/write history files in default format", "``default``"
    "", "``pio_pnetcdf``", "read/write restart files with pnetcdf in pio", ""
    "``history_precision``", "integer", "history file precision: 4 or 8 byte", "4"
-   "``hist_str``", "character array", "extension to h character in filename. x means no extension", "``x,x,x,x,x``"
+   "``hist_suffix``", "character array", "appended to history_file when not x", "``x,x,x,x,x``"
    "``hist_time_axis``","character","history file time axis interval location: begin, middle, end","end"
    "``ice_ic``", "``default``", "equal to internal", "``default``"
    "", "``internal``", "initial conditions set based on ice\_data\_type,conc,dist inputs", ""

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -198,6 +198,7 @@ setup_nml
    "``history_format``", "``default``", "read/write history files in default format", "``default``"
    "", "``pio_pnetcdf``", "read/write restart files with pnetcdf in pio", ""
    "``history_precision``", "integer", "history file precision: 4 or 8 byte", "4"
+   "``hist_str``", "character array", "extension to h character in filename. x means no extension", "``x,x,x,x,x``"
    "``hist_time_axis``","character","history file time axis interval location: begin, middle, end","end"
    "``ice_ic``", "``default``", "equal to internal", "``default``"
    "", "``internal``", "initial conditions set based on ice\_data\_type,conc,dist inputs", ""

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -1156,8 +1156,11 @@ io package.  The namelist variable ``history_format`` further refines the
 format approach or style for some io packages.
 
 Model output data can be written as instantaneous or average data as specified
-by the ``hist_avg`` namelist array and is customizable by stream.  The data is 
-written at the period(s) given by ``histfreq`` and
+by the ``hist_avg`` namelist array and is customizable by stream. Characters
+can be added to the "h" character to distinguish the streams. This can be changed
+by modifying ``hist_str`` to something other than "x".
+
+The data written at the period(s) given by ``histfreq`` and
 ``histfreq_n`` relative to a reference date specified by ``histfreq_base``.  
 The files are written to binary or netCDF files prepended by ``history_file``
 in **ice_in**. These settings for history files are set in the 

--- a/doc/source/user_guide/ug_implementation.rst
+++ b/doc/source/user_guide/ug_implementation.rst
@@ -1157,8 +1157,8 @@ format approach or style for some io packages.
 
 Model output data can be written as instantaneous or average data as specified
 by the ``hist_avg`` namelist array and is customizable by stream. Characters
-can be added to the "h" character to distinguish the streams. This can be changed
-by modifying ``hist_str`` to something other than "x".
+can be added to the ``history_filename`` to distinguish the streams. This can be changed
+by modifying ``hist_suffix`` to something other than "x".
 
 The data written at the period(s) given by ``histfreq`` and
 ``histfreq_n`` relative to a reference date specified by ``histfreq_base``.  
@@ -1200,7 +1200,7 @@ is a character string corresponding to ``histfreq`` or ‘x’ for none.
 files, no matter what the frequency is.) If there are no namelist flags
 with a given ``histfreq`` value, or if an element of ``histfreq_n`` is 0, then
 no file will be written at that frequency. The output period can be
-discerned from the filenames.  Each history stream will be either instantaneous
+discerned from the filenames or the ``hist_suffix`` can be used.  Each history stream will be either instantaneous
 or averaged as specified by the corresponding entry in the ``hist_avg`` namelist array, and the frequency
 will be relative to a reference date specified by the corresponding entry in ``histfreq_base``.
 More information about how the frequency is


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
This is a potential solution to issue #854 
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Tested in CESM aux_cice.

https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#d05b1f30e57d2531799d4dbfb53464422582dd6f
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:
This adds a new namelist parameter hist_str. This will allow for arbitrary extension on each of the history file streams. I am using 'x' to denote no extension. Happy to discuss this. For example in CESM we would use:

hist_str = 'x','1','2','3','4'

to get filenames cice.h, cice.h1, cice.h2, cice.h3, cice.h4.
