### PR TITLE
Fix outgoing lw for history and coupling.

### DIFF
--- a/cicecore/cicedyn/general/ice_flux.F90
+++ b/cicecore/cicedyn/general/ice_flux.F90
@@ -1209,7 +1209,7 @@
       real (kind=dbl_kind) :: &
           ar, &   ! 1/aice
           stefan_boltzmann, &
-          Tffresh
+          Tffresh, puny
 
       integer (kind=int_kind) :: &
           i, j    ! horizontal indices
@@ -1217,7 +1217,7 @@
       character(len=*), parameter :: subname = '(scale_fluxes)'
 
       call icepack_query_parameters(stefan_boltzmann_out=stefan_boltzmann, &
-         Tffresh_out=Tffresh)
+         Tffresh_out=Tffresh, puny_out=puny)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)
@@ -1231,7 +1231,10 @@
             fsens   (i,j) = fsens   (i,j) * ar
             flat    (i,j) = flat    (i,j) * ar
             fswabs  (i,j) = fswabs  (i,j) * ar
+            if (flwout(i,j) > -puny) & 
+               flwout  (i,j) = -stefan_boltzmann *(Tf(i,j) + Tffresh)**4
             flwout  (i,j) = flwout  (i,j) * ar
+            ! Special case where aice_init was zero and aice > 0.
             evap    (i,j) = evap    (i,j) * ar
             Tref    (i,j) = Tref    (i,j) * ar
             Qref    (i,j) = Qref    (i,j) * ar

--- a/cicecore/cicedyn/general/ice_flux.F90
+++ b/cicecore/cicedyn/general/ice_flux.F90
@@ -1231,10 +1231,10 @@
             fsens   (i,j) = fsens   (i,j) * ar
             flat    (i,j) = flat    (i,j) * ar
             fswabs  (i,j) = fswabs  (i,j) * ar
+            ! Special case where aice_init was zero and aice > 0.
             if (flwout(i,j) > -puny) & 
                flwout  (i,j) = -stefan_boltzmann *(Tf(i,j) + Tffresh)**4
             flwout  (i,j) = flwout  (i,j) * ar
-            ! Special case where aice_init was zero and aice > 0.
             evap    (i,j) = evap    (i,j) * ar
             Tref    (i,j) = Tref    (i,j) * ar
             Qref    (i,j) = Qref    (i,j) * ar


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
A bug was identified when a grid cell goes from ice free to ice covered. Issue #994
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#6aa677ec49b415298b6368a19e5122f9c9d49f8e
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
This is a two-line change in ice_flux.F90 (scale_fluxes) to check for the condition where aice > ), but flwout > -puny. This means the cell was ice free at the beginning of the step, but non-zero at the end. It sets the outgoing longwave to the open ocean value based on the freezing temperature. This is bfb, but will change the history output of flwup and flwup_ai. Test results are coming.