### PR TITLE
Update derecho gnu to add coverage capability with lcov

### DIFF
--- a/cice.setup
+++ b/cice.setup
@@ -1173,7 +1173,7 @@ cp ${rundir}/compile/*.{gcno,gcda} ${testname_base}/codecov_output/
 EOF
 
       cat >> ${tsdir}/report_lcov.csh << EOF
-lcov --gcov-tool gcov -c -d ${rundir}/compile -o ${testname_base}/lcov.info
+lcov --gcov-tool gcov -c --rc geninfo_unexecuted_blocks=1 -d ${rundir}/compile -o ${testname_base}/lcov.info
 if (-s ${testname_base}/lcov.info) then
   set lcovalist = "\${lcovalist} -a ${testname_base}/lcov.info"
 endif

--- a/configuration/scripts/machines/Macros.derecho_gnu
+++ b/configuration/scripts/machines/Macros.derecho_gnu
@@ -26,11 +26,6 @@ else
 endif
 endif
 
-#ifneq ($(ICE_BLDDEBUG), true)
-#ifneq ($(ICE_COVERAGE), true)
-#endif
-#endif
-
 SCC   := gcc 
 SFC   := gfortran
 MPICC := mpicc

--- a/configuration/scripts/machines/Macros.derecho_gnu
+++ b/configuration/scripts/machines/Macros.derecho_gnu
@@ -11,24 +11,25 @@ FREEFLAGS  := -ffree-form
 FFLAGS     := -fconvert=big-endian -fbacktrace -ffree-line-length-none -fallow-argument-mismatch
 FFLAGS_NOOPT:= -O0
 
-ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow --std f2008
-#  FFLAGS   += -O0 -g -fcheck=all -finit-real=snan -fimplicit-none -ffpe-trap=invalid,zero,overflow
-  CFLAGS   += -O0
-endif
-
 ifeq ($(ICE_COVERAGE), true)
   FFLAGS   += -O0 -g -fprofile-arcs -ftest-coverage
   CFLAGS   += -O0 -g -coverage
   LDFLAGS  += -g -ftest-coverage -fprofile-arcs
-endif
-
-ifneq ($(ICE_BLDDEBUG), true)
-ifneq ($(ICE_COVERAGE), true)
+else
+ifeq ($(ICE_BLDDEBUG), true)
+  FFLAGS   += -O0 -g -fcheck=bounds -finit-real=nan -fimplicit-none -ffpe-trap=invalid,zero,overflow --std f2008
+#  FFLAGS   += -O0 -g -fcheck=all -finit-real=snan -fimplicit-none -ffpe-trap=invalid,zero,overflow
+  CFLAGS   += -O0
+else
   FFLAGS   += -O2
   CFLAGS   += -O2
 endif
 endif
+
+#ifneq ($(ICE_BLDDEBUG), true)
+#ifneq ($(ICE_COVERAGE), true)
+#endif
+#endif
 
 SCC   := gcc 
 SFC   := gfortran

--- a/configuration/scripts/machines/env.derecho_gnu
+++ b/configuration/scripts/machines/env.derecho_gnu
@@ -61,7 +61,7 @@ setenv OMP_STACKSIZE 64M
 setenv ICE_MACHINE_MACHNAME derecho
 setenv ICE_MACHINE_MACHINFO "HPE Cray EX Milan Slingshot 11"
 setenv ICE_MACHINE_ENVNAME gnu
-setenv ICE_MACHINE_ENVINFO "gcc 12.4.0, cray-mpich 8.1.29, netcdf4.9.2, pnetcdf1.12.3, pio1.10.1, pio2.6.2"
+setenv ICE_MACHINE_ENVINFO "gcc 12.4.0, cray-mpich 8.1.29, netcdf4.9.2, pnetcdf1.14.0, pio1.10.1, pio2.6.3"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR /glade/derecho/scratch/$user/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/campaign/cesm/development/pcwg

--- a/configuration/scripts/machines/env.derecho_gnu
+++ b/configuration/scripts/machines/env.derecho_gnu
@@ -10,16 +10,16 @@ if ("$inp" != "-nomodules") then
 source ${MODULESHOME}/init/csh
 
 module --force purge
-module load ncarenv/23.06
+module load ncarenv/24.12
 module load craype
-module load gcc/12.2.0
+module load gcc/12.4.0
 module load ncarcompilers
-module load cray-mpich/8.1.25
+module load cray-mpich/8.1.29
 module load netcdf/4.9.2
 #module load hdf5/1.12.2
 #module load netcdf-mpi/4.9.2
 
-module load cray-libsci/23.02.1.1
+module load cray-libsci/24.03.0
 
 if ($?ICE_IOTYPE) then
 if ($ICE_IOTYPE =~ pio*) then
@@ -33,6 +33,8 @@ if ($ICE_IOTYPE =~ pio*) then
   endif
 endif
 endif
+
+module load lcov
 
 if ($?ICE_BFBTYPE) then
 if ($ICE_BFBTYPE =~ qcchk*) then
@@ -61,7 +63,7 @@ setenv OMP_STACKSIZE 64M
 setenv ICE_MACHINE_MACHNAME derecho
 setenv ICE_MACHINE_MACHINFO "HPE Cray EX Milan Slingshot 11"
 setenv ICE_MACHINE_ENVNAME gnu
-setenv ICE_MACHINE_ENVINFO "gcc 12.2.0 20220819, cray-mpich 8.1.25, netcdf4.9.2, pnetcdf1.12.3, pio1.10.1, pio2.6.2"
+setenv ICE_MACHINE_ENVINFO "gcc 12.4.0, cray-mpich 8.1.29, netcdf4.9.2, pnetcdf1.12.3, pio1.10.1, pio2.6.2"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR /glade/derecho/scratch/$user/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/campaign/cesm/development/pcwg

--- a/configuration/scripts/machines/env.derecho_gnu
+++ b/configuration/scripts/machines/env.derecho_gnu
@@ -11,25 +11,23 @@ source ${MODULESHOME}/init/csh
 
 module --force purge
 module load ncarenv/24.12
+module reset
 module load craype
 module load gcc/12.4.0
 module load ncarcompilers
 module load cray-mpich/8.1.29
 module load netcdf/4.9.2
-#module load hdf5/1.12.2
-#module load netcdf-mpi/4.9.2
-
 module load cray-libsci/24.03.0
 
 if ($?ICE_IOTYPE) then
 if ($ICE_IOTYPE =~ pio*) then
   module unload	netcdf
   module load netcdf-mpi/4.9.2
-  module load parallel-netcdf/1.12.3
+  module load parallel-netcdf/1.14.0
   if ($ICE_IOTYPE == "pio1") then
     module load parallelio/1.10.1
   else
-    module load parallelio/2.6.2
+    module load parallelio/2.6.3
   endif
 endif
 endif

--- a/configuration/scripts/tests/cice.lcov.csh
+++ b/configuration/scripts/tests/cice.lcov.csh
@@ -14,7 +14,7 @@ cp -p -r ${lcovhtmldir} ${lcovrepo}/
 
 cd ${lcovrepo}
 set covp0 = `grep message coverage.json | cut -d : -f 2 | cut -d \" -f 2 | cut -d % -f 1`
-set covp  = `grep -i headerCovTableEntry ${lcovhtmldir}/index.html | grep % | head -1 | cut -d \> -f 2 | cut -d % -f 1`
+set covp  = `grep -i headerCovTableEntry ${lcovhtmldir}/index.html | grep % | head -1 | cut -d \> -f 2 | cut -d \& -f 1`
 set covpi = `echo $covp | cut -d . -f 1`
 
 set lcovhtmlname = "${covpi}%:${report_name}"


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update derecho gnu to add coverage capability with lcov
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    All results are bit-for-bit, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#242329f7be9ff1c1b43f173d5e2c5585eaa6f53d
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update derecho gnu to support code coverage testing

- Update to ncarenv/24.12 and gcc/12.4.0
- Add coverage compiler flags
- Update lcov scripting as needed

As part of the CICE port to the new coverage tools, a bug was found in the tools that requires debug flags to be disabled when compiling with coverage flags. This was not the case when coverage was running on cheyenne. See https://github.com/linux-test-project/lcov/issues/385
