### PR TITLE
Setting calendar attribute in output to proleptic_gregorian

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_binary/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_binary/ice_history_write.F90
@@ -109,7 +109,7 @@
         write (nu_hdr, 999) 'runid',runid,' '
 #endif
         if (use_leap_years) then
-           write (nu_hdr, 999) 'calendar','Gregorian',' '
+           write (nu_hdr, 999) 'calendar','proleptic_gregorian',' '
            write (title,'(a,i3,a)') 'This year has ',int(dayyr),' days'
         else
            write (nu_hdr, 999) 'calendar','noleap',' '

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -254,7 +254,7 @@
             elseif (days_per_year == 365 .and. .not.use_leap_years ) then
                cal_att='noleap'
             elseif (use_leap_years) then
-               cal_att='Gregorian'
+               cal_att='proleptic_gregorian'
             else
                call abort_ice(subname//' ERROR: invalid calendar settings', file=__FILE__, line=__LINE__)
             endif

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -253,7 +253,7 @@
          elseif (days_per_year == 365 .and. .not.use_leap_years ) then
             cal_att='noleap'
          elseif (use_leap_years) then
-            cal_att='Gregorian'
+            cal_att='proleptic_gregorian'
          else
             call abort_ice(subname//' ERROR: invalid calendar settings')
          endif

--- a/configuration/tools/jra55_datasets/interp_jra55_ncdf_bilinear.py
+++ b/configuration/tools/jra55_datasets/interp_jra55_ncdf_bilinear.py
@@ -287,7 +287,7 @@ def init_ncout(ncout,nc1,llat,llon):
     # with dimension 'time'
     times          = dsout.createVariable('time','f8',('time',))
     times.units    = nc1['initial_time0_hours'].units
-    times.calendar = 'gregorian'
+    times.calendar = 'proleptic_gregorian'
 
     # loop over nc1 times
     dates = []


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
    This sets the calendar attribute correctly in history output. The docs and code comments already note the calendar is actually proleptic gregorian
- [ ] Developer(s): 
    @anton-seaice 
- [ ] Suggest PR reviewers from list in the column to the right.
     @apcraig 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    N/A 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [ ] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
    This sets the calendar attribute correctly in history output. The calendar CICE uses with leap years is now called proleptic_gregorian rather than greogorian. The gregorian calendar starts in 1582, and a calendar which uses the same pattern of leap years as the modern calendar but exists before 1582 should be refered to as proleptic_gregorian .