### PR TITLE
pio_errorhandling call was in the wrong location

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -741,6 +741,8 @@
       call ice_pio_check(pio_inq_varndims(File, vardesc, ndims), &
            subname// " ERROR: missing varndims "//trim(vname),file=__FILE__,line=__LINE__)
 
+      call pio_seterrorhandling(File, PIO_INTERNAL_ERROR)
+
       if (ndim3 == ncat .and. ndims == 3) then
          call pio_read_darray(File, vardesc, iodesc3d_ncat, work, status)
 #ifdef CESMCOUPLED
@@ -767,8 +769,6 @@
 
       call ice_pio_check(status, &
            subname//" ERROR: reading var "//trim(vname),file=__FILE__,line=__LINE__)
-
-      call pio_seterrorhandling(File, PIO_INTERNAL_ERROR)
 
       if (diag) then
          if (ndim3 > 1) then


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Call to pio_seterrorhandling was in the wrong location as pio_read_darray was called with no check of return status.
- [X] Developer(s): 
    Jim Edwards
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
   Tested CESM F case hybrid restart from B case.  Without this change the model hangs with no obvious error message, with this change the model aborts with appropriate error message. 
 
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
