### PR TITLE
io: allow disabling coordinates in history files

### DIFF
--- a/cicecore/cicedyn/analysis/ice_history.F90
+++ b/cicecore/cicedyn/analysis/ice_history.F90
@@ -447,6 +447,14 @@
       if (f_Tsnz (1:1) /= 'x')                          f_VGRDs = .true.
       if (tr_fsd)                                       f_NFSD  = .true.
 
+      call broadcast_scalar (f_tlon, master_task)
+      call broadcast_scalar (f_tlat, master_task)
+      call broadcast_scalar (f_ulon, master_task)
+      call broadcast_scalar (f_ulat, master_task)
+      call broadcast_scalar (f_nlon, master_task)
+      call broadcast_scalar (f_nlat, master_task)
+      call broadcast_scalar (f_elon, master_task)
+      call broadcast_scalar (f_elat, master_task)
       call broadcast_scalar (f_tmask, master_task)
       call broadcast_scalar (f_umask, master_task)
       call broadcast_scalar (f_nmask, master_task)
@@ -1972,6 +1980,21 @@
 
       ! floe size distribution
        call init_hist_fsd_4Df
+
+      !-----------------------------------------------------------------
+      ! fill icoord array with namelist values
+      !-----------------------------------------------------------------
+
+       icoord=.true.
+
+       icoord(n_tlon   ) = f_tlon
+       icoord(n_tlat   ) = f_tlat
+       icoord(n_ulon   ) = f_ulon
+       icoord(n_ulat   ) = f_ulat
+       icoord(n_nlon   ) = f_nlon
+       icoord(n_nlat   ) = f_nlat
+       icoord(n_elon   ) = f_elon
+       icoord(n_elat   ) = f_elat
 
       !-----------------------------------------------------------------
       ! fill igrd array with namelist values

--- a/cicecore/cicedyn/analysis/ice_history_shared.F90
+++ b/cicecore/cicedyn/analysis/ice_history_shared.F90
@@ -131,6 +131,7 @@
          avail_hist_fields(max_avail_hist_fields)
 
       integer (kind=int_kind), parameter, public :: &
+         ncoord   = 8           , & ! number of coordinate variables: TLON, TLAT, ULON, ULAT, NLON, NLAT, ELON, ELAT
          nvar_grd = 21          , & ! number of grid fields that can be written
                                     !   excluding grid vertices
          nvar_grdz = 6              ! number of category/vertical grid fields written
@@ -165,6 +166,7 @@
          avgct(max_nstrm)   ! average sample counter
 
       logical (kind=log_kind), public :: &
+         icoord(ncoord) , &    ! true if coord field is written to output file
          igrd (nvar_grd), &    ! true if grid field is written to output file
          igrdz(nvar_grdz)      ! true if category/vertical grid field is written
 
@@ -194,6 +196,10 @@
       !---------------------------------------------------------------
 
       logical (kind=log_kind), public :: &
+           f_tlon      = .true., f_tlat       = .true., &
+           f_ulon      = .true., f_ulat       = .true., &
+           f_nlon      = .true., f_nlat       = .true., &
+           f_elon      = .true., f_elat       = .true., &
            f_tmask     = .true., f_umask      = .true., &
            f_nmask     = .true., f_emask      = .true., &
            f_blkmask   = .true., &
@@ -362,6 +368,10 @@
       !---------------------------------------------------------------
 
       namelist / icefields_nml /     &
+           f_tlon     , f_tlat     , &
+           f_ulon     , f_ulat     , &
+           f_nlon     , f_nlat     , &
+           f_elon     , f_elat     , &
            f_tmask    , f_umask    , &
            f_nmask    , f_emask    , &
            f_blkmask  , &
@@ -529,6 +539,15 @@
       !---------------------------------------------------------------
 
       integer (kind=int_kind), parameter, public :: &
