### PR TITLE
Update rectangular (box) configurations

### DIFF
--- a/cicecore/cicedyn/general/ice_forcing.F90
+++ b/cicecore/cicedyn/general/ice_forcing.F90
@@ -5202,7 +5202,6 @@
       use ice_domain, only: nblocks, blocks_ice
       use ice_blocks, only: block, get_block, nx_block, ny_block, nghost
       use ice_flux, only: uocn, vocn
-      use ice_grid, only: uvm
 
       ! local parameters
 
@@ -5234,9 +5233,6 @@
                             / real(ny_global,kind=dbl_kind) - p1
          vocn(i,j,iblk) = -p2*real(iglob(i), kind=dbl_kind) &
                             / real(nx_global,kind=dbl_kind) + p1
-
-         uocn(i,j,iblk) = uocn(i,j,iblk) * uvm(i,j,iblk)
-         vocn(i,j,iblk) = vocn(i,j,iblk) * uvm(i,j,iblk)
 
          enddo
          enddo

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -1967,7 +1967,12 @@
          write(nu_diag,1030) '   grid_ocn_dynu  = ',trim(grid_ocn_dynu)
          write(nu_diag,1030) '   grid_ocn_dynv  = ',trim(grid_ocn_dynv)
          write(nu_diag,1030) ' kmt_type         = ',trim(kmt_type)
-         if (trim(grid_type) /= 'rectangular') then
+         if (trim(grid_type) == 'rectangular') then
+            write(nu_diag,1004) 'lon/lat refrect   = ',lonrefrect,latrefrect
+            write(nu_diag,1004) 'dx/dy rect (cm)   = ',dxrect,dyrect
+            write(nu_diag,1010) 'scale_dxdy        = ',scale_dxdy
+            write(nu_diag,1004) 'dx/dy scale       = ',dxscale,dyscale
+         else
             if (use_bathymetry) then
                tmpstr2 = ' : bathymetric input data is used'
             else
@@ -2759,7 +2764,8 @@
 
  1000    format (a20,1x,f13.6,1x,a) ! float
  1002    format (a20,5x,f9.2,1x,a)
- 1003    format (a20,1x,G13.4,1x,a)
+ 1003    format (a20,1x,g13.4,1x,a)
+ 1004    format (a20,1x,2g13.4,1x,a)
  1009    format (a20,1x,d13.6,1x,a)
  1010    format (a20,8x,l6,1x,a)  ! logical
  1011    format (a20,1x,l6)
@@ -3318,23 +3324,9 @@
          ! location of ice
          !---------------------------------------------------------
 
-         if (trim(ice_data_type) == 'box2001') then
+         icells = 0
 
-            ! place ice on left side of domain
-            icells = 0
-            do j = jlo, jhi
-            do i = ilo, ihi
-               if (tmask(i,j)) then
-                  if (ULON(i,j) < -50./rad_to_deg) then
-                     icells = icells + 1
-                     indxi(icells) = i
-                     indxj(icells) = j
-                  endif            ! ULON
-               endif               ! tmask
-            enddo                  ! i
-            enddo                  ! j
-
-         elseif (trim(ice_data_type) == 'boxslotcyl') then
+         if (trim(ice_data_type) == 'boxslotcyl') then
 
             ! Geometric configuration of the slotted cylinder
             diam     = p3 *dxrect*(nx_global-1)
@@ -3366,8 +3358,10 @@
             enddo
             enddo
 
-         elseif (trim(ice_data_type) == 'uniform') then
+         elseif (trim(ice_data_type) == 'uniform' .or. trim(ice_data_type) == 'box2001') then
             ! all cells not land mask are ice
+            ! box2001 used to have a check for west of 50W, this was changed, so now box2001 is 
+            ! the same as uniform.  keep box2001 option for backwards compatibility.
             icells = 0
             do j = jlo, jhi
             do i = ilo, ihi

--- a/cicecore/cicedyn/infrastructure/ice_grid.F90
+++ b/cicecore/cicedyn/infrastructure/ice_grid.F90
@@ -673,7 +673,8 @@
          !$OMP END PARALLEL DO
       endif
 
-      if (trim(grid_type) == 'regional' .and. &
+      if ((trim(grid_type) == 'regional' .or. &
+           trim(grid_type) == 'rectangular') .and. &
           (.not. (l_readCenter))) then
          ! for W boundary extrapolate from interior
          !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
@@ -2329,7 +2330,8 @@
       enddo                     ! iblk
       !$OMP END PARALLEL DO
 
-      if (trim(grid_type) == 'regional') then
+      if (trim(grid_type) == 'regional' .or. &
+          trim(grid_type) == 'rectangular') then
          ! for W boundary extrapolate from interior
          !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
          do iblk = 1, nblocks
@@ -2479,7 +2481,8 @@
       enddo                     ! iblk
       !$OMP END PARALLEL DO
 
-      if (trim(grid_type) == 'regional') then
+      if (trim(grid_type) == 'regional' .or. &
+          trim(grid_type) == 'rectangular') then
          ! for W boundary extrapolate from interior
          !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block)
          do iblk = 1, nblocks

--- a/configuration/scripts/options/set_nml.bgcsklclim
+++ b/configuration/scripts/options/set_nml.bgcsklclim
@@ -12,6 +12,7 @@ n_fed           = 1
 n_fep           = 1
 year_init       = 2005
 istep0          = 0
