### PR TITLE
NUOPC/CMEPS only: Make datestamps in pointer filenames configurable (#9)

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_binary/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_binary/ice_restart.F90
@@ -396,6 +396,7 @@
          nbtrcr                  ! number of bgc tracers
 
       character(len=char_len_long) :: filename
+      character(len=char_len_long) :: lpointer_file
 
       character(len=*), parameter :: subname = '(init_restart_write)'
 
@@ -422,7 +423,13 @@
 
       ! write pointer (path/file)
       if (my_task == master_task) then
-         open(nu_rst_pointer,file=pointer_file)
+         lpointer_file = pointer_file
+         if (pointer_date) then
+            ! append date to pointer filename
+            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
+               trim(lpointer_file)//'.',myear,'-',mmonth,'-',mday,'-',msec
+         end if
+         open(nu_rst_pointer,file=lpointer_file)
          write(nu_rst_pointer,'(a)') filename
          close(nu_rst_pointer)
          if (restart_ext) then

--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_restart.F90
@@ -168,6 +168,7 @@
          nbtrcr                  ! number of bgc tracers
 
       character(len=char_len_long) :: filename
+      character(len=char_len_long) :: lpointer_file
 
       integer (kind=int_kind), allocatable :: dims(:)
 
@@ -214,7 +215,13 @@
       ! write pointer (path/file)
       if (my_task == master_task) then
          filename = trim(filename) // '.nc'
-         open(nu_rst_pointer,file=pointer_file)
+         lpointer_file = pointer_file
+         if (pointer_date) then
+            ! append date to pointer filename
+            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
+               trim(lpointer_file)//'.',myear,'-',mmonth,'-',mday,'-',msec
+         end if
+         open(nu_rst_pointer,file=lpointer_file)
          write(nu_rst_pointer,'(a)') filename
          close(nu_rst_pointer)
 

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -223,12 +223,16 @@
 
       ! write pointer (path/file)
       if (my_task == master_task) then
-#ifdef CESMCOUPLED
-            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
-                 'rpointer.ice'//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
+#ifdef CESMCOUPLED 
+            lpointer_file = 'rpointer.ice'//trim(inst_suffix)
 #else
             lpointer_file = pointer_file
 #endif
+         if (pointer_date) then
+            ! append date to pointer filename
+            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
+               trim(lpointer_file)//'.',myear,'-',mmonth,'-',mday,'-',msec
+         end if
          open(nu_rst_pointer,file=lpointer_file)
          write(nu_rst_pointer,'(a)') filename
          close(nu_rst_pointer)

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -219,7 +219,7 @@
                myear,'-',mmonth,'-',mday,'-',msec
       end if
 
-      if (restart_format(1:3) /= 'bin') filename = trim(filename) // '.nc'
+      filename = trim(filename) // '.nc'
 
       ! write pointer (path/file)
       if (my_task == master_task) then

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -30,7 +30,8 @@ module ice_comp_nuopc
   use ice_kinds_mod      , only : dbl_kind, int_kind, char_len, char_len_long
   use ice_fileunits      , only : nu_diag, nu_diag_set, inst_index, inst_name
   use ice_fileunits      , only : inst_suffix, release_all_fileunits, flush_fileunit
-  use ice_restart_shared , only : runid, runtype, restart, use_restart_time, restart_dir, restart_file, restart_format, restart_chunksize
+  use ice_restart_shared , only : runid, runtype, restart, use_restart_time, restart_dir, restart_file, &
+                                  restart_format, restart_chunksize, pointer_date
   use ice_history        , only : accum_hist
   use ice_history_shared , only : history_format, history_chunksize
   use ice_exit           , only : abort_ice
@@ -329,6 +330,15 @@ contains
        if (trim(cvalue) .eq. '.true.') restart_eor = .true.
     endif
 
+#ifdef CESMCOUPLED
+    pointer_date = .true.
+#endif
+
+    ! set CICE internal pointer_date variable based on nuopc settings
+    ! this appends a datestamp to the "rpointer" file
+    call NUOPC_CompAttributeGet(gcomp, name="restart_pointer_append_date", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) pointer_date = (trim(cvalue) .eq. ".true.")
     !----------------------------------------------------------------------------
     ! generate local mpi comm
     !----------------------------------------------------------------------------

--- a/cicecore/shared/ice_restart_shared.F90
+++ b/cicecore/shared/ice_restart_shared.F90
@@ -25,6 +25,9 @@
       character (len=char_len_long), public :: &
          pointer_file      ! input pointer file for restarts
 
+      logical (kind=log_kind), public :: &
+         pointer_date =  .false.   ! if true, append datestamp to pointer file
+
       character (len=char_len), public :: &
          restart_format      , & ! format of restart files 'nc'
          restart_rearranger      ! restart file rearranger, box or subset for pio


### PR DESCRIPTION

## PR checklist
- [x] Short (1 sentence) summary of your PR: 
This adds support in NUOPC/CMEPS driver for the addition of datestamps to the pointer filenames (https://github.com/CICE-Consortium/CICE/pull/990) to be configurable instead of always on when #CESMCOUPLED is set
- [x] Developer(s): 
@anton-seaice 
- [x] Suggest PR reviewers from list in the column to the right.
@apcraig @jedwards4b 
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
If the changes look conceptually ok, I will run one of the test suites
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

This adds support in NUOPC/CMEPS driver for the addition of datestamps to the pointer filenames to be configurable through the nuopc option restart_pointer_append_date .

This is a companion change to https://github.com/ESCOMP/CESM_share/pull/70, and does not impact any current default behaviour.