### PR TITLE
Access alternative congelation ice formulation in icepack

### DIFF
--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -164,7 +164,7 @@
 
       character (len=char_len) :: shortwave, albedo_type, conduct, fbot_xfer_type, &
         tfrz_option, saltflux_option, frzpnd, atmbndy, wave_spec_type, snwredist, snw_aging_table, &
-        capping_method, snw_ssp_table
+        congel_freeze, capping_method, snw_ssp_table
 
       logical (kind=log_kind) :: calc_Tsfc, formdrag, highfreq, calc_strair, wave_spec, &
         sw_redist, calc_dragio, use_smliq_pnd, snwgrain
@@ -280,7 +280,7 @@
         highfreq,       natmiter,        atmiter_conv,  calc_dragio,    &
         ustar_min,      emissivity,      iceruf,        iceruf_ocn,     &
         fbot_xfer_type, update_ocn_f,    l_mpond_fresh, tfrz_option,    &
-        saltflux_option,ice_ref_salinity,cpl_frazil,                    &
+        saltflux_option,ice_ref_salinity,cpl_frazil,    congel_freeze,  &
         oceanmixed_ice, restore_ice,     restore_ocn,   trestore,       &
         precip_units,   default_season,  wave_spec_type,nfreq,          &
         atm_data_type,  ocn_data_type,   bgc_data_type, fe_data_type,   &
@@ -537,6 +537,7 @@
       atmiter_conv    = c0        ! ustar convergence criteria
       precip_units    = 'mks'     ! 'mm_per_month' or
                                   ! 'mm_per_sec' = 'mks' = kg/m^2 s
+      congel_freeze   = 'two-step'! congelation freezing method
       tfrz_option     = 'mushy'   ! freezing temp formulation
       saltflux_option = 'constant'    ! saltflux calculation
       ice_ref_salinity = 4.0_dbl_kind ! Ice reference salinity for coupling
@@ -1127,6 +1128,7 @@
       call broadcast_scalar(wave_spec_type,       master_task)
       call broadcast_scalar(wave_spec_file,       master_task)
       call broadcast_scalar(nfreq,                master_task)
+      call broadcast_scalar(congel_freeze,        master_task)
       call broadcast_scalar(tfrz_option,          master_task)
       call broadcast_scalar(saltflux_option,      master_task)
       call broadcast_scalar(ice_ref_salinity,     master_task)
@@ -2313,6 +2315,7 @@
          if (trim(tfrz_option) == 'constant') then
             write(nu_diag,1002) ' Tocnfrz          = ', Tocnfrz
          endif
+         write(nu_diag,1030) ' congel_freeze    = ', trim(congel_freeze)
          if (update_ocn_f) then
             tmpstr2 = ' : frazil water/salt fluxes included in ocean fluxes'
          else
@@ -2723,7 +2726,7 @@
          aspect_rapid_mode_in=aspect_rapid_mode, dSdt_slow_mode_in=dSdt_slow_mode, &
          phi_c_slow_mode_in=phi_c_slow_mode, phi_i_mushy_in=phi_i_mushy, conserv_check_in=conserv_check, &
          wave_spec_type_in = wave_spec_type, wave_spec_in=wave_spec, nfreq_in=nfreq, &
-         update_ocn_f_in=update_ocn_f, cpl_frazil_in=cpl_frazil, &
+         update_ocn_f_in=update_ocn_f, cpl_frazil_in=cpl_frazil, congel_freeze_in=congel_freeze, &
          tfrz_option_in=tfrz_option, kalg_in=kalg, fbot_xfer_type_in=fbot_xfer_type, &
          saltflux_option_in=saltflux_option, ice_ref_salinity_in=ice_ref_salinity, &
          Pstar_in=Pstar, Cstar_in=Cstar, iceruf_in=iceruf, iceruf_ocn_in=iceruf_ocn, calc_dragio_in=calc_dragio, &

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -270,6 +270,7 @@
     fbot_xfer_type  = 'constant'
     update_ocn_f    = .false.
     l_mpond_fresh   = .false.
+    congel_freeze   = 'two-step'
     tfrz_option     = 'mushy'
     saltflux_option = 'constant'
     ice_ref_salinity = 4.0

