### PR TITLE
Set 'idate0' and 'use_leap_years' in nuopc cap

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -675,10 +675,8 @@ contains
     else
       if(mastertask) write(nu_diag,*) trim(subname)//'WARNING: pio_typename from driver needs to be set for netcdf output to work'
     end if
-    ! Set use_leap_years as some CICE calls use this instead of the calendar type
-    call ESMF_TimeGet( currTime, calkindflag=esmf_caltype, rc=rc )
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (esmf_caltype == ESMF_CALKIND_GREGORIAN) use_leap_years = .true.
+
+    
 
 #else
 
@@ -793,7 +791,7 @@ contains
     call cice_init2()
     call t_stopf ('cice_init2')
     !---------------------------------------------------------------------------
-    ! use EClock to reset calendar information on initial start
+    ! use EClock to reset calendar information
     !---------------------------------------------------------------------------
 
     ! - on initial run
@@ -846,6 +844,13 @@ contains
     year_init = (idate0/10000)
     month_init= (idate0-year_init*10000)/100           ! integer month of basedate
     day_init  = idate0-year_init*10000-month_init*100 
+
+    !  - Set use_leap_years based on calendar (as some CICE calls use this instead of the calendar type)
+    if (calendar_type == ice_calendar_gregorian) then
+      use_leap_years = .true.
+    else
+      use_leap_years = .false. ! no_leap calendars
+    endif
 
     call calendar()     ! update calendar info
 

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -26,7 +26,7 @@ module ice_comp_nuopc
   use ice_calendar       , only : force_restart_now, write_ic
   use ice_calendar       , only : idate, idate0,  mday, mmonth, myear, year_init, month_init, day_init
   use ice_calendar       , only : msec, dt, calendar, calendar_type, nextsw_cday, istep
-  use ice_calendar       , only : ice_calendar_noleap, ice_calendar_gregorian
+  use ice_calendar       , only : ice_calendar_noleap, ice_calendar_gregorian, use_leap_years
   use ice_kinds_mod      , only : dbl_kind, int_kind, char_len, char_len_long
   use ice_fileunits      , only : nu_diag, nu_diag_set, inst_index, inst_name
   use ice_fileunits      , only : inst_suffix, release_all_fileunits, flush_fileunit
@@ -675,6 +675,10 @@ contains
     else
       if(mastertask) write(nu_diag,*) trim(subname)//'WARNING: pio_typename from driver needs to be set for netcdf output to work'
     end if
