### PR TITLE
Changes shr_file to shr_log.

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/cice_wrapper_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/cice_wrapper_mod.F90
@@ -82,12 +82,12 @@ contains
 
   ! Define stub routines that do nothing - they are just here to avoid
   ! having cppdefs in the main program
-  subroutine shr_file_setLogUnit(nunit)
+  subroutine shr_log_setLogUnit(nunit)
     integer, intent(in) :: nunit
-  end subroutine shr_file_setLogUnit
-  subroutine shr_file_getLogUnit(nunit)
+  end subroutine shr_log_setLogUnit
+  subroutine shr_log_getLogUnit(nunit)
     integer, intent(in) :: nunit
-  end subroutine shr_file_getLogUnit
+  end subroutine shr_log_getLogUnit
   subroutine t_startf(string)
     character(len=*) :: string
   end subroutine t_startf

--- a/cicecore/drivers/nuopc/cmeps/cice_wrapper_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/cice_wrapper_mod.F90
@@ -2,7 +2,7 @@ module cice_wrapper_mod
 
 #ifdef CESMCOUPLED
   use perf_mod      , only : t_startf, t_stopf, t_barrierf
-  use shr_file_mod  , only : shr_file_getlogunit, shr_file_setlogunit
+  use shr_log_mod  , only : shr_log_getlogunit, shr_log_setlogunit
 
   use ice_kinds_mod , only : dbl_kind, int_kind, char_len, char_len_long
 

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -38,7 +38,7 @@ module ice_comp_nuopc
   use icepack_intfc      , only : icepack_init_orbit, icepack_init_parameters, icepack_query_orbit
   use icepack_intfc      , only : icepack_query_tracer_flags, icepack_query_parameters
   use cice_wrapper_mod   , only : t_startf, t_stopf, t_barrierf
-  use cice_wrapper_mod   , only : shr_file_getlogunit, shr_file_setlogunit
+  use cice_wrapper_mod   , only : shr_log_getlogunit, shr_log_setlogunit
   use cice_wrapper_mod   , only : ufs_settimer, ufs_logtimer, ufs_file_setlogunit, wtime
 #ifdef CESMCOUPLED
   use shr_const_mod
@@ -497,7 +497,7 @@ contains
     ! Note that sets the nu_diag module variable in ice_fileunits
     ! Set the nu_diag_set flag so it's not reset later
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
     call ufs_file_setLogUnit('./log.ice.timer',nu_timer,runtimelog)
 
     call NUOPC_CompAttributeGet(gcomp, name="diro", value=cvalue, &
@@ -1067,8 +1067,8 @@ contains
     ! Reset shr logging to my log file
     !--------------------------------
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (nu_diag)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (nu_diag)
 
     !--------------------------------
     ! Query the Component for its clock, importState and exportState
@@ -1207,7 +1207,7 @@ contains
     end if
 
     ! reset shr logging to my original values
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
     !--------------------------------
     ! stop timers and print timer info

--- a/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
@@ -23,7 +23,7 @@ module ice_shr_methods
   use ice_kinds_mod, only : r8 => dbl_kind, cl=>char_len_long, cs=>char_len
   use ice_exit     , only : abort_ice
 #ifdef CESMCOUPLED
-  use shr_file_mod , only : shr_file_setlogunit, shr_file_getLogUnit
+  use shr_log_mod , only : shr_log_setlogunit
 #endif
 
   implicit none
@@ -165,7 +165,7 @@ contains
     endif
 
 #ifdef CESMCOUPLED
-    call shr_file_setLogUnit (logunit)
+    call shr_log_setLogUnit (logunit)
 #endif
 
   end subroutine set_component_logging


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
This changes the CESM nuopc driver to use shr_log.
- [X] Developer(s): 
jedwards
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
Tested within the CESM scripts
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
Only impacts CESMCOUPLED cases.