--- a/configuration/scripts/machines/env.chicoma_intel
+++ b/configuration/scripts/machines/env.chicoma_intel
@@ -64,7 +64,7 @@ setenv ICE_MACHINE_WKDIR /lustre/scratch5/$user/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /usr/projects/climate/eclare/DATA/Consortium
 setenv ICE_MACHINE_BASELINE /lustre/scratch5/$user/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch "
-setenv ICE_MACHINE_ACCT t23_cice
+setenv ICE_MACHINE_ACCT t24_cice
 setenv ICE_MACHINE_QUEUE "debug"
 setenv ICE_MACHINE_TPNODE 128    # tasks per node
 setenv ICE_MACHINE_BLDTHRDS 12

--- a/configuration/scripts/options/set_nml.congel
+++ b/configuration/scripts/options/set_nml.congel
@@ -1,0 +1,2 @@
+  congel_freeze      = 'one-step'
+

--- a/configuration/scripts/tests/base_suite.ts
+++ b/configuration/scripts/tests/base_suite.ts
@@ -27,6 +27,7 @@ restart        gx3     8x2        alt06
 restart        gx3     8x3        alt07
 restart        gx3    16x2        snicar
 restart        gx3    12x2        snicartest
+restart        gx3     8x2        congel
 restart        gx3     8x3        saltflux
 restart        gx3    18x2        debug,maskhalo
 restart        gx3     6x2        alt01,debug,short
@@ -37,6 +38,7 @@ smoke          gx3     4x4        alt04,debug,short
 smoke          gx3     4x4        alt05,debug,short
 smoke          gx3     8x2        alt06,debug,short
 smoke          gx3     8x3        alt07,debug,short
+smoke          gx3     8x2        congel,debug,short
 smoke          gx3    16x2        snicar,debug,short
 smoke          gx3    12x2        snicartest,debug,short
 smoke          gx3     10x2       debug,diag1,run5day,gx3sep2

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -673,6 +673,8 @@ forcing_nml
    "``calc_strair``", "``.false.``", "read wind stress and speed from files", "``.true.``"
    "", "``.true.``", "calculate wind stress and speed", ""
    "``calc_Tsfc``", "logical", "calculate surface temperature", "``.true.``"
+   "``congel_freeze``", "``one-step``", "immediately freeze congelation ice", "``two-step``"
+   "", "``two-step``", "delayed freezing of congelation ice", ""
    "``cpl_frazil``", "``external``", "frazil water/salt fluxes are handled outside of Icepack", "``fresh_ice_correction``"
    "", "``fresh_ice_correction``", "correct fresh-ice frazil water/salt fluxes for mushy physics", ""
    "", "``internal``", "send full frazil water/salt fluxes for mushy physics", ""


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
Provides namelist and brief documentation for new, alternative congelation ice formulation in Icepack,
https://github.com/CICE-Consortium/Icepack/pull/494/files
- [x] Developer(s): 
@eclare108213 
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.

base_suite comparison of the new code using default settings with the original code prior to modifications:
```
391 measured results of 391 total results
377 of 391 tests PASSED
2 of 391 tests PENDING
4 of 391 tests MISSING data
8 of 391 tests FAILED
```
The 8 failed tests are expected on chicoma (due to large processor counts; missing forcing data), and there are always 2 tests left in pending status when all have finished.  The tests with missing data are the new ones for testing the `congel_freeze='one-step'` option.

QC testing was done comparing the 'two-step' and new 'one-step' option and this passed, see additional information below.

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit when `congel_freeze = 'two-step'` (default)
    - [ ] different at roundoff level
    - [x] more substantial when `congel_freeze = 'one-step'`
- Does this PR create or have dependencies on Icepack or any other models?
    - [x] Yes
    - [ ] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [X] Yes
    - [ ] No
- Does this PR add any new test cases?
    - [x] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [x] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [ ] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Add support for 'one-step' congelation ice formation in addition to current default 'two-step' option.  Added a new namelist, congel_freeze to control the congelation option.  This CICE update requires an update to Icepack to support the new congel_freeze option.  The default setting for congel_freeze is set to 'two-step' for backwards compatibility.  The new 'one-step' option will be evaluated and may become the default option in the future.

Testing indicates the default setting is bit-for-bit identical with the current main.
