### PR TITLE
Write restart at end of run via NUOPC component attribute & Initialize cpl_scalar field when created for UFS

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/cice_wrapper_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/cice_wrapper_mod.F90
@@ -72,7 +72,7 @@ contains
     real(dbl_kind),    intent(in)    :: hour
     character(len=char_len)          :: filename
     integer(int_kind)                :: nunit
-    write(filename,'(a,i3.3)')'log.ice.f',int(hour)
+    write(filename,'(a,i4.4)')'log.ice.f',int(hour)
     open(newunit=nunit,file=trim(filename))
     write(nunit,'(a)')'completed: cice'
     write(nunit,'(a,f10.3)')'forecast hour:',hour

--- a/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
@@ -1495,6 +1495,7 @@ contains
       ! local variables
       type(ESMF_Distgrid) :: distgrid
       type(ESMF_Grid)     :: grid
+      real(ESMF_KIND_R8), pointer :: fldptr2d(:,:)
       character(len=*), parameter :: subname='(ice_import_export:SetScalarField)'
       ! ----------------------------------------------
 
@@ -1510,6 +1511,11 @@ contains
       field = ESMF_FieldCreate(name=trim(flds_scalar_name), grid=grid, typekind=ESMF_TYPEKIND_R8, &
            ungriddedLBound=(/1/), ungriddedUBound=(/flds_scalar_num/), gridToFieldMap=(/2/), rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+      ! initialize fldptr to zero
+      call ESMF_FieldGet(field, farrayPtr=fldptr2d, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      fldptr2d(:,:) = 0.0
 
     end subroutine SetScalarField
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Write restart at end of run via NUOPC attribute. Initialize cpl_scalar field when created
- [x] Developer(s): 
    Daniel Sarmiento & Denise Worthen
- [ ] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    Tested in UFS. See https://github.com/NOAA-EMC/CICE/pull/77 and https://github.com/NOAA-EMC/CICE/pull/83, respectively
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No : Docs for the caps reside in the coupled models, afaik
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

These are two commits cherry-picked from as in UFS and needed to close https://github.com/NOAA-EMC/CICE/issues/84. 

This PR adds the ability for CICE to write restart files at the end of the run (independent of other settings) and controlled via the CMEPS configuration option **write_restart_at_endofrun**. Setting this configuration option to _True_ creates a restart file in the same way for CMEPS, MOM6, and CICE.

This PR also initializes the scalar field value for the index for `NTile` (implemented for FV3) not used or set in CICE. In certain cases, the scalar field value for this index has been found to be non-zero (NaN in debug compiles). This is the cause of the failure reported in https://github.com/ufs-community/ufs-weather-model/issues/2338.