+           n_tlon       = 1,  &
+           n_tlat       = 2,  &
+           n_ulon       = 3,  &
+           n_ulat       = 4,  &
+           n_nlon       = 5,  &
+           n_nlat       = 6,  &
+           n_elon       = 7,  &
+           n_elat       = 8,  &
+
            n_tmask      = 1,  &
            n_umask      = 2,  &
            n_nmask      = 3,  &

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -113,9 +113,6 @@
       ! time coord
       TYPE(coord_attributes) :: time_coord
 
-      ! 8 coordinate variables: TLON, TLAT, ULON, ULAT, NLON, NLAT, ELON, ELAT
-      INTEGER (kind=int_kind), PARAMETER :: ncoord = 8
-
       ! 4 vertices in each grid cell
       INTEGER (kind=int_kind), PARAMETER :: nverts = 4
 

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -260,39 +260,42 @@
          ! define information for required time-invariant variables
          !-----------------------------------------------------------------
 
-         ind = 0
-         ind = ind + 1
-         var_coord(ind) = coord_attributes('TLON', &
-                          'T grid center longitude', 'degrees_east')
-         coord_bounds(ind) = 'lont_bounds'
-         ind = ind + 1
-         var_coord(ind) = coord_attributes('TLAT', &
-                          'T grid center latitude',  'degrees_north')
-         coord_bounds(ind) = 'latt_bounds'
-         ind = ind + 1
-         var_coord(ind) = coord_attributes('ULON', &
-                          'U grid center longitude', 'degrees_east')
-         coord_bounds(ind) = 'lonu_bounds'
-         ind = ind + 1
-         var_coord(ind) = coord_attributes('ULAT', &
-                          'U grid center latitude',  'degrees_north')
-         coord_bounds(ind) = 'latu_bounds'
-         ind = ind + 1
-         var_coord(ind) = coord_attributes('NLON', &
-                          'N grid center longitude', 'degrees_east')
-         coord_bounds(ind) = 'lonn_bounds'
-         ind = ind + 1
-         var_coord(ind) = coord_attributes('NLAT', &
-                          'N grid center latitude',  'degrees_north')
-         coord_bounds(ind) = 'latn_bounds'
-         ind = ind + 1
-         var_coord(ind) = coord_attributes('ELON', &
-                          'E grid center longitude', 'degrees_east')
-         coord_bounds(ind) = 'lone_bounds'
-         ind = ind + 1
-         var_coord(ind) = coord_attributes('ELAT', &
-                          'E grid center latitude',  'degrees_north')
-         coord_bounds(ind) = 'late_bounds'
+         do ind = 1, ncoord
+            select case (ind)
+               case(n_tlon)
+                  var_coord(ind) = coord_attributes('TLON', &
+                                   'T grid center longitude', 'degrees_east')
+                  coord_bounds(ind) = 'lont_bounds'
+               case(n_tlat)
+                  var_coord(ind) = coord_attributes('TLAT', &
+                                   'T grid center latitude',  'degrees_north')
+                  coord_bounds(ind) = 'latt_bounds'
+               case(n_ulon)
+                  var_coord(ind) = coord_attributes('ULON', &
+                                   'U grid center longitude', 'degrees_east')
+                  coord_bounds(ind) = 'lonu_bounds'
+               case(n_ulat)
+                  var_coord(ind) = coord_attributes('ULAT', &
+                                   'U grid center latitude',  'degrees_north')
+                  coord_bounds(ind) = 'latu_bounds'
+               case(n_nlon)
+                  var_coord(ind) = coord_attributes('NLON', &
+                                   'N grid center longitude', 'degrees_east')
+                  coord_bounds(ind) = 'lonn_bounds'
+               case(n_nlat)
+                  var_coord(ind) = coord_attributes('NLAT', &
+                                   'N grid center latitude',  'degrees_north')
+                  coord_bounds(ind) = 'latn_bounds'
+               case(n_elon)
+                  var_coord(ind) = coord_attributes('ELON', &
+                                   'E grid center longitude', 'degrees_east')
+                  coord_bounds(ind) = 'lone_bounds'
+               case(n_elat)
+                  var_coord(ind) = coord_attributes('ELAT', &
+                                   'E grid center latitude',  'degrees_north')
+                  coord_bounds(ind) = 'late_bounds'
+            end select
+         end do
 
          var_grdz(1) = coord_attributes('NCAT', 'category maximum thickness', 'm')
          var_grdz(2) = coord_attributes('VGRDi', 'vertical ice levels', '1')

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -273,39 +273,42 @@
       ! define information for required time-invariant variables
       !-----------------------------------------------------------------
 
