### PR TITLE
Newgrid

### DIFF
--- a/cicecore/cicedyn/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_eap.F90
@@ -109,7 +109,7 @@
           seabed_stress_factor_LKD, seabed_stress_factor_prob, &
           seabed_stress_method, seabed_stress, &
           stack_fields, unstack_fields, iceTmask, iceUmask, &
-          fld2, fld3, fld4
+          fld2, fld3, fld4, dxhy, dyhx, cxp, cyp, cxm, cym
       use ice_flux, only: rdg_conv, strairxT, strairyT, &
           strairxU, strairyU, uocn, vocn, ss_tltx, ss_tlty, fmU, &
           strtltxU, strtltyU, strocnxU, strocnyU, strintxU, strintyU, taubxU, taubyU, &
@@ -118,7 +118,7 @@
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
-      use ice_grid, only: tmask, umask, dxT, dyT, dxhy, dyhx, cxp, cyp, cxm, cym, &
+      use ice_grid, only: tmask, umask, dxT, dyT, &
           tarear, uarear, grid_average_X2Y, &
           grid_atm_dynu, grid_atm_dynv, grid_ocn_dynu, grid_ocn_dynv
       use ice_state, only: aice, aiU, vice, vsno, uvel, vvel, divu, shear, &

--- a/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
@@ -84,6 +84,12 @@
          emass    (:,:,:) , & ! total mass of ice and snow (E grid)
          emassdti (:,:,:)     ! mass of E-cell/dte (kg/m^2 s)
 
+      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
+         ratiodxN    , & ! - dxN(i+1,j)   / dxN(i,j)
+         ratiodyE    , & ! - dyE(i  ,j+1) / dyE(i,j)
+         ratiodxNr   , & !   1 / ratiodxN
+         ratiodyEr       !   1 / ratiodyE
+
       real (kind=dbl_kind), allocatable :: &
          strengthU(:,:,:) , & ! strength averaged to U points
          divergU  (:,:,:) , & ! div array on U points, differentiate from divu
@@ -119,9 +125,10 @@
 ! Elastic-viscous-plastic dynamics driver
 !
       subroutine init_evp
-      use ice_blocks, only: nx_block, ny_block, nghost
-      use ice_domain_size, only: max_blocks, nx_global, ny_global
-      use ice_grid, only: grid_ice, dyT, dxT, uarear, tmask, G_HTE, G_HTN
+      use ice_blocks, only: get_block, nx_block, ny_block, nghost, block
+      use ice_domain_size, only: max_blocks
+      use ice_domain, only: nblocks, blocks_ice
+      use ice_grid, only: grid_ice, dyT, dxT, uarear, tmask, G_HTE, G_HTN, dxN, dyE
       use ice_calendar, only: dt_dyn
       use ice_dyn_shared, only: init_dyn_shared, evp_algorithm
       use ice_dyn_evp1d, only: dyn_evp1d_init
@@ -130,6 +137,14 @@
       integer (int_kind) :: ierr
 
       character(len=*), parameter :: subname = '(init_evp)'
+
+     type (block) :: &
+         this_block   ! block information for current block
+
+      integer (kind=int_kind) :: &
+         i, j, iblk            , & ! block index
+         ilo,ihi,jlo,jhi           ! beginning and end of physical domain
+
 
       call init_dyn_shared(dt_dyn)
 
