### PR TITLE
Typo in nmode0 in PIO for CESMCOUPLED

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_pio.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_pio.F90
@@ -83,7 +83,7 @@
    if ((pio_iotype==PIO_IOTYPE_NETCDF).or.(pio_iotype==PIO_IOTYPE_PNETCDF)) then
       nmode0 = shr_pio_getioformat(inst_name)
    else
-      nmode=0
+      nmode0 = 0
    endif
 
    call pio_seterrorhandling(ice_pio_subsystem, PIO_RETURN_ERROR)


### PR DESCRIPTION
## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
There is a typo in the CESMCOUPLED implementation of PIO (updated in #928)
- [ ] Developer(s): 
    @anton-seaice 
- [ ] Suggest PR reviewers from list in the column to the right.
@dabail10 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
Adhoc testing only. Only impacts CESMCOUPLED.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

For CESMCOUPLED, the pio_iotype is set though CMEPS. For completeness, we also need to check the ioformat set through CMEPS. ioformat is used to set the nmode0. nmode0 and clobber combine to set the nmode flag for pio_createfile / pio_openfile operations. Due a typo nmode0 was not being set for netcdf4 iotypes (before this change).