+    ! Set use_leap_years as some CICE calls use this instead of the calendar type
+    call ESMF_TimeGet( currTime, calkindflag=esmf_caltype, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (esmf_caltype == ESMF_CALKIND_GREGORIAN) use_leap_years = .true.
 
 #else
 

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -26,7 +26,7 @@ module ice_comp_nuopc
   use ice_calendar       , only : force_restart_now, write_ic
   use ice_calendar       , only : idate, idate0,  mday, mmonth, myear, year_init, month_init, day_init
   use ice_calendar       , only : msec, dt, calendar, calendar_type, nextsw_cday, istep
-  use ice_calendar       , only : ice_calendar_noleap, ice_calendar_gregorian, use_leap_years
+  use ice_calendar       , only : ice_calendar_noleap, ice_calendar_gregorian
   use ice_kinds_mod      , only : dbl_kind, int_kind, char_len, char_len_long
   use ice_fileunits      , only : nu_diag, nu_diag_set, inst_index, inst_name
   use ice_fileunits      , only : inst_suffix, release_all_fileunits, flush_fileunit
@@ -675,10 +675,6 @@ contains
     else
       if(mastertask) write(nu_diag,*) trim(subname)//'WARNING: pio_typename from driver needs to be set for netcdf output to work'
     end if
-    ! Set use_leap_years as some CICE calls use this instead of the calendar type
-    call ESMF_TimeGet( currTime, calkindflag=esmf_caltype, rc=rc )
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (esmf_caltype == ESMF_CALKIND_GREGORIAN) use_leap_years = .true.
 
 #else
 

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -809,7 +809,7 @@ contains
        if (ref_ymd /= start_ymd .or. ref_tod /= start_tod) then
           if (my_task == master_task) then
              write(nu_diag,*) trim(subname),': ref_ymd ',ref_ymd, ' must equal start_ymd ',start_ymd
-             write(nu_diag,*) trim(subname),': ref_ymd ',ref_tod, ' must equal start_tod ',start_tod
+             write(nu_diag,*) trim(subname),': ref_tod',ref_tod, ' must equal start_tod ',start_tod
           end if
        end if
 

--- a/cicecore/shared/ice_calendar.F90
+++ b/cicecore/shared/ice_calendar.F90
@@ -211,14 +211,7 @@
       nstreams = 0
 
 #ifdef CESMCOUPLED
-   ! calendar_type set by coupling
-   ! set use_leap_years for consistency
-   if (calendar_type == trim(ice_calendar_gregorian)) then
-      use_leap_years = .true.
-   else 
-      use_leap_years = .false.
-   endif
-
+      ! calendar_type set by coupling
 #else
       calendar_type = ''
       if (use_leap_years) then

--- a/cicecore/shared/ice_calendar.F90
+++ b/cicecore/shared/ice_calendar.F90
@@ -211,7 +211,14 @@
       nstreams = 0
 
 #ifdef CESMCOUPLED
-      ! calendar_type set by coupling
+   ! calendar_type set by coupling
+   ! set use_leap_years for consistency
+   if (calendar_type == trim(ice_calendar_gregorian)) then
+      use_leap_years = .true.
+   else 
+      use_leap_years = .false.
+   endif
+
 #else
       calendar_type = ''
       if (use_leap_years) then


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
   Set 'idate0' and 'use_leap_years' in nuopc cap. The nuopc cap sets the calendar for CICE (rather than the normal namelist options), but these variables were missing. This means that the attributes of the time variable history output are incorrect in two ways:

- _time:units_ start from year 0000, which is not allowed if Gregorian calendar is used strictly (it starts in 1582 or so)
- _time:calendar_ is always 'noleap', even when it should be 'Gregorian'

- [x] Developer(s): 
    @anton-seaice 
- [ ] Suggest PR reviewers from list in the column to the right.
@DeniseWorthen @dabail10 
- [x] Please copy the PR test results link or provide a summary of testing completed below.
I did adhoc testing, with the defaults in `ice_in`, a gregorian calendar in nuopc/cmeps and current CICE, on initial run, the time var looks like this:

```
        double time(time) ;
                time:long_name = "time" ;
                time:units = "days since 0000-01-01 00:00:00" ;
                time:calendar = "noleap" ;
                time:bounds = "time_bounds" ;

                time = 715146 ;
```

After the change:
runtype = 'initial'

```
ncdump -v time archive/output000/GMOM_JRA.cice.h.1958-01-01.nc 

        double time(time) ;
                time:long_name = "time" ;
                time:units = "days since 1958-01-01 00:00:00" ;
                time:calendar = "Gregorian" ;
                time:bounds = "time_bounds" ;

time = 1 ;
```
runtype = 'continue'
```
ncdump -v time archive/output001/GMOM_JRA.cice.h.1958-01-02.nc 

        double time(time) ;
                time:long_name = "time" ;
                time:units = "days since 1958-01-01 00:00:00" ;
                time:calendar = "Gregorian" ;
                time:bounds = "time_bounds" ;

                data:

 time = 2 ;
```
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No (NUOPC driver changes only)

- [ ] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Set run start date (idate0) in nuopc driver, so that the history "time:units" attribute in netcdf output is consistent with the date set through nuopc.

Set use_leap_years in nuopc cap, so that netcdf output "time:calendar" is set correctly in history output (i.e. is correctly set as noleap / gregorian) for calendars set through the driver.