-      ind = 0
-      ind = ind + 1
-      var_coord(ind) = coord_attributes('TLON', &
-                       'T grid center longitude', 'degrees_east')
-      coord_bounds(ind) = 'lont_bounds'
-      ind = ind + 1
-      var_coord(ind) = coord_attributes('TLAT', &
-                       'T grid center latitude',  'degrees_north')
-      coord_bounds(ind) = 'latt_bounds'
-      ind = ind + 1
-      var_coord(ind) = coord_attributes('ULON', &
-                       'U grid center longitude', 'degrees_east')
-      coord_bounds(ind) = 'lonu_bounds'
-      ind = ind + 1
-      var_coord(ind) = coord_attributes('ULAT', &
-                       'U grid center latitude',  'degrees_north')
-      coord_bounds(ind) = 'latu_bounds'
-      ind = ind + 1
-      var_coord(ind) = coord_attributes('NLON', &
-                       'N grid center longitude', 'degrees_east')
-      coord_bounds(ind) = 'lonn_bounds'
-      ind = ind + 1
-      var_coord(ind) = coord_attributes('NLAT', &
-                       'N grid center latitude',  'degrees_north')
-      coord_bounds(ind) = 'latn_bounds'
-      ind = ind + 1
-      var_coord(ind) = coord_attributes('ELON', &
-                       'E grid center longitude', 'degrees_east')
-      coord_bounds(ind) = 'lone_bounds'
-      ind = ind + 1
-      var_coord(ind) = coord_attributes('ELAT', &
-                       'E grid center latitude',  'degrees_north')
-      coord_bounds(ind) = 'late_bounds'
+      do ind = 1, ncoord
+         select case (ind)
+            case(n_tlon)
+               var_coord(ind) = coord_attributes('TLON', &
+                                'T grid center longitude', 'degrees_east')
+               coord_bounds(ind) = 'lont_bounds'
+            case(n_tlat)
+               var_coord(ind) = coord_attributes('TLAT', &
+                                'T grid center latitude',  'degrees_north')
+               coord_bounds(ind) = 'latt_bounds'
+            case(n_ulon)
+               var_coord(ind) = coord_attributes('ULON', &
+                                'U grid center longitude', 'degrees_east')
+               coord_bounds(ind) = 'lonu_bounds'
+            case(n_ulat)
+               var_coord(ind) = coord_attributes('ULAT', &
+                                'U grid center latitude',  'degrees_north')
+               coord_bounds(ind) = 'latu_bounds'
+            case(n_nlon)
+               var_coord(ind) = coord_attributes('NLON', &
+                                'N grid center longitude', 'degrees_east')
+               coord_bounds(ind) = 'lonn_bounds'
+            case(n_nlat)
+               var_coord(ind) = coord_attributes('NLAT', &
+                                'N grid center latitude',  'degrees_north')
+               coord_bounds(ind) = 'latn_bounds'
+            case(n_elon)
+               var_coord(ind) = coord_attributes('ELON', &
+                                'E grid center longitude', 'degrees_east')
+               coord_bounds(ind) = 'lone_bounds'
+            case(n_elat)
+               var_coord(ind) = coord_attributes('ELAT', &
+                                'E grid center latitude',  'degrees_north')
+               coord_bounds(ind) = 'late_bounds'
+         end select
+      end do
 
       var_grdz(1) = coord_attributes('NCAT', 'category maximum thickness', 'm')
       var_grdz(2) = coord_attributes('VGRDi', 'vertical ice levels', '1')

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -418,16 +418,18 @@
       dimid2(2) = jmtid
 
       do i = 1, ncoord
