### PR TITLE
Fix bug in ice_restoring with respect to indexing of trcrn_rest

### DIFF
--- a/cicecore/cicedyn/infrastructure/ice_restoring.F90
+++ b/cicecore/cicedyn/infrastructure/ice_restoring.F90
@@ -215,7 +215,7 @@
                vicen_rest(i,j,n,iblk) = vicen(i,jlo,n,iblk)
                vsnon_rest(i,j,n,iblk) = vsnon(i,jlo,n,iblk)
                do nt = 1, ntrcr
-                  trcrn_rest(i,j,nt,n,iblk) = trcrn(ilo,j,nt,n,iblk)
+                  trcrn_rest(i,j,nt,n,iblk) = trcrn(i,jlo,nt,n,iblk)
                enddo
             enddo
             enddo
@@ -246,7 +246,7 @@
                vicen_rest(i,j,n,iblk) = vicen(i,jhi,n,iblk)
                vsnon_rest(i,j,n,iblk) = vsnon(i,jhi,n,iblk)
                do nt = 1, ntrcr
-                  trcrn_rest(i,j,nt,n,iblk) = trcrn(ihi,j,nt,n,iblk)
+                  trcrn_rest(i,j,nt,n,iblk) = trcrn(i,jhi,nt,n,iblk)
                enddo
             enddo
             enddo


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix bug in ice_restoring with respect to indexing of trcrn_rest
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Results are bit-for-bit on derecho with the intel compiler, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#b01032506d71d86ca51cef8c3c28c1ab87532833
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial but only for cases with ice restoring on, a feature which is currently mostly unused and untested. 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Fix bug in ice_restoring with respect to indexing of trcrn_rest.  This will change answers when ice restoring is turned on.

The CICE restoring feature is not generally used, and we currently have no tests to cover that feature.  This bug was discovered as part of an ongoing effort to improve regional grid capability with additional PRs to come in the future.  A full test suite run on derecho with the intel compiler confirmed this, no answers changed.

Closes #1047 