@@ -197,6 +212,33 @@
                    stat=ierr)
          if (ierr/=0) call abort_ice(subname//' ERROR: Out of memory E evp')
 
+         allocate( &
+            ratiodxN (nx_block,ny_block,max_blocks), &
+            ratiodyE (nx_block,ny_block,max_blocks), &
+            ratiodxNr(nx_block,ny_block,max_blocks), &
+            ratiodyEr(nx_block,ny_block,max_blocks), &
+            stat=ierr)
+         if (ierr/=0) call abort_ice(subname//'ERROR: Out of memory ratio')
+
+         !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
+         do iblk = 1, nblocks
+            this_block = get_block(blocks_ice(iblk),iblk)
+            ilo = this_block%ilo
+            ihi = this_block%ihi
+            jlo = this_block%jlo
+            jhi = this_block%jhi
+
+            do j = jlo, jhi
+            do i = ilo, ihi
+               ratiodxN (i,j,iblk) = - dxN(i+1,j  ,iblk) / dxN(i,j,iblk)
+               ratiodyE (i,j,iblk) = - dyE(i  ,j+1,iblk) / dyE(i,j,iblk)
+               ratiodxNr(i,j,iblk) =   c1 / ratiodxN(i,j,iblk)
+               ratiodyEr(i,j,iblk) =   c1 / ratiodyE(i,j,iblk)
+            enddo
+            enddo
+         enddo                     ! iblk
+         !$OMP END PARALLEL DO
+
       endif
 
       end subroutine init_evp
@@ -219,7 +261,7 @@
           ice_HaloDestroy, ice_HaloUpdate_stress
       use ice_blocks, only: block, get_block, nx_block, ny_block, nghost
       use ice_domain, only: nblocks, blocks_ice, halo_info, maskhalo_dyn
-      use ice_domain_size, only: max_blocks, ncat, nx_global, ny_global
+      use ice_domain_size, only: max_blocks, ncat
       use ice_flux, only: rdg_conv, rdg_shear, strairxT, strairyT, &
           strairxU, strairyU, uocn, vocn, ss_tltx, ss_tlty, fmU, &
           strtltxU, strtltyU, strocnxU, strocnyU, strintxU, strintyU, taubxU, taubyU, &
@@ -238,8 +280,6 @@
           stresspU, stressmU, stress12U
       use ice_grid, only: tmask, umask, umaskCD, nmask, emask, uvm, epm, npm, &
           dxE, dxN, dxT, dxU, dyE, dyN, dyT, dyU, &
-          ratiodxN, ratiodxNr, ratiodyE, ratiodyEr, &
-          dxhy, dyhx, cxp, cyp, cxm, cym, &
           tarear, uarear, earear, narear, grid_average_X2Y, uarea, &
           grid_type, grid_ice, &
           grid_atm_dynu, grid_atm_dynv, grid_ocn_dynu, grid_ocn_dynv
@@ -250,7 +290,7 @@
           ice_timer_start, ice_timer_stop, timer_evp
       use ice_dyn_shared, only: evp_algorithm, stack_fields, unstack_fields, &
           DminTarea, visc_method, deformations, deformationsC_T, deformationsCD_T, &
-          strain_rates_U, &
+          strain_rates_U, dxhy, dyhx, cxp, cyp, cxm, cym, &
           iceTmask, iceUmask, iceEmask, iceNmask, &
           dyn_haloUpdate, fld2, fld3, fld4
       use ice_dyn_evp1d, only: dyn_evp1d_run

--- a/cicecore/cicedyn/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_vp.F90
@@ -43,16 +43,17 @@
           field_type_scalar, field_type_vector
       use ice_constants, only: c0, p027, p055, p111, p166, &
           p222, p25, p333, p5, c1
-      use ice_domain, only: nblocks, distrb_info
+      use ice_domain, only: nblocks, distrb_info, halo_info
       use ice_domain_size, only: max_blocks
       use ice_dyn_shared, only: dyn_prep1, dyn_prep2, dyn_finish, &
           cosw, sinw, fcor_blk, uvel_init, vvel_init, &
           seabed_stress_factor_LKD, seabed_stress_factor_prob, seabed_stress_method, &
-          seabed_stress, Ktens, stack_fields,  unstack_fields, fld2, fld3, fld4
+          seabed_stress, Ktens, stack_fields,  unstack_fields, fld2, fld3, fld4, &
+          dxhy, dyhx, cxp, cyp, cxm, cym
       use ice_fileunits, only: nu_diag
       use ice_flux, only: fmU
       use ice_global_reductions, only: global_sum
-      use ice_grid, only: dxT, dyT, dxhy, dyhx, cxp, cyp, cxm, cym, uarear
+      use ice_grid, only: dxT, dyT, uarear
       use ice_exit, only: abort_ice
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
       use icepack_intfc, only: icepack_ice_strength, icepack_query_parameters
@@ -120,19 +121,9 @@
       use ice_boundary, only: ice_HaloUpdate
       use ice_constants, only: c1, &
           field_loc_center, field_type_scalar
-      use ice_domain, only: blocks_ice, halo_info
+      use ice_domain, only: blocks_ice
       use ice_calendar, only: dt_dyn
       use ice_dyn_shared, only: init_dyn_shared
-!      use ice_grid, only: tarea
-
-      ! local variables
-
-      integer (kind=int_kind) :: &
-         i, j, iblk, &
-         ilo,ihi,jlo,jhi      ! beginning and end of physical domain
-
-      type (block) :: &
-         this_block           ! block information for current block
 
       call init_dyn_shared(dt_dyn)
 
@@ -167,7 +158,8 @@
       use ice_blocks, only: block, get_block, nx_block, ny_block
       use ice_domain, only: blocks_ice, halo_info, maskhalo_dyn
       use ice_domain_size, only: max_blocks, ncat
-      use ice_dyn_shared, only: deformations, iceTmask, iceUmask
+      use ice_dyn_shared, only: deformations, iceTmask, iceUmask, &
+          cxp, cyp, cxm, cym
       use ice_flux, only: rdg_conv, rdg_shear, strairxT, strairyT, &
           strairxU, strairyU, uocn, vocn, ss_tltx, ss_tlty, fmU, &
           strtltxU, strtltyU, strocnxU, strocnyU, strintxU, strintyU, taubxU, taubyU, &
@@ -176,7 +168,7 @@
           stressp_1, stressp_2, stressp_3, stressp_4, &
           stressm_1, stressm_2, stressm_3, stressm_4, &
           stress12_1, stress12_2, stress12_3, stress12_4
-      use ice_grid, only: tmask, umask, dxT, dyT, cxp, cyp, cxm, cym, &
+      use ice_grid, only: tmask, umask, dxT, dyT, &
           tarear, grid_type, grid_average_X2Y, &
           grid_atm_dynu, grid_atm_dynv, grid_ocn_dynu, grid_ocn_dynv
       use ice_state, only: aice, aiU, vice, vsno, uvel, vvel, divu, shear, &
@@ -686,9 +678,8 @@
       use ice_domain, only: maskhalo_dyn, halo_info
       use ice_domain_size, only: max_blocks
       use ice_flux, only:   fmU, TbU
-      use ice_grid, only: dxT, dyT, dxhy, dyhx, cxp, cyp, cxm, cym, &
-           uarear
-      use ice_dyn_shared, only: DminTarea
+      use ice_grid, only: dxT, dyT, uarear
+      use ice_dyn_shared, only: DminTarea, dxhy, dyhx, cxp, cyp, cxm, cym
       use ice_state, only: uvel, vvel, strength
       use ice_timers, only: ice_timer_start, ice_timer_stop, timer_bound
 

--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -63,7 +63,31 @@
                       ! if false, area flux is determined internally
                       ! and is passed out
 
+!      REMOVE? I
+      ! geometric quantities used for remapping transport
+!      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
+!         xav  , & ! mean T-cell value of x
+!         yav  , & ! mean T-cell value of y
+!         xxav , & ! mean T-cell value of xx
+!         xyav , & ! mean T-cell value of xy
+!         yyav , & ! mean T-cell value of yy
+!         yyav     ! mean T-cell value of yy
+!         xxxav, & ! mean T-cell value of xxx
+!         xxyav, & ! mean T-cell value of xxy
+!         xyyav, & ! mean T-cell value of xyy
+!         yyyav    ! mean T-cell value of yyy
+
+      real    (kind=dbl_kind), parameter :: xav=c0
+      real    (kind=dbl_kind), parameter :: yav=c0
+      real    (kind=dbl_kind), parameter :: xxav=c1/c12
+      real    (kind=dbl_kind), parameter :: yyav=c1/c12
+
       logical (kind=log_kind), parameter :: bugcheck = .false.
+
+      interface limited_gradient
+         module procedure limited_gradient_cn_dbl,   &
+                          limited_gradient_cn_scalar
+      end interface
 
 !=======================================================================
 ! Here is some information about how the incremental remapping scheme
@@ -261,13 +285,13 @@
 
       subroutine init_remap
 
-      use ice_domain, only: nblocks
-      use ice_grid, only: xav, yav, xxav, yyav
+!      use ice_domain, only: nblocks
+!      use ice_grid, only: xav, yav, xxav, yyav
 !                          dxT, dyT, xyav, &
 !                          xxxav, xxyav, xyyav, yyyav
 
-      integer (kind=int_kind) ::     &
-        i, j, iblk     ! standard indices
+!      integer (kind=int_kind) ::     &
+!        i, j, iblk     ! standard indices
 
       character(len=*), parameter :: subname = '(init_remap)'
 
@@ -277,27 +301,27 @@
       ! Note: On a rectangular grid, the integral of any odd function
       !       of x or y = 0.
 
-      !$OMP PARALLEL DO PRIVATE(iblk,i,j) SCHEDULE(runtime)
-      do iblk = 1, nblocks
-         do j = 1, ny_block
-         do i = 1, nx_block
-            xav(i,j,iblk) = c0
-            yav(i,j,iblk) = c0
+!      !$OMP PARALLEL DO PRIVATE(iblk,i,j) SCHEDULE(runtime)
+!      do iblk = 1, nblocks
+!         do j = 1, ny_block
+!         do i = 1, nx_block
+!            xav(i,j,iblk) = c0
+!            yav(i,j,iblk) = c0
 !!!            These formulas would be used on a rectangular grid
 !!!            with dimensions (dxT, dyT):
 !!!            xxav(i,j,iblk) = dxT(i,j,iblk)**2 / c12
 !!!            yyav(i,j,iblk) = dyT(i,j,iblk)**2 / c12
-            xxav(i,j,iblk) = c1/c12
-            yyav(i,j,iblk) = c1/c12
+!            xxav(i,j,iblk) = c1/c12
+!            yyav(i,j,iblk) = c1/c12
 !            xyav(i,j,iblk) = c0
 !            xxxav(i,j,iblk) = c0
 !            xxyav(i,j,iblk) = c0
 !            xyyav(i,j,iblk) = c0
 !            yyyav(i,j,iblk) = c0
-         enddo
-         enddo
-      enddo
-      !$OMP END PARALLEL DO
+!         enddo
+!         enddo
+!      enddo
+!      !$OMP END PARALLEL DO
 
       !-------------------------------------------------------------------
       ! Set logical l_fixed_area depending of the grid type.
@@ -356,8 +380,8 @@
       use ice_domain, only: nblocks, blocks_ice, halo_info, maskhalo_remap
       use ice_blocks, only: block, get_block, nghost
       use ice_grid, only: HTE, HTN, dxu, dyu,       &
-                          earea, narea, tarear, hm,                  &
-                          xav, yav, xxav, yyav
+                          earea, narea, tarear, hm!,                  &
+!                          xav, yav, xxav, yyav
 !                          xyav, xxxav, xxyav, xyyav, yyyav
       use ice_timers, only: ice_timer_start, ice_timer_stop, timer_bound
 
@@ -519,9 +543,10 @@
                                tracer_type,       depend,            &
                                has_dependents,    icellsnc(0,iblk),  &
                                indxinc(:,0),      indxjnc(:,0),      &
-                               hm     (:,:,iblk), xav   (:,:,iblk),  &
-                               yav    (:,:,iblk), xxav  (:,:,iblk),  &
-                               yyav   (:,:,iblk),                    &
+                               hm     (:,:,iblk),                    &
+!                              xav   (:,:,iblk),  &         
+!                               yav    (:,:,iblk), xxav  (:,:,iblk),  &
+!                               yyav   (:,:,iblk),                    &
 !                               xyav   (:,:,iblk),                    &
 !                               xxxav  (:,:,iblk), xxyav (:,:,iblk),  &
 !                               xyyav  (:,:,iblk), yyyav (:,:,iblk),  &
@@ -539,9 +564,10 @@
                                   tracer_type,         depend,              &
                                   has_dependents,      icellsnc (n,iblk),   &
                                   indxinc  (:,n),      indxjnc(:,n),        &
-                                  hm       (:,:,iblk), xav    (:,:,iblk),   &
-                                  yav      (:,:,iblk), xxav   (:,:,iblk),   &
-                                  yyav     (:,:,iblk),                      &
+                                  hm       (:,:,iblk),                      &
+!                                  xav    (:,:,iblk),   &
+!                                  yav      (:,:,iblk), xxav   (:,:,iblk),   &
+!                                  yyav     (:,:,iblk),                      &
 !                                  xyav     (:,:,iblk),                      &
 !                                  xxxav    (:,:,iblk), xxyav  (:,:,iblk),   &
 !                                  xyyav    (:,:,iblk), yyyav  (:,:,iblk),   &
@@ -1052,9 +1078,10 @@
                                    tracer_type,    depend,     &
                                    has_dependents, icells,     &
                                    indxi,          indxj,      &
-                                   hm,             xav,        &
-                                   yav,            xxav,       &
-                                   yyav,       &
+                                   hm,                         &
+!                                   xav,        &
+!                                   yav,            xxav,       &
+!                                   yyav,       &
 !                                   xyav,      &
 !                                   xxxav,          xxyav,      &
 !                                   xyyav,          yyyav,      &
@@ -1084,9 +1111,9 @@
          indxj
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) ::   &
-         hm                , & ! land/boundary mask, thickness (T-cell)
-         xav,  yav         , & ! mean T-cell values of x, y
-         xxav, yyav            ! mean T-cell values of xx, yy
+         hm                !, & ! land/boundary mask, thickness (T-cell)
+!         xav,  yav         , & ! mean T-cell values of x, y
+!         xxav, yyav            ! mean T-cell values of xx, yy
 !         xyav,             , & ! mean T-cell values of xy
 !         xxxav,xxyav,xyyav,yyyav ! mean T-cell values of xxx, xxy, xyy, yyy
 
@@ -1231,11 +1258,12 @@
 
             ! center of mass (mxav,myav) for each cell
             ! echmod: xyav = 0
-            mxav(i,j) = (mx(i,j)*xxav(i,j)    &
-                       + mc(i,j)*xav (i,j)) / mm(i,j)
-            myav(i,j) = (my(i,j)*yyav(i,j)    &
-                       + mc(i,j)*yav(i,j)) / mm(i,j)
-
+            mxav(i,j) = (mx(i,j)*xxav         & !(i,j)    &
+!                       + mc(i,j)*xav (i,j)) / mm(i,j)
+                       + mc(i,j)*xav ) / mm(i,j)
+            myav(i,j) = (my(i,j)*yyav         &!(i,j)    &
+!                       + mc(i,j)*yav(i,j)) / mm(i,j)
+                        + mc(i,j)*yav) / mm(i,j)
 !            mxav(i,j) = (mx(i,j)*xxav(i,j)    &
 !                       + my(i,j)*xyav(i,j)    &
 !                       + mc(i,j)*xav (i,j)) / mm(i,j)
