### PR TITLE
Update the qstat job completion checks

### DIFF
--- a/configuration/scripts/tests/baseline.script
+++ b/configuration/scripts/tests/baseline.script
@@ -136,17 +136,17 @@ if (${ICE_BFBCOMP} != ${ICE_SPVAL}) then
     set cnt = 0
     if (${job} =~ [0-9]*) then
       while ($qstatjob)
-        ${ICE_MACHINE_QSTAT} $job >&/dev/null
-        set qstatus = $status
+        set qstatus = `${ICE_MACHINE_QSTAT} $job | grep $job | wc -l`
+#        ${ICE_MACHINE_QSTAT} $job
 #        echo $job $qstatus
-        if ($qstatus != 0) then
+        if ($qstatus == 0) then
           echo "Job $job completed"
           set qstatjob = 0
         else
           @ cnt = $cnt + 1
           echo "Waiting for $job to complete $cnt"
           sleep 60   # Sleep for 1 minute, so as not to overwhelm the queue manager
-          if ($cnt > 30) then
+          if ($cnt > 5) then
             echo "No longer waiting for $job to complete"
             set qstatjob = 0 # Abandon check after cnt sleep 60 checks
           endif


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update the qstat job completion checks
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Testing carried out on derecho intel, tests pass bit-for-bit.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update the qstat job completion checks to use

  set qstatus = `${ICE_MACHINE_QSTAT} $job | grep $job | wc -l`

Some recent changes made the return status of "${ICE_MACHINE_QSTAT} $job" no longer robust as a way to check if a job was in the queue or not.

