### PR TITLE
A bug fix mainly for the nvhpc compiler from the EarthWorks model

### DIFF
--- a/cicecore/cicedyn/infrastructure/comm/mpi/ice_boundary.F90
+++ b/cicecore/cicedyn/infrastructure/comm/mpi/ice_boundary.F90
@@ -1333,7 +1333,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)
-      call MPI_IRECV(bufRecvR8(1:len,nmsg), len, mpiR8, &
+      call MPI_IRECV(bufRecvR8(1,nmsg), len, mpiR8, &
                      halo%recvTask(nmsg),               &
                      mpitagHalo + halo%recvTask(nmsg),  &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -1359,7 +1359,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)
-      call MPI_ISEND(bufSendR8(1:len,nmsg), len, mpiR8, &
+      call MPI_ISEND(bufSendR8(1,nmsg), len, mpiR8, &
                      halo%sendTask(nmsg),               &
                      mpitagHalo + my_task,              &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -1768,7 +1768,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)
-      call MPI_IRECV(bufRecvR4(1:len,nmsg), len, mpiR4, &
+      call MPI_IRECV(bufRecvR4(1,nmsg), len, mpiR4, &
                      halo%recvTask(nmsg),               &
                      mpitagHalo + halo%recvTask(nmsg),  &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -1794,7 +1794,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)
-      call MPI_ISEND(bufSendR4(1:len,nmsg), len, mpiR4, &
+      call MPI_ISEND(bufSendR4(1,nmsg), len, mpiR4, &
                      halo%sendTask(nmsg),               &
                      mpitagHalo + my_task,              &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -2183,7 +2183,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)
-      call MPI_IRECV(bufRecvI4(1:len,nmsg), len, MPI_INTEGER, &
+      call MPI_IRECV(bufRecvI4(1,nmsg), len, MPI_INTEGER, &
                      halo%recvTask(nmsg),                     &
                      mpitagHalo + halo%recvTask(nmsg),        &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -2209,7 +2209,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)
-      call MPI_ISEND(bufSendI4(1:len,nmsg), len, MPI_INTEGER, &
+      call MPI_ISEND(bufSendI4(1,nmsg), len, MPI_INTEGER, &
                      halo%sendTask(nmsg),                     &
                      mpitagHalo + my_task,                    &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -2702,7 +2702,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)*nz
-      call MPI_IRECV(bufRecv(1:len,nmsg), len, mpiR8,   &
+      call MPI_IRECV(bufRecv(1,nmsg), len, mpiR8,   &
                      halo%recvTask(nmsg),               &
                      mpitagHalo + halo%recvTask(nmsg),  &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -2732,7 +2732,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)*nz
-      call MPI_ISEND(bufSend(1:len,nmsg), len, mpiR8, &
+      call MPI_ISEND(bufSend(1,nmsg), len, mpiR8, &
                      halo%sendTask(nmsg),             &
                      mpitagHalo + my_task,            &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -3176,7 +3176,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)*nz
-      call MPI_IRECV(bufRecv(1:len,nmsg), len, mpiR4,   &
+      call MPI_IRECV(bufRecv(1,nmsg), len, mpiR4,   &
                      halo%recvTask(nmsg),               &
                      mpitagHalo + halo%recvTask(nmsg),  &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -3206,7 +3206,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)*nz
-      call MPI_ISEND(bufSend(1:len,nmsg), len, mpiR4, &
+      call MPI_ISEND(bufSend(1,nmsg), len, mpiR4, &
                      halo%sendTask(nmsg),             &
                      mpitagHalo + my_task,            &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -3650,7 +3650,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)*nz
-      call MPI_IRECV(bufRecv(1:len,nmsg), len, MPI_INTEGER, &
+      call MPI_IRECV(bufRecv(1,nmsg), len, MPI_INTEGER, &
                      halo%recvTask(nmsg),                   &
                      mpitagHalo + halo%recvTask(nmsg),      &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -3680,7 +3680,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)*nz
-      call MPI_ISEND(bufSend(1:len,nmsg), len, MPI_INTEGER, &
+      call MPI_ISEND(bufSend(1,nmsg), len, MPI_INTEGER, &
                      halo%sendTask(nmsg),                   &
                      mpitagHalo + my_task,                  &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -4125,7 +4125,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)*nz*nt
-      call MPI_IRECV(bufRecv(1:len,nmsg), len, mpiR8,  &
+      call MPI_IRECV(bufRecv(1,nmsg), len, mpiR8,  &
                      halo%recvTask(nmsg),              &
                      mpitagHalo + halo%recvTask(nmsg), &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -4158,7 +4158,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)*nz*nt
-      call MPI_ISEND(bufSend(1:len,nmsg), len, mpiR8, &
+      call MPI_ISEND(bufSend(1,nmsg), len, mpiR8, &
                      halo%sendTask(nmsg),             &
                      mpitagHalo + my_task,            &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -4623,7 +4623,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)*nz*nt
-      call MPI_IRECV(bufRecv(1:len,nmsg), len, mpiR4,  &
+      call MPI_IRECV(bufRecv(1,nmsg), len, mpiR4,  &
                      halo%recvTask(nmsg),              &
                      mpitagHalo + halo%recvTask(nmsg), &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -4656,7 +4656,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)*nz*nt
-      call MPI_ISEND(bufSend(1:len,nmsg), len, mpiR4, &
+      call MPI_ISEND(bufSend(1,nmsg), len, mpiR4, &
                      halo%sendTask(nmsg),             &
                      mpitagHalo + my_task,            &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -5121,7 +5121,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)*nz*nt
-      call MPI_IRECV(bufRecv(1:len,nmsg), len, MPI_INTEGER, &
+      call MPI_IRECV(bufRecv(1,nmsg), len, MPI_INTEGER, &
                      halo%recvTask(nmsg),                   &
                      mpitagHalo + halo%recvTask(nmsg),      &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -5154,7 +5154,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)*nz*nt
-      call MPI_ISEND(bufSend(1:len,nmsg), len, MPI_INTEGER, &
+      call MPI_ISEND(bufSend(1,nmsg), len, MPI_INTEGER, &
                      halo%sendTask(nmsg),                   &
                      mpitagHalo + my_task,                  &
                      halo%communicator, sndRequest(nmsg), ierr)
@@ -5588,7 +5588,7 @@ contains
    do nmsg=1,halo%numMsgRecv
 
       len = halo%SizeRecv(nmsg)
-      call MPI_IRECV(bufRecvR8(1:len,nmsg), len, mpiR8, &
+      call MPI_IRECV(bufRecvR8(1,nmsg), len, mpiR8, &
                      halo%recvTask(nmsg),               &
                      mpitagHalo + halo%recvTask(nmsg),  &
                      halo%communicator, rcvRequest(nmsg), ierr)
@@ -5614,7 +5614,7 @@ contains
       end do
 
       len = halo%SizeSend(nmsg)
-      call MPI_ISEND(bufSendR8(1:len,nmsg), len, mpiR8, &
+      call MPI_ISEND(bufSendR8(1,nmsg), len, mpiR8, &
                      halo%sendTask(nmsg),               &
                      mpitagHalo + my_task,              &
                      halo%communicator, sndRequest(nmsg), ierr)


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
This is a bug fix only to ice_boundary.F90 to fix an issue with the nvhpc compiler and MPI calls. Found in the EarthWorks model.
- [X] Developer(s): 
dabail10 (D. Bailey)
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#ce8cc304c78ef07265ef8e4f7739229eaee65573
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
This simply removes the 1:len in MPI calls.