### PR TITLE
Consistent character(char_len) :: stdname in cmeps cap

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
@@ -79,7 +79,7 @@ module ice_import_export
   ! Private module data
 
   type fld_list_type
-    character(len=128) :: stdname
+    character(char_len) :: stdname
     integer :: ungridded_lbound = 0
     integer :: ungridded_ubound = 0
   end type fld_list_type
@@ -1409,7 +1409,7 @@ contains
     ! local variables
     integer                :: n
     type(ESMF_Field)       :: field
-    character(len=80)      :: stdname
+    character(char_len)    :: stdname
     character(ESMF_MAXSTR) :: msg
     character(len=*),parameter  :: subname='(ice_import_export:fld_list_realize)'
     ! ----------------------------------------------


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Clean up -Wcharacter-truncation compiler warning via consistent character(char_len) :: stdname in cmeps cap
- [x] Developer(s): 
    Nick Szapiro
- [ ] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    bit-for-bit in UFS regression tests 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

For operational implementation, clean up compiler `Warning: CHARACTER expression will be truncated in assignment (80/128) at (1) [-Wcharacter-truncation]`. NUOPC standard names here are all shorter than 80 characters. Part of https://github.com/ufs-community/ufs-weather-model/issues/2703