-         call ice_hist_coord_def(File, var_coord(i), lprecision, dimid2, varid)
-         call ice_write_hist_fill(File,varid,var_coord(i)%short_name,history_precision)
-         if (var_coord(i)%short_name == 'ULAT') then
-            call ice_pio_check(pio_put_att(File,varid,'comment', &
-                 trim('Latitude of NE corner of T grid cell')), &
-                 subname//' ERROR: defining att comment',file=__FILE__,line=__LINE__)
-         endif
-         if (f_bounds) then
-            call ice_pio_check(pio_put_att(File, varid, 'bounds', trim(coord_bounds(i))), &
-                 subname//' ERROR: defining att bounds '//trim(coord_bounds(i)),file=__FILE__,line=__LINE__)
+         if (icoord(i)) then
+            call ice_hist_coord_def(File, var_coord(i), lprecision, dimid2, varid)
+            call ice_write_hist_fill(File,varid,var_coord(i)%short_name,history_precision)
+            if (var_coord(i)%short_name == 'ULAT') then
+               call ice_pio_check(pio_put_att(File,varid,'comment', &
+                    trim('Latitude of NE corner of T grid cell')), &
+                    subname//' ERROR: defining att comment',file=__FILE__,line=__LINE__)
+            endif
+            if (f_bounds) then
+               call ice_pio_check(pio_put_att(File, varid, 'bounds', trim(coord_bounds(i))), &
+                    subname//' ERROR: defining att bounds '//trim(coord_bounds(i)),file=__FILE__,line=__LINE__)
+            endif
          endif
       enddo
 
@@ -706,38 +708,40 @@
       allocate(workr2(nx_block,ny_block,nblocks))
 
       do i = 1,ncoord
-         call ice_pio_check(pio_inq_varid(File, var_coord(i)%short_name, varid), &
-              subname//' ERROR: getting '//var_coord(i)%short_name ,file=__FILE__,line=__LINE__)
-         SELECT CASE (var_coord(i)%short_name)
-            CASE ('TLON')
-              ! Convert T grid longitude from -180 -> 180 to 0 to 360
-                 workd2(:,:,:) = mod(tlon(:,:,1:nblocks)*rad_to_deg + c360, c360)
-            CASE ('TLAT')
-              workd2(:,:,:) = tlat(:,:,1:nblocks)*rad_to_deg
-            CASE ('ULON')
-              workd2(:,:,:) = ulon(:,:,1:nblocks)*rad_to_deg
-            CASE ('ULAT')
-              workd2(:,:,:) = ulat(:,:,1:nblocks)*rad_to_deg
-            CASE ('NLON')
-              workd2(:,:,:) = nlon(:,:,1:nblocks)*rad_to_deg
-            CASE ('NLAT')
-              workd2(:,:,:) = nlat(:,:,1:nblocks)*rad_to_deg
-            CASE ('ELON')
-              workd2(:,:,:) = elon(:,:,1:nblocks)*rad_to_deg
-            CASE ('ELAT')
-              workd2(:,:,:) = elat(:,:,1:nblocks)*rad_to_deg
-         END SELECT
-         if (history_precision == 8) then
-            call pio_write_darray(File, varid, iodesc2d, &
-                 workd2, status, fillval=spval_dbl)
-         else
-            workr2 = workd2
-            call pio_write_darray(File, varid, iodesc2d, &
-                 workr2, status, fillval=spval)
-         endif
+         if(icoord(i)) then
+            call ice_pio_check(pio_inq_varid(File, var_coord(i)%short_name, varid), &
+                 subname//' ERROR: getting '//var_coord(i)%short_name ,file=__FILE__,line=__LINE__)
+            SELECT CASE (var_coord(i)%short_name)
+               CASE ('TLON')
+                 ! Convert T grid longitude from -180 -> 180 to 0 to 360
+                    workd2(:,:,:) = mod(tlon(:,:,1:nblocks)*rad_to_deg + c360, c360)
+               CASE ('TLAT')
+                 workd2(:,:,:) = tlat(:,:,1:nblocks)*rad_to_deg
+               CASE ('ULON')
+                 workd2(:,:,:) = ulon(:,:,1:nblocks)*rad_to_deg
+               CASE ('ULAT')
+                 workd2(:,:,:) = ulat(:,:,1:nblocks)*rad_to_deg
+               CASE ('NLON')
+                 workd2(:,:,:) = nlon(:,:,1:nblocks)*rad_to_deg
+               CASE ('NLAT')
+                 workd2(:,:,:) = nlat(:,:,1:nblocks)*rad_to_deg
+               CASE ('ELON')
+                 workd2(:,:,:) = elon(:,:,1:nblocks)*rad_to_deg
+               CASE ('ELAT')
+                 workd2(:,:,:) = elat(:,:,1:nblocks)*rad_to_deg
+            END SELECT
+            if (history_precision == 8) then
+               call pio_write_darray(File, varid, iodesc2d, &
+                    workd2, status, fillval=spval_dbl)
+            else
+               workr2 = workd2
+               call pio_write_darray(File, varid, iodesc2d, &
+                    workr2, status, fillval=spval)
+            endif
 
-         call ice_pio_check(status,subname//' ERROR: writing '//avail_hist_fields(n)%vname, &
-                            file=__FILE__,line=__LINE__)
+            call ice_pio_check(status,subname//' ERROR: writing '//avail_hist_fields(n)%vname, &
+                               file=__FILE__,line=__LINE__)
+         endif
       enddo
 
       ! Extra dimensions (NCAT, NFSD, VGRD*)

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -110,9 +110,6 @@
       ! time coord
       TYPE(coord_attributes) :: time_coord
 
-      ! 8 coordinate variables: TLON, TLAT, ULON, ULAT, NLON, NLAT, ELON, ELAT
-      INTEGER (kind=int_kind), PARAMETER :: ncoord = 8
-
       ! 4 vertices in each grid cell
       INTEGER (kind=int_kind), PARAMETER :: nverts = 4
 

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -471,6 +471,14 @@
 /
 
 &icefields_nml
+    f_tlon         = .true.
+    f_tlat         = .true.
+    f_ulon         = .true.
+    f_ulat         = .true.
+    f_nlon         = .true.
+    f_nlat         = .true.
+    f_elon         = .true.
+    f_elat         = .true.
     f_tmask        = .true.
     f_umask        = .false.
     f_nmask        = .false.


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    See title.
- [x] Developer(s): 
    me.
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
   Base suite is bit for bit  (**EDIT** I did run the io_suite but I do not have PIO on our machines so the PIO tests fail to build).
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
~~~
ice_history_shared: add namelist flags for coordinate variables

Users might not wish for all 8 coordinate variables to be written to
each history file, so add namelist flags allowing to disable each
coordinate variable independantly, following the approach used for the
other grid variables. Move the definition of 'ncoord' from each IO
backend to 'ice_history_shared'. Note that we already 'use' the whole of
ice_history_shared in ice_history_write, so we do not need to adjust the
use statement.

Note that the code that writes these variables in module
'ice_history_write' in each of the IO backends is not modified, it will
be adjusted in a following commit.

io_{netcdf,pio2}/ice_history_write: define coordinates attributes in a loop

In ice_history_write::ice_write_hist, we initialize the 'var_coord' and
'coord_bounds' arrays by manually incrementing 'ind' and initializing
each elements with the corresponding information for each coordinate
variable. The rest of the code in that subroutine instead uses a loop on
'ncoord', which is a parameter holding the number of coordinates
variable, along with 'select' statements.

The latter approach is more elegant and also more flexible if we change
the number of coordinates variables. Refactor the code to use a loop and
leverage the integers n_{u,t,n,e}{lon,lat} added in the previous commit,
in both io_netcdf and io_pio2, which have identical code in this part of
the subroutine.

io_{netcdf,pio2}/ice_history_write: use namelist flags for coordinate variables

In order to enable the namelist flags for each coordinate variables
added in the previous commit, adjust the code of the io_netcdf and
io_pio2 backends by checking the value of 'icoord(i)' for each loop on
'ncoord' that calls NetCDF or PIO functions.

Add the new flags to the reference namelist.
~~~
