### PR TITLE
Fix for ice_mesh_mod with grid variables removed

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -439,7 +439,6 @@ contains
     use ice_grid      , only : uarea, uarear, tarear!, tinyarea
     use ice_grid      , only : dxT, dyT, dxU, dyU
     use ice_grid      , only : makemask
-    use ice_dyn_shared, only : dyhx, dxhy, cyp, cxp, cym, cxm
     use ice_boundary  , only : ice_HaloUpdate
     use ice_domain    , only : blocks_ice, nblocks, halo_info, distrb_info
     use ice_constants , only : c0, c1, p25
@@ -536,12 +535,6 @@ contains
              dyT   (i,j,iblk) = 1.e36_dbl_kind
              dxU   (i,j,iblk) = 1.e36_dbl_kind
              dyU   (i,j,iblk) = 1.e36_dbl_kind
-             dxhy  (i,j,iblk) = 1.e36_dbl_kind
-             dyhx  (i,j,iblk) = 1.e36_dbl_kind
-             cyp   (i,j,iblk) = 1.e36_dbl_kind
-             cxp   (i,j,iblk) = 1.e36_dbl_kind
-             cym   (i,j,iblk) = 1.e36_dbl_kind
-             cxm   (i,j,iblk) = 1.e36_dbl_kind
           enddo
        enddo
     enddo


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
 Fix for ice_mesh_mod in nuopc/cmeps for grid variables removed.
- [X] Developer(s): 
 dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Tested in CESM.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
Just the one module related to NUOPC CMEPS.