+npt_unit        = '1'
 npt             = 168
 ice_ic          = 'none'
 tr_brine        = .true.

--- a/configuration/scripts/options/set_nml.box2001
+++ b/configuration/scripts/options/set_nml.box2001
@@ -2,6 +2,7 @@ grid_atm = 'B'
 grid_ocn = 'B'
 days_per_year = 360
 use_leap_years = .false.
+npt_unit       = '1'
 npt = 240
 ice_ic = 'internal'
 restart_ext = .true.

--- a/configuration/scripts/options/set_nml.boxnodyn
+++ b/configuration/scripts/options/set_nml.boxnodyn
@@ -2,6 +2,7 @@ nilyr =	1
 ice_ic = 'internal'
 days_per_year = 360
 use_leap_years = .false.
+npt_unit       = '1'
 npt            = 72
 dumpfreq       = 'd'
 dumpfreq_n     = 2

--- a/configuration/scripts/options/set_nml.boxopen
+++ b/configuration/scripts/options/set_nml.boxopen
@@ -1,3 +1,4 @@
+npt_unit       = '1'
 npt = 48
 ice_ic   = 'internal'
 use_leap_years = .false.

--- a/configuration/scripts/options/set_nml.boxslotcyl
+++ b/configuration/scripts/options/set_nml.boxslotcyl
@@ -4,6 +4,7 @@ nilyr = 1
 ice_ic = 'internal'
 restart_ext = .false.
 dt             = 3600.0
+npt_unit       = '1'
 npt            = 288
 grid_type      = 'rectangular'
 kmt_type       = 'default'

--- a/configuration/scripts/options/set_nml.boxwallblock
+++ b/configuration/scripts/options/set_nml.boxwallblock
@@ -1,5 +1,6 @@
 days_per_year = 360
 use_leap_years = .false.
+npt_unit       = '1'
 npt = 240
 ice_ic = 'internal'
 restart_ext = .true.

--- a/configuration/scripts/options/set_nml.gbox12
+++ b/configuration/scripts/options/set_nml.gbox12
@@ -1,3 +1,5 @@
+dxrect        = 30.e5
+dyrect        = 30.e5
 ice_ic = 'internal'
 grid_type = 'rectangular'
 kmt_type      = 'default'

--- a/configuration/scripts/options/set_nml.gbox128
+++ b/configuration/scripts/options/set_nml.gbox128
@@ -1,3 +1,5 @@
+dxrect        = 3.e5
+dyrect        = 3.e5
 grid_ocn = 'B'
 ice_ic = 'internal'
 grid_type = 'rectangular'

--- a/configuration/scripts/options/set_nml.gbox180
+++ b/configuration/scripts/options/set_nml.gbox180
@@ -1,3 +1,6 @@
+dxrect        = 2.e5
+dyrect        = 2.e5
+dt = 1800.0
 ice_ic = 'internal'
 grid_type = 'rectangular'
 kmt_type      = 'default'

--- a/configuration/scripts/options/set_nml.gbox80
+++ b/configuration/scripts/options/set_nml.gbox80
@@ -1,3 +1,5 @@
+dxrect        = 5.e5
+dyrect        = 5.e5
 ice_ic = 'internal'
 grid_type = 'rectangular'
 kmt_type      = 'default'

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -239,11 +239,11 @@ Ocean stresses are computed as in :cite:`Hunke01` where they are circular and ce
 in the square domain.  The ice distribution is fixed, with a constant 2 meter ice 
 thickness and a concentration field that varies linearly in the x-direction from ``0``
 to ``1`` and is constant in the y-direction.  No islands are included in this
-configuration.  The test is configured to run on a single processor.
+configuration.
 
 To run the test::
 
-  ./cice.setup -m <machine> --test smoke -s box2001 --testid <test_id> --grid gbox80 --acct <queue manager account> -p 1x1
+  ./cice.setup -m <machine> --test smoke -s box2001 --testid <test_id> --grid gbox80 --acct <queue manager account>
 
 .. _boxslotcyl:
 


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update rectangular (box) configurations
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Several box tests change answers, as expected.  This fixes a few bugs in the box setup.  Non-box configurations pass and are bit-for-bit as expected.  https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#c3429c9a8f34869800e2ef8d06a2096be89d1d0e
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial, but just for some box configurations 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update the rectangular (box) grid configurations.
- Fix bug where left hand side of rectangular grids had incorrect longitudes and latitudes computed.  This changes answers in some box configurations.
- Update the box resolutions.  dxrect and dyrect were hardwired to 30km for all box resolutions.  Now adjust dxrect and dyrect depending on the number of gridcells so it always covers an area of about 3 degrees by 3 degrees.  This means gbox12 is 30km resolution, gbox80 is 5km, gbox128 is 3 km, and gbox180 is 2 km.  Reduce the gbox180 timestep to 1800s for stability.  This changes answers for some box configurations.
- Remove u masking from box2001 ocean forcing, bit-for-bit.
- Remove 50W check associated with box2001 initial conditions, bit-for-bit.
- Add rectangular grid diagnostics
- Minor update to the box2001 documentation
    
Explicitly set npt_unit in all set_nml files that have npt set.  Improves robustness where one option sets npt and another sets npt_unit.

These changes do not fundamentally change how the model behaves with simple box test configurations.  This just fixes a few inconsistencies in how the box grids are setup.

Closes #1004 