@@ -1287,9 +1315,11 @@
 !                        w6 = my(i,j)*ty(i,j,nt)
                         w7 = c1 / (mm(i,j)*tm(i,j,nt))
                         ! echmod: grid arrays = 0
-                        mtxav(i,j,nt) = (w1*xav (i,j)  + w2*xxav (i,j))   &
+!                        mtxav(i,j,nt) = (w1*xav (i,j)  + w2*xxav (i,j))   &
+                        mtxav(i,j,nt) = (w1*xav + w2*xxav)   &
                                        * w7
-                        mtyav(i,j,nt) = (w1*yav(i,j)   + w3*yyav(i,j)) &
+                        mtyav(i,j,nt) = (w1*yav   + w3*yyav) &
+!                        mtyav(i,j,nt) = (w1*yav(i,j)   + w3*yyav(i,j)) &
                                        * w7
 
 !                        mtxav(i,j,nt) = (w1*xav (i,j)  + w2*xxav (i,j)   &
@@ -1365,12 +1395,12 @@
 ! authors William H. Lipscomb, LANL
 !         John R. Baumgardner, LANL
 
-      subroutine limited_gradient (nx_block, ny_block,   &
-                                   ilo, ihi, jlo, jhi,   &
-                                   nghost,               &
-                                   phi,      phimask,    &
-                                   cnx,      cny,        &
-                                   gx,       gy)
+      subroutine limited_gradient_cn_dbl (nx_block, ny_block,   &
+                                          ilo, ihi, jlo, jhi,   &
+                                          nghost,               &
+                                          phi,      phimask,    &
+                                          cnx,      cny,        &
+                                          gx,       gy)
 
       integer (kind=int_kind), intent(in) ::   &
          nx_block, ny_block, & ! block dimensions
@@ -1379,11 +1409,13 @@
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent (in) ::   &
          phi      , & ! input tracer field (mean values in each grid cell)
-         cnx      , & ! x-coordinate of phi relative to geometric center of cell
-         cny      , & ! y-coordinate of phi relative to geometric center of cell
          phimask      ! phimask(i,j) = 1 if phi(i,j) has physical meaning, = 0 otherwise.
                       ! For instance, aice has no physical meaning in land cells,
                       ! and hice no physical meaning where aice = 0.
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent (in) ::   &
+         cnx      , & ! x-coordinate of phi relative to geometric center of cell
+         cny          ! y-coordinate of phi relative to geometric center of cell½
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(out) ::   &
          gx       , & ! limited x-direction gradient
@@ -1410,7 +1442,7 @@
          puny        , & !
          gxtmp, gytmp    ! temporary term for x- and y- limited gradient
 
-      character(len=*), parameter :: subname = '(limited_gradient)'
+      character(len=*), parameter :: subname = '(limited_gradient_cn_dbl)'
 
       call icepack_query_parameters(puny_out=puny)
       call icepack_warnings_flush(nu_diag)
@@ -1508,7 +1540,160 @@
 
       enddo                     ! ij
 
-      end subroutine limited_gradient
+      end subroutine limited_gradient_cn_dbl
+
+!=======================================================================
+! Part 2 of the interface that allow cnx and cny to either matrices or scalars
+! Based on limited_gradient_cn_dbl
+! Updated by Till Rasmussen, DMI
+
+      subroutine limited_gradient_cn_scalar (nx_block, ny_block,   &
+                                            ilo, ihi, jlo, jhi,   &
+                                            nghost,               &
+                                            phi,      phimask,    &
+                                            cnx,      cny,        &
+                                            gx,       gy)
+
+      integer (kind=int_kind), intent(in) ::   &
+         nx_block, ny_block, & ! block dimensions
+         ilo,ihi,jlo,jhi   , & ! beginning and end of physical domain
+         nghost                ! number of ghost cells
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent (in) ::   &
+         phi      , & ! input tracer field (mean values in each grid cell)
+         phimask      ! phimask(i,j) = 1 if phi(i,j) has physical meaning, = 0 otherwise.
+                      ! For instance, aice has no physical meaning in land cells,
+                      ! and hice no physical meaning where aice = 0.
+
+      real (kind=dbl_kind), intent (in) ::   &
+         cnx      , & ! x-coordinate of phi relative to geometric center of cell
+         cny          ! y-coordinate of phi relative to geometric center of cell
+
+      real (kind=dbl_kind), dimension (nx_block,ny_block), intent(out) ::   &
+         gx       , & ! limited x-direction gradient
+         gy           ! limited y-direction gradient
+
+      ! local variables
+
+      integer (kind=int_kind) ::   &
+         i, j, ij , & ! standard indices
+         icells       ! number of cells to limit
+
+      integer (kind=int_kind), dimension(nx_block*ny_block) ::   &
+         indxi, indxj ! combined i/j horizontal indices
+
+      real (kind=dbl_kind) ::   &
+         phi_nw, phi_n, phi_ne , & ! values of phi in 8 neighbor cells
+         phi_w,         phi_e  , &
+         phi_sw, phi_s, phi_se , &
+         qmn, qmx              , & ! min and max value of phi within grid cell
+         pmn, pmx              , & ! min and max value of phi among neighbor cells
+         w1, w2, w3, w4            ! work variables
+
+      real (kind=dbl_kind) ::   &
+         puny        , & !
+         gxtmp, gytmp    ! temporary term for x- and y- limited gradient
+
+      character(len=*), parameter :: subname = '(limited_gradient_cn_scalar)'
+
+      call icepack_query_parameters(puny_out=puny)
+      call icepack_warnings_flush(nu_diag)
+      if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
+         file=__FILE__, line=__LINE__)
+
+      gx(:,:) = c0
+      gy(:,:) = c0
+
+      ! For nghost = 1, loop over physical cells and update ghost cells later
+      ! For nghost = 2, loop over a layer of ghost cells and skip the update
+
+      icells = 0
+      do j = jlo-nghost+1, jhi+nghost-1
+      do i = ilo-nghost+1, ihi+nghost-1
+         if (phimask(i,j) > puny) then
+            icells = icells + 1
+            indxi(icells) = i
+            indxj(icells) = j
+         endif                  ! phimask > puny
+      enddo
+      enddo
+
+      do ij = 1, icells
+         i = indxi(ij)
+         j = indxj(ij)
+
+         ! Store values of phi in the 8 neighbor cells.
+         ! Note: phimask = 1. or 0.  If phimask = 1., use the true value;
+         !  if phimask = 0., use the home cell value so that non-physical
+         !  values of phi do not contribute to the gradient.
+         phi_nw = phimask(i-1,j+1) * phi(i-1,j+1)  &
+            + (c1-phimask(i-1,j+1))* phi(i  ,j  )
+         phi_n  = phimask(i  ,j+1) * phi(i  ,j+1)  &
+            + (c1-phimask(i  ,j+1))* phi(i  ,j  )
+         phi_ne = phimask(i+1,j+1) * phi(i+1,j+1)  &
+            + (c1-phimask(i+1,j+1))* phi(i  ,j  )
+         phi_w  = phimask(i-1,j  ) * phi(i-1,j  )  &
+            + (c1-phimask(i-1,j  ))* phi(i  ,j  )
+         phi_e  = phimask(i+1,j  ) * phi(i+1,j  )  &
+            + (c1-phimask(i+1,j  ))* phi(i  ,j  )
+         phi_sw = phimask(i-1,j-1) * phi(i-1,j-1)  &
+            + (c1-phimask(i-1,j-1))* phi(i  ,j  )
+         phi_s  = phimask(i  ,j-1) * phi(i  ,j-1)  &
+            + (c1-phimask(i  ,j-1))* phi(i  ,j  )
+         phi_se = phimask(i+1,j-1) * phi(i+1,j-1)  &
+            + (c1-phimask(i+1,j-1))* phi(i  ,j  )
+
+         ! unlimited gradient components
+         ! (factors of two cancel out)
+
+         gxtmp = (phi_e - phi_w) * p5
+         gytmp = (phi_n - phi_s) * p5
+
+         ! minimum and maximum among the nine local cells
+         pmn = min (phi_nw, phi_n,  phi_ne, phi_w, phi(i,j),   &
+                    phi_e,  phi_sw, phi_s,  phi_se)
+         pmx = max (phi_nw, phi_n,  phi_ne, phi_w, phi(i,j),   &
+                    phi_e,  phi_sw, phi_s,  phi_se)
+
+         pmn = pmn - phi(i,j)
+         pmx = pmx - phi(i,j)
+
+         ! minimum and maximum deviation of phi within the cell
+         ! minimum and maximum deviation of phi within the cell
+         w1  =  (p5 - cnx) * gxtmp   &
+              + (p5 - cny) * gytmp
+         w2  =  (p5 - cnx) * gxtmp   &
+              - (p5 + cny) * gytmp
+         w3  = -(p5 + cnx) * gxtmp   &
+              - (p5 + cny) * gytmp
+         w4  =  (p5 - cny) * gytmp   &
+              - (p5 + cnx) * gxtmp
+
+         qmn = min (w1, w2, w3, w4)
+         qmx = max (w1, w2, w3, w4)
+
+         ! the limiting coefficient
+         if ( abs(qmn) > abs(pmn) ) then ! 'abs(qmn) > puny' not sufficient
+            w1 = max(c0, pmn/qmn)
+         else
+            w1 = c1
+         endif
+
+         if ( abs(qmx) > abs(pmx) ) then
+            w2 = max(c0, pmx/qmx)
+         else
+            w2 = c1
+         endif
+
+         w1 = min(w1, w2)
+
+         ! Limit the gradient components
+         gx(i,j) = w1 * gxtmp
+         gy(i,j) = w1 * gytmp
+
+      enddo                     ! ij
+
+      end subroutine limited_gradient_cn_scalar
 
 !=======================================================================
 !

