### PR TITLE
Use ymd instead of uninitialized date in timeInit for (unused?) optDate in alarmInit

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
@@ -971,8 +971,7 @@ contains
 
     ! local variables
     integer :: year, mon, day ! year, month, day as integers
-    integer :: tdate          ! temporary date
-    integer :: date           ! coded-date (yyyymmdd)
+    integer :: tdate          ! temporary date (yyyymmdd)
     character(len=*), parameter :: subname='(timeInit)'
     !-------------------------------------------------------------------------------
 
@@ -982,9 +981,9 @@ contains
        call abort_ice( subname//'ERROR yymmdd is a negative number or time-of-day out of bounds' )
     end if
 
-    tdate = abs(date)
+    tdate = abs(ymd)
     year = int(tdate/10000)
-    if (date < 0) year = -year
+    if (ymd < 0) year = -year
     mon = int( mod(tdate,10000)/  100)
     day = mod(tdate,  100)
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Use ymd instead of uninitialized date in timeInit for (unused?) optDate in alarmInit
- [x] Developer(s): 
    Denise Worthen, Nick Szapiro
- [ ] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    Options aren't exercised in UFS regression testing. Any suggestions for how to test? 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit (almost everywhere)
    - [ ] different at roundoff level
    - [x] more substantial (in optDate alarmInit option)
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Address compiler warning and bug that `Warning: 'date' is used uninitialized [-Wuninitialized]`. This impacts alarmInit when using optDate. I don't know that anyone does that, especially as it's not working properly. Part of https://github.com/ufs-community/ufs-weather-model/issues/2703
