### PR TITLE
Update job completion checking associated with testing

### DIFF
--- a/configuration/scripts/tests/poll_queue.csh
+++ b/configuration/scripts/tests/poll_queue.csh
@@ -13,10 +13,9 @@ foreach line ("`cat suite.jobs`")
   set qstatjob = 1
   if (${job} =~ [0-9]*) then
     while ($qstatjob)
-      ${ICE_MACHINE_QSTAT} $job >&/dev/null
-      set qstatus = $status
+      set qstatus = `${ICE_MACHINE_QSTAT} $job | grep $job | wc -l`
 #      echo $job $qstatus
-      if ($qstatus != 0) then
+      if ($qstatus == 0) then
         echo "Job $job completed"
         set qstatjob = 0
       else


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update job completion checking associated with testing
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    This was tested on derecho (pbs) and blueback (slurm) with success.  This only affects testing with automated reporting (--report) turned on.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update job completion checking associated with testing and automated reporting.  Latest version of slurm does not return the same error codes, so now we're switching to checking whether the job is in the queue explicitly.  This only impacts automated test reporting (--report).
