### PR TITLE
Confirm backward compatibility for PIO reads on non-parallel files

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_pio.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_pio.F90
@@ -236,8 +236,15 @@
                write(nu_diag,*) subname//' opening file for reading '//trim(filename)
             endif
             status = pio_openfile(ice_pio_subsystem, File, pio_iotype, trim(filename), pio_nowrite)
-            call ice_pio_check( status, subname//' ERROR: Failed to open file '//trim(filename), &
-             file=__FILE__,line=__LINE__)
+            if (status /= PIO_NOERR) then
+               if (my_task == master_task) then
+                  write(nu_diag,*) subname//' opening '//trim(filename)//' as type '//trim(fformat)//&
+                  ' failed, retrying as type cdf1'
+               endif
+               status = pio_openfile(ice_pio_subsystem, File, PIO_IOTYPE_NETCDF, trim(filename), pio_nowrite)
+               call ice_pio_check( status, subname//' ERROR: Failed to open file '//trim(filename), &
+               file=__FILE__,line=__LINE__)
+            endif
          else
             if(my_task==master_task) then
                write(nu_diag,*) subname//' ERROR: file not found '//trim(filename)

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_pio.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_pio.F90
@@ -238,8 +238,7 @@
             status = pio_openfile(ice_pio_subsystem, File, pio_iotype, trim(filename), pio_nowrite)
             if (status /= PIO_NOERR) then
                if (my_task == master_task) then
-                  write(nu_diag,*) subname//' opening '//trim(filename)//' as type '//trim(fformat)//&
-                  ' failed, retrying as type cdf1'
+                  write(nu_diag,*) subname//' opening '//trim(filename)//' as type '//trim(fformat)//' failed, retrying as type cdf1'
                endif
                status = pio_openfile(ice_pio_subsystem, File, PIO_IOTYPE_NETCDF, trim(filename), pio_nowrite)
                call ice_pio_check( status, subname//' ERROR: Failed to open file '//trim(filename), &

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -78,13 +78,8 @@
       end if
 
       File%fh=-1
-! tcraig, including fformat here causes some problems when restart_format=hdf5
-!         and reading non hdf5 files with spack built PIO.  Excluding the fformat
-!         argument here defaults the PIO format to cdf1 which then reads
-!         any netcdf format file fine.
       call ice_pio_init(mode='read', filename=trim(filename), File=File, &
-!          fformat=trim(restart_format), rearr=trim(restart_rearranger), &
-                                         rearr=trim(restart_rearranger), &
+           fformat=trim(restart_format), rearr=trim(restart_rearranger), &
            iotasks=restart_iotasks, root=restart_root, stride=restart_stride, &
            debug=first_call)
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    This change ensures backwards compatibility of attempting a parallel read of netcdf file which doesn't support parallel reads
- [ ] Developer(s): 
    @anton-seaice 
- [ ] Suggest PR reviewers from list in the column to the right.
 @apcraig @DeniseWorthen 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    I did adhoc testing with PIO 2.5.10 to check that this will read restart files of format hdf5 and cdf1. I couldn't replicate the initial problem however (maybe I need an earlier PIO version?). 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [ ] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

For some versions of the PIO library (<2.5.10), attempting a parallel read with filetype netcdf4 (hdf5) of a file which does not support parallel reads fails. The expected behaviour (which is fixed in latest PIO versions) is to fall back to a serial read. The change ensures support for older PIO versions.