### PR TITLE
nuopc/cmeps cap fixes; remove compiler warning and fix missing j-loop index 

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
@@ -1773,9 +1773,11 @@ contains
                 end do
              end do
           else
-             do i = ilo, ihi
-                n = n+1
-                dataPtr1d(n) = input(i,j,index,iblk)
+             do j = jlo, jhi
+                do i = ilo, ihi
+                   n = n+1
+                   dataPtr1d(n) = input(i,j,index,iblk)
+                end do
              end do
           end if
        end do

--- a/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
@@ -7,7 +7,8 @@ module ice_prescribed_mod
   ! Ice/ocean fluxes are set to zero, and ice dynamics are not calculated.
   ! Regridding and data cycling capabilities are included.
 
-  use ESMF
+  use ESMF, only : ESMF_Clock, ESMF_Mesh, ESMF_SUCCESS, ESMF_FAILURE
+  use ESMF, only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_Finalize, ESMF_END_ABORT
 
 #ifndef CESMCOUPLED
 
@@ -23,6 +24,7 @@ contains
     type(ESMF_Mesh)        , intent(in)  :: mesh
     integer                , intent(out) :: rc
     ! do nothing
+    rc = ESMF_SUCCESS
   end subroutine ice_prescribed_init
 
 #else


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix two small issues in nuopc/cmeps cap: fix to resolve compiler warning (operational req) and fix to add missing j-loop
- [x] Developer(s): 
    @DeniseWorthen 
- [ ] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ENTER INFORMATION HERE 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Resolve compiler warning arising from ice_prescribed_mod due to the intent(out) variable RC not being given an explicit value. This is an operational requirement for NOAA. Fix bug arising from missing j-loop index in ice_import_export 