### PR TITLE
Fix Github Actions for macos system update

### DIFF
--- a/.github/workflows/test-cice.yml
+++ b/.github/workflows/test-cice.yml
@@ -50,6 +50,7 @@ jobs:
           echo "xcrun --show-sdk-path: $(xcrun --show-sdk-path)"
           echo "xcode-select -p: $(xcode-select -p)"
           export SDKROOT=$(xcrun --show-sdk-path)
+          echo "SDKROOT: $SDKROOT"
       - name: system info
         shell: /bin/bash {0}
         run: |

--- a/.github/workflows/test-cice.yml
+++ b/.github/workflows/test-cice.yml
@@ -46,18 +46,15 @@ jobs:
         run: |
           sudo xcode-select -r
           sudo xcode-select -s /Library/Developer/CommandLineTools
-          sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
           echo "xcrun --show-sdk-path: $(xcrun --show-sdk-path)"
           echo "xcode-select -p: $(xcode-select -p)"
-          export SDKROOT=$(xcrun --show-sdk-path)
-          echo "SDKROOT: $SDKROOT"
       - name: system info
         shell: /bin/bash {0}
         run: |
           type wget
           type curl
           type csh
-          echo "readlink \$(which csh): $(python -c 'import os, sys; print os.path.realpath(sys.argv[1])' $(which csh))"
+          echo "readlink \$(which csh): $(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $(which csh))"
           echo "csh --version: $(csh --version)"
           echo "uname -a: $(uname -a)"
           echo "sw_vers: $(sw_vers)"
@@ -66,7 +63,6 @@ jobs:
           echo "OS: ${{ matrix.os }}"
           echo "ENVDEF: ${{ matrix.envdef }}"
           echo "MINICOND: ${{ matrix.minicond }}"
-          echo "SDKROOT: $SDKROOT"
       - name : install miniconda
         shell: /bin/bash {0}
         run: |

--- a/.github/workflows/test-cice.yml
+++ b/.github/workflows/test-cice.yml
@@ -1,6 +1,5 @@
 name: GHActions
 
-
 # This workflow is triggered on pushes, pull-requeust, and releases
 # ghactions* branch names will trigger this to support development testing
 # To Do: get it working with bash and ubuntu
@@ -48,9 +47,9 @@ jobs:
           sudo xcode-select -r
           sudo xcode-select -s /Library/Developer/CommandLineTools
           sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
-          echo "xcrun --show-sdk-path: $(xcrun -sdk macosx --show-sdk-path)"
+          echo "xcrun --show-sdk-path: $(xcrun --show-sdk-path)"
           echo "xcode-select -p: $(xcode-select -p)"
-          export SDKROOT=$(xcrun -sdk macos --show-sdk-path)
+          export SDKROOT=$(xcrun --show-sdk-path)
       - name: system info
         shell: /bin/bash {0}
         run: |

--- a/.github/workflows/test-cice.yml
+++ b/.github/workflows/test-cice.yml
@@ -48,7 +48,7 @@ jobs:
           sudo xcode-select -r
           sudo xcode-select -s /Library/Developer/CommandLineTools
           sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
-          echo "xcrun --show-sdk-path: $(xcrun --show-sdk-path)"
+          echo "xcrun --show-sdk-path: $(xcrun -sdk macosx --show-sdk-path)"
           echo "xcode-select -p: $(xcode-select -p)"
       - name: system info
         shell: /bin/bash {0}
@@ -65,6 +65,7 @@ jobs:
           echo "OS: ${{ matrix.os }}"
           echo "ENVDEF: ${{ matrix.envdef }}"
           echo "MINICOND: ${{ matrix.minicond }}"
+          echo "SDKROOT: $SDKROOT"
       - name : install miniconda
         shell: /bin/bash {0}
         run: |

--- a/.github/workflows/test-cice.yml
+++ b/.github/workflows/test-cice.yml
@@ -1,5 +1,6 @@
 name: GHActions
 
+
 # This workflow is triggered on pushes, pull-requeust, and releases
 # ghactions* branch names will trigger this to support development testing
 # To Do: get it working with bash and ubuntu

--- a/.github/workflows/test-cice.yml
+++ b/.github/workflows/test-cice.yml
@@ -50,6 +50,7 @@ jobs:
           sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
           echo "xcrun --show-sdk-path: $(xcrun -sdk macosx --show-sdk-path)"
           echo "xcode-select -p: $(xcode-select -p)"
+          export SDKROOT=$(xcrun -sdk macos --show-sdk-path)
       - name: system info
         shell: /bin/bash {0}
         run: |

--- a/configuration/scripts/machines/Macros.conda_macos
+++ b/configuration/scripts/machines/Macros.conda_macos
@@ -47,7 +47,8 @@ SDKPATH = $(shell xcrun --show-sdk-path)
 ifeq ($(strip $(SDKPATH)),)
   CFLAGS_HOST := 
 else
-  CFLAGS_HOST = -isysroot $(SDKPATH)
+  CFLAGS_HOST := -isysroot $(SDKPATH)
+  CFLAGS += -isysroot $(SDKPATH)
   LD += -L$(SDKPATH)/usr/lib
 endif
 


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix latest problem with Github Actions for macos system update
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    TBD
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Github Actions broke again after default macos system update.

Clang was not picking up the C system files.  Had to change the implementation and add -isysroot to the CFLAGS option.  At the same time, removed prior implementation where the system files were linked into /usr/local/include, this was no longer working.