--- a/cicecore/cicedyn/infrastructure/ice_grid.F90
+++ b/cicecore/cicedyn/infrastructure/ice_grid.F90
@@ -167,13 +167,6 @@
 !         xyyav, & ! mean T-cell value of xyy
 !         yyyav    ! mean T-cell value of yyy
 
-      real (kind=dbl_kind), &
-         dimension (:,:,:,:,:), allocatable, public :: &
-         mne, & ! matrices used for coordinate transformations in remapping
-         mnw, & ! ne = northeast corner, nw = northwest, etc.
-         mse, &
-         msw
-
       ! masks
       real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          hm     , & ! land/boundary mask, thickness (T-cell)
@@ -288,10 +281,6 @@
          latn_bounds(4,nx_block,ny_block,max_blocks), & ! latitude of gridbox corners for N point
          lone_bounds(4,nx_block,ny_block,max_blocks), & ! longitude of gridbox corners for E point
          late_bounds(4,nx_block,ny_block,max_blocks), & ! latitude of gridbox corners for E point
-         mne  (2,2,nx_block,ny_block,max_blocks), & ! matrices used for coordinate transformations in remapping
-         mnw  (2,2,nx_block,ny_block,max_blocks), & ! ne = northeast corner, nw = northwest, etc.
-         mse  (2,2,nx_block,ny_block,max_blocks), &
-         msw  (2,2,nx_block,ny_block,max_blocks), &
          stat=ierr)
       if (ierr/=0) call abort_ice(subname//'ERROR: Out of memory1')
 

--- a/cicecore/cicedyn/infrastructure/ice_grid.F90
+++ b/cicecore/cicedyn/infrastructure/ice_grid.F90
@@ -154,19 +154,6 @@
          lone_bounds, & ! longitude of gridbox corners for E point
          late_bounds    ! latitude of gridbox corners for E point
 
-      ! geometric quantities used for remapping transport
-      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
-         xav  , & ! mean T-cell value of x
-         yav  , & ! mean T-cell value of y
-         xxav , & ! mean T-cell value of xx
-!         xyav , & ! mean T-cell value of xy
-!         yyav , & ! mean T-cell value of yy
-         yyav     ! mean T-cell value of yy
-!         xxxav, & ! mean T-cell value of xxx
-!         xxyav, & ! mean T-cell value of xxy
-!         xyyav, & ! mean T-cell value of xyy
-!         yyyav    ! mean T-cell value of yyy
-
       ! masks
       real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
          hm     , & ! land/boundary mask, thickness (T-cell)
@@ -255,10 +242,6 @@
          cxm      (nx_block,ny_block,max_blocks), & ! 0.5*HTN - 1.5*HTS
          dxhy     (nx_block,ny_block,max_blocks), & ! 0.5*(HTE - HTW)
          dyhx     (nx_block,ny_block,max_blocks), & ! 0.5*(HTN - HTS)
-         xav      (nx_block,ny_block,max_blocks), & ! mean T-cell value of x
-         yav      (nx_block,ny_block,max_blocks), & ! mean T-cell value of y
-         xxav     (nx_block,ny_block,max_blocks), & ! mean T-cell value of xx
-         yyav     (nx_block,ny_block,max_blocks), & ! mean T-cell value of yy
          hm       (nx_block,ny_block,max_blocks), & ! land/boundary mask, thickness (T-cell)
          bm       (nx_block,ny_block,max_blocks), & ! task/block id
          uvm      (nx_block,ny_block,max_blocks), & ! land/boundary mask, velocity (U-cell) - water in case of all water point

--- a/cicecore/cicedyn/infrastructure/ice_grid.F90
+++ b/cicecore/cicedyn/infrastructure/ice_grid.F90
@@ -115,20 +115,6 @@
          G_HTE  , & ! length of eastern edge of T-cell (global ext.)
          G_HTN      ! length of northern edge of T-cell (global ext.)
 
-      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
-         cyp    , & ! 1.5*HTE(i,j)-0.5*HTW(i,j) = 1.5*HTE(i,j)-0.5*HTE(i-1,j)
-         cxp    , & ! 1.5*HTN(i,j)-0.5*HTS(i,j) = 1.5*HTN(i,j)-0.5*HTN(i,j-1)
-         cym    , & ! 0.5*HTE(i,j)-1.5*HTW(i,j) = 0.5*HTE(i,j)-1.5*HTE(i-1,j)
-         cxm    , & ! 0.5*HTN(i,j)-1.5*HTS(i,j) = 0.5*HTN(i,j)-1.5*HTN(i,j-1)
-         dxhy   , & ! 0.5*(HTE(i,j) - HTW(i,j)) = 0.5*(HTE(i,j) - HTE(i-1,j))
-         dyhx       ! 0.5*(HTN(i,j) - HTS(i,j)) = 0.5*(HTN(i,j) - HTN(i,j-1))
-
-      real (kind=dbl_kind), dimension (:,:,:), allocatable, public :: &
-         ratiodxN    , & ! - dxN(i+1,j)   / dxN(i,j)
-         ratiodyE    , & ! - dyE(i  ,j+1) / dyE(i,j)
-         ratiodxNr   , & !   1 / ratiodxN
-         ratiodyEr       !   1 / ratiodyE
-
       ! grid dimensions for rectangular grid
       real (kind=dbl_kind), public ::  &
          dxrect, & !  user_specified spacing (cm) in x-direction (uniform HTN)
@@ -236,12 +222,6 @@
          ANGLET   (nx_block,ny_block,max_blocks), & ! ANGLE converted to T-cells
          bathymetry(nx_block,ny_block,max_blocks),& ! ocean depth, for grounding keels and bergs (m)
          ocn_gridcell_frac(nx_block,ny_block,max_blocks),& ! only relevant for lat-lon grids
-         cyp      (nx_block,ny_block,max_blocks), & ! 1.5*HTE - 0.5*HTW
-         cxp      (nx_block,ny_block,max_blocks), & ! 1.5*HTN - 0.5*HTS
-         cym      (nx_block,ny_block,max_blocks), & ! 0.5*HTE - 1.5*HTW
-         cxm      (nx_block,ny_block,max_blocks), & ! 0.5*HTN - 1.5*HTS
-         dxhy     (nx_block,ny_block,max_blocks), & ! 0.5*(HTE - HTW)
-         dyhx     (nx_block,ny_block,max_blocks), & ! 0.5*(HTN - HTS)
          hm       (nx_block,ny_block,max_blocks), & ! land/boundary mask, thickness (T-cell)
          bm       (nx_block,ny_block,max_blocks), & ! task/block id
          uvm      (nx_block,ny_block,max_blocks), & ! land/boundary mask, velocity (U-cell) - water in case of all water point
@@ -266,16 +246,6 @@
          late_bounds(4,nx_block,ny_block,max_blocks), & ! latitude of gridbox corners for E point
          stat=ierr)
       if (ierr/=0) call abort_ice(subname//'ERROR: Out of memory1')
-
-      if (grid_ice == 'CD' .or. grid_ice == 'C') then
-         allocate( &
-            ratiodxN (nx_block,ny_block,max_blocks), &
-            ratiodyE (nx_block,ny_block,max_blocks), &
-            ratiodxNr(nx_block,ny_block,max_blocks), &
-            ratiodyEr(nx_block,ny_block,max_blocks), &
-            stat=ierr)
-         if (ierr/=0) call abort_ice(subname//'ERROR: Out of memory2')
-      endif
 
       if (save_ghte_ghtn) then
          if (my_task == master_task) then
@@ -571,34 +541,6 @@
          enddo
          enddo
 
-         do j = jlo, jhi
-         do i = ilo, ihi
-            dxhy(i,j,iblk) = p5*(HTE(i,j,iblk) - HTE(i-1,j,iblk))
-            dyhx(i,j,iblk) = p5*(HTN(i,j,iblk) - HTN(i,j-1,iblk))
-         enddo
-         enddo
-
-         do j = jlo, jhi+1
-         do i = ilo, ihi+1
-            cyp(i,j,iblk) = (c1p5*HTE(i,j,iblk) - p5*HTE(i-1,j,iblk))
-            cxp(i,j,iblk) = (c1p5*HTN(i,j,iblk) - p5*HTN(i,j-1,iblk))
-            ! match order of operations in cyp, cxp for tripole grids
-            cym(i,j,iblk) = -(c1p5*HTE(i-1,j,iblk) - p5*HTE(i,j,iblk))
-            cxm(i,j,iblk) = -(c1p5*HTN(i,j-1,iblk) - p5*HTN(i,j,iblk))
-         enddo
-         enddo
-
-         if (grid_ice == 'CD' .or. grid_ice == 'C') then
-            do j = jlo, jhi
-            do i = ilo, ihi
-               ratiodxN (i,j,iblk) = - dxN(i+1,j  ,iblk) / dxN(i,j,iblk)
-               ratiodyE (i,j,iblk) = - dyE(i  ,j+1,iblk) / dyE(i,j,iblk)
-               ratiodxNr(i,j,iblk) =   c1 / ratiodxN(i,j,iblk)
-               ratiodyEr(i,j,iblk) =   c1 / ratiodyE(i,j,iblk)
-            enddo
-            enddo
-         endif
-
       enddo                     ! iblk
       !$OMP END PARALLEL DO
 
@@ -613,13 +555,6 @@
       !-----------------------------------------------------------------
 
       call ice_timer_start(timer_bound)
-
-      call ice_HaloUpdate (dxhy,               halo_info, &
-                           field_loc_center,   field_type_vector, &
-                           fillValue=c1)
-      call ice_HaloUpdate (dyhx,               halo_info, &
-                           field_loc_center,   field_type_vector, &
-                           fillValue=c1)
 
       ! Update just on the tripole seam to ensure bit-for-bit symmetry across seam
       call ice_HaloUpdate (tarea,              halo_info, &
@@ -1325,12 +1260,12 @@
             dyN   (i,j,iblk) = 1.e36_dbl_kind
             dxE   (i,j,iblk) = 1.e36_dbl_kind
             dyE   (i,j,iblk) = 1.e36_dbl_kind
-            dxhy  (i,j,iblk) = 1.e36_dbl_kind
-            dyhx  (i,j,iblk) = 1.e36_dbl_kind
-            cyp   (i,j,iblk) = 1.e36_dbl_kind
-            cxp   (i,j,iblk) = 1.e36_dbl_kind
-            cym   (i,j,iblk) = 1.e36_dbl_kind
-            cxm   (i,j,iblk) = 1.e36_dbl_kind
+!TILL            dxhy  (i,j,iblk) = 1.e36_dbl_kind
+!TILL            dyhx  (i,j,iblk) = 1.e36_dbl_kind
+!TILL            cyp   (i,j,iblk) = 1.e36_dbl_kind
+!TILL            cxp   (i,j,iblk) = 1.e36_dbl_kind
+!TILL            cym   (i,j,iblk) = 1.e36_dbl_kind
+!TILL            cxm   (i,j,iblk) = 1.e36_dbl_kind
          enddo
          enddo
       enddo


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
  Reduce and remove arrays not needed from ice_grid
- [ ] Developer(s): 
    Till Rasmussen, DMI
- [ x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    Bit for Bit
- How much do the PR code changes differ from the unmodified code? 
    - [ x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x ] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [ x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [ x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ x] No 
- [ ] Please provide any additional information or relevant details below:
Changes according to these principles
a/ If not used remove
b/ If only used in specific modules move there and allocate when needed.
In ice_grid:
1/ Removed mne, mnw, mse, msw. Not used. Points to remapping
2/ xav, yav, xxav, yyav changed to paremeters and moved to remapping where they are used. First two are 0. Should be removed. The latter two are 1/12. An interface was needed as subroutine limited_gradient required input as array. This could probably be fixed in alternative ways.
3/ Moved cyp, cxp, cym, cxm, dxhy, dyhx. Moved to ice_dyn_shared. Only allocate when 2d B-grid (EAP, EVP, VP).
Moved  ratiodxN, ratiodyE, ratiodxNr, ratiodyEr to ice_dyn_evp. Only allocated when C grid
@dabail10 Many grid parameters are set to 1e36 within CESM cpp flag. I cannot really check. any preferences for what to do?