### PR TITLE
Port to Carpenter intel and gnu with intel mpi

### DIFF
--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -89,10 +89,30 @@ mpirun -np ${ntasks} -hostfile \$PBS_NODEFILE \${EXTRA_OMPI_SETTINGS} ./cice >&!
 EOFR
 
 #=======
-else if (${ICE_MACHCOMP} =~ onyx* || ${ICE_MACHCOMP} =~ narwhal* || ${ICE_MACHCOMP} =~ carpenter*) then
+else if (${ICE_MACHCOMP} =~ onyx* || ${ICE_MACHCOMP} =~ narwhal*) then
 cat >> ${jobfile} << EOFR
 aprun -q -n ${ntasks} -N ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
 EOFR
+
+#=======
+else if (${ICE_MACHCOMP} =~ carpenter*) then 
+if (${ICE_COMMDIR} =~ serial*) then
+cat >> ${jobfile} << EOFR
+./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+else
+
+if (${ICE_ENVNAME} =~ intelimpi* || ${ICE_ENVNAME} =~ gnuimpi*) then
+cat >> ${jobfile} << EOFR
+mpiexec -n ${ntasks} -ppn ${taskpernodelimit} ./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+else
+cat >> ${jobfile} << EOFR
+mpiexec --cpu-bind depth -n ${ntasks} -ppn ${taskpernodelimit} -d ${nthrds} ./cice >&! \$ICE_RUNLOG_FILE
+EOFR
+endif
+
+endif
 
 #=======
 else if (${ICE_MACHCOMP} =~ cori* || ${ICE_MACHCOMP} =~ perlmutter*) then

--- a/configuration/scripts/machines/Macros.carpenter_cray
+++ b/configuration/scripts/machines/Macros.carpenter_cray
@@ -1,5 +1,5 @@
 #==============================================================================
-# Macros file for NAVYDSRC narwhal, cray compiler
+# Macros file for ERDC carpenter, cray compiler
 #==============================================================================
 
 CPP        := ftn -e P

--- a/configuration/scripts/machines/Macros.carpenter_gnuimpi
+++ b/configuration/scripts/machines/Macros.carpenter_gnuimpi
@@ -1,5 +1,5 @@
 #==============================================================================
-# Macros file for ERDC carpenter, gnu compiler
+# Macros file for NAVYDSRC narwhal, gnu compiler
 #==============================================================================
 
 CPP        := ftn -E
@@ -31,10 +31,10 @@ endif
 
 #SCC   := gcc
 #SFC   := gfortran
-SCC   := cc
-SFC   := ftn
-MPICC := cc
-MPIFC := ftn
+SCC   := mpicc
+SFC   := mpif90
+MPICC := mpicc
+MPIFC := mpif90
 
 ifeq ($(ICE_COMMDIR), mpi)
   FC := $(MPIFC)

--- a/configuration/scripts/machines/Macros.carpenter_intel
+++ b/configuration/scripts/machines/Macros.carpenter_intel
@@ -1,5 +1,5 @@
 #==============================================================================
-# Macros file for NAVYDSRC narwhal, intel compiler
+# Macros file for ERDC carpenter, intel compiler
 #==============================================================================
 
 CPP        := fpp

--- a/configuration/scripts/machines/Macros.carpenter_intelimpi
+++ b/configuration/scripts/machines/Macros.carpenter_intelimpi
@@ -1,40 +1,30 @@
 #==============================================================================
-# Macros file for ERDC carpenter, gnu compiler
+# Macros file for ERDC carpenter, intel compiler, intel mpi
 #==============================================================================
 
-CPP        := ftn -E
+CPP        := fpp
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c
+CFLAGS     := -c -O2 -fp-model precise -fcommon
 
-FIXEDFLAGS := -ffixed-line-length-132
-FREEFLAGS  := -ffree-form
-FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none -fallow-argument-mismatch
+FIXEDFLAGS := -132
+FREEFLAGS  := -FR
+FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback
+# -mcmodel medium -shared-intel
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-  CFLAGS     += -O0
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+#  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays
+else
+  FFLAGS     += -O2
 endif
 
-ifeq ($(ICE_COVERAGE), true)
-  FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
-  CFLAGS   += -O0 -g -coverage
-  LDFLAGS  += -g -ftest-coverage -fprofile-arcs
-endif
-
-ifneq ($(ICE_BLDDEBUG), true)
-ifneq ($(ICE_COVERAGE), true)
-  FFLAGS   += -O2
-  CFLAGS   += -O2
-endif
-endif
-
-#SCC   := gcc
-#SFC   := gfortran
-SCC   := cc
-SFC   := ftn
-MPICC := cc
-MPIFC := ftn
+#SCC   := icx 
+#SFC   := ifort
+SCC   := mpiicc
+SFC   := mpiifort
+MPICC := mpiicc
+MPIFC := mpiifort
 
 ifeq ($(ICE_COMMDIR), mpi)
   FC := $(MPIFC)
@@ -62,8 +52,8 @@ LIB_NETCDF := $(NETCDF_PATH)/lib
 SLIBS   := -L$(LIB_NETCDF) -lnetcdf -lnetcdff
 
 ifeq ($(ICE_THREADED), true) 
-   LDFLAGS += -fopenmp
-   CFLAGS += -fopenmp
-   FFLAGS += -fopenmp
+   LDFLAGS += -qopenmp
+   CFLAGS += -qopenmp
+   FFLAGS += -qopenmp
 endif
 

--- a/configuration/scripts/machines/env.carpenter_gnuimpi
+++ b/configuration/scripts/machines/env.carpenter_gnuimpi
@@ -1,0 +1,58 @@
+#!/bin/csh -f
+
+set inp = "undefined"
+if ($#argv == 1) then
+  set inp = $1
+endif
+
+if ("$inp" != "-nomodules") then
+
+source ${MODULESHOME}/init/csh
+
+module unload PrgEnv-cray
+module unload PrgEnv-gnu
+module unload PrgEnv-intel
+module unload PrgEnv-pgi
+module load PrgEnv-gnu/8.4.0
+
+module unload gcc
+module load gcc/11.2.0
+
+module unload cray-mpich
+module unload mpi
+module unload openmpi
+#module load cray-mpich/8.1.26
+#module load openmpi/4.1.6
+module load mpi/2021.11
+
+module unload cray-hdf5
+module unload cray-hdf5-parallel
+module unload cray-netcdf-hdf5parallel
+module unload cray-parallel-netcdf
+module unload netcdf
+module load cray-netcdf/4.9.0.3
+module load cray-hdf5/1.12.2.3
+
+setenv NETCDF_PATH ${NETCDF_DIR}
+limit coredumpsize unlimited
+limit stacksize unlimited
+setenv OMP_STACKSIZE 128M
+setenv OMP_WAIT_POLICY PASSIVE
+setenv FI_CXI_RX_MATCH_MODE hybrid
+
+endif
+
+setenv ICE_MACHINE_MACHNAME carpenter
+setenv ICE_MACHINE_MACHINFO "Cray EX4000 AMD 9654 Genoa 2.1GHz, Slingshot Interconnect"
+setenv ICE_MACHINE_ENVNAME gnuimpi
+setenv ICE_MACHINE_ENVINFO "gnu gcc 11.2.0 20210728, intel mpi 2021.11, netcdf/4.9.0.3"
+setenv ICE_MACHINE_MAKE gmake
+setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
+setenv ICE_MACHINE_INPUTDATA /p/app/unsupported/RASM/cice_consortium
+setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
+setenv ICE_MACHINE_SUBMIT "qsub "
+setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_TPNODE 192    # tasks per node
+setenv ICE_MACHINE_BLDTHRDS 12
+setenv ICE_MACHINE_QSTAT "qstat "

--- a/configuration/scripts/machines/env.carpenter_intelimpi
+++ b/configuration/scripts/machines/env.carpenter_intelimpi
@@ -1,0 +1,57 @@
+#!/bin/csh -f
+set inp = "undefined"
+if ($#argv == 1) then
+  set inp = $1
+endif
+
+if ("$inp" != "-nomodules") then
+
+source ${MODULESHOME}/init/csh
+
+module unload PrgEnv-cray
+module unload PrgEnv-gnu
+module unload PrgEnv-intel
+module unload PrgEnv-pgi
+module load PrgEnv-intel/8.4.0
+
+module unload intel
+module load intel/2023.0.0
+
+module unload cray-mpich
+module unload mpi
+module unload openmpi
+#module load cray-mpich/8.1.26
+module load mpi/2021.11
+#module load openmpi/4.1.6
+
+module unload cray-hdf5
+module unload cray-hdf5-parallel
+module unload cray-netcdf-hdf5parallel
+module unload cray-parallel-netcdf
+module unload netcdf
+module load cray-netcdf/4.9.0.3
+module load cray-hdf5/1.12.2.3
+
+setenv NETCDF_PATH ${NETCDF_DIR}
+limit coredumpsize unlimited
+limit stacksize unlimited
+setenv OMP_STACKSIZE 128M
+setenv OMP_WAIT_POLICY PASSIVE
+setenv FI_CXI_RX_MATCH_MODE hybrid
+
+endif
+
+setenv ICE_MACHINE_MACHNAME carpenter
+setenv ICE_MACHINE_MACHINFO "Cray EX4000 AMD 9654 Genoa 2.1GHz, Slingshot Interconnect"
+setenv ICE_MACHINE_ENVNAME intelimpi
+setenv ICE_MACHINE_ENVINFO "ifort 2021.8.0 20221119, intel mpi 2021.11, netcdf/4.9.0.3"
+setenv ICE_MACHINE_MAKE gmake
+setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
+setenv ICE_MACHINE_INPUTDATA /p/app/unsupported/RASM/cice_consortium
+setenv ICE_MACHINE_BASELINE $WORKDIR/CICE_BASELINE
+setenv ICE_MACHINE_SUBMIT "qsub "
+setenv ICE_MACHINE_ACCT P00000000
+setenv ICE_MACHINE_QUEUE "debug"
+setenv ICE_MACHINE_TPNODE 192    # tasks per node
+setenv ICE_MACHINE_BLDTHRDS 12
+setenv ICE_MACHINE_QSTAT "qstat "


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Port to Carpenter intel and gnu with intel mpi
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Test results as expected, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#740f2a65e055e37bebc81aa25675ebc2a65d735d
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

This PR adds support for two new compiler/mpi options on Carpenter.  In addition to Intel, GNU, and Cray compilers with cray-mpich, this adds Intel and GNU support with Intel MPI.
