### PR TITLE
Set rheology to zero for the C-grid when concentration is very small

### DIFF
--- a/cicecore/cicedyn/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_eap.F90
@@ -298,7 +298,7 @@
                          indxUi      (:,iblk), indxUj      (:,iblk), &
                          aiU       (:,:,iblk), umass     (:,:,iblk), &
                          umassdti  (:,:,iblk), fcor_blk  (:,:,iblk), &
-                         umask     (:,:,iblk),                       &
+                         umask     (:,:,iblk), rheofactU (:,:,iblk), &
                          uocnU     (:,:,iblk), vocnU     (:,:,iblk), &
                          strairxU  (:,:,iblk), strairyU  (:,:,iblk), &
                          ss_tltxU  (:,:,iblk), ss_tltyU  (:,:,iblk), &

--- a/cicecore/cicedyn/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_eap.F90
@@ -160,7 +160,7 @@
          forceyU    , & ! work array: combined atm stress and ocn tilt, y
          umass      , & ! total mass of ice and snow (u grid)
          umassdti   , & ! mass of U-cell/dte (kg/m^2 s)
-         rheofactU      ! mult. factor = 1, set to 0 if aiU < rheo_area_min
+         rheofactU      ! mult. factor = 1, set to 0 if aiU <= rheo_area_min
                         ! rheofactU is not used but added for consistency with
                         ! C-grid rheofactN and rheofactE (for call dyn_prep2)
 

--- a/cicecore/cicedyn/dynamics/ice_dyn_eap.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_eap.F90
@@ -159,7 +159,10 @@
          forcexU    , & ! work array: combined atm stress and ocn tilt, x
          forceyU    , & ! work array: combined atm stress and ocn tilt, y
          umass      , & ! total mass of ice and snow (u grid)
-         umassdti       ! mass of U-cell/dte (kg/m^2 s)
+         umassdti   , & ! mass of U-cell/dte (kg/m^2 s)
+         rheofactU      ! mult. factor = 1, set to 0 if aiU < rheo_area_min
+                        ! rheofactU is not used but added for consistency with
+                        ! C-grid rheofactN and rheofactE (for call dyn_prep2)
 
       real (kind=dbl_kind), dimension(nx_block,ny_block,8):: &
          strtmp         ! stress combinations for momentum equation

--- a/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
@@ -1024,7 +1024,7 @@
                                    indxEi      (:,iblk), indxEj      (:,iblk), &
                                    dxE       (:,:,iblk), dyE       (:,:,iblk), &
                                    dxU       (:,:,iblk), dyT       (:,:,iblk), &
-                                   earear    (:,:,iblk)                      , &
+                                   earear    (:,:,iblk), rheofactE (:,:,iblk), &
                                    stresspT  (:,:,iblk), stressmT  (:,:,iblk), &
                                    stress12U (:,:,iblk), strintxE  (:,:,iblk)  )
 
@@ -1033,7 +1033,7 @@
                                    indxNi      (:,iblk), indxNj      (:,iblk), &
                                    dxN       (:,:,iblk), dyN       (:,:,iblk), &
                                    dxT       (:,:,iblk), dyU       (:,:,iblk), &
-                                   narear    (:,:,iblk)                      , &
+                                   narear    (:,:,iblk), rheofactN (:,:,iblk), &
                                    stresspT  (:,:,iblk), stressmT  (:,:,iblk), &
                                    stress12U (:,:,iblk), strintyN  (:,:,iblk)  )
 
@@ -1206,7 +1206,7 @@
                                    indxEi      (:,iblk), indxEj      (:,iblk), &
                                    dxE       (:,:,iblk), dyE       (:,:,iblk), &
                                    dxU       (:,:,iblk), dyT       (:,:,iblk), &
-                                   earear    (:,:,iblk)                      , &
+                                   earear    (:,:,iblk), rheofactE (:,:,iblk), &
                                    stresspT  (:,:,iblk), stressmT  (:,:,iblk), &
                                    stress12U (:,:,iblk), strintxE  (:,:,iblk)  )
 
@@ -1215,7 +1215,7 @@
                                    indxEi      (:,iblk), indxEj      (:,iblk), &
                                    dxE       (:,:,iblk), dyE       (:,:,iblk), &
                                    dxU       (:,:,iblk), dyT       (:,:,iblk), &
-                                   earear    (:,:,iblk)                      , &
+                                   earear    (:,:,iblk), rheofactE (:,:,iblk), &
                                    stresspU  (:,:,iblk), stressmU  (:,:,iblk), &
                                    stress12T (:,:,iblk), strintyE  (:,:,iblk)  )
 
@@ -1224,7 +1224,7 @@
                                    indxNi      (:,iblk), indxNj      (:,iblk), &
                                    dxN       (:,:,iblk), dyN       (:,:,iblk), &
                                    dxT       (:,:,iblk), dyU       (:,:,iblk), &
-                                   narear    (:,:,iblk)                      , &
+                                   narear    (:,:,iblk), rheofactN (:,:,iblk), &
                                    stresspU  (:,:,iblk), stressmU  (:,:,iblk), &
                                    stress12T (:,:,iblk), strintxN  (:,:,iblk)  )
 
@@ -1233,7 +1233,7 @@
                                    indxNi      (:,iblk), indxNj      (:,iblk), &
                                    dxN       (:,:,iblk), dyN       (:,:,iblk), &
                                    dxT       (:,:,iblk), dyU       (:,:,iblk), &
-                                   narear    (:,:,iblk)                      , &
+                                   narear    (:,:,iblk), rheofactN (:,:,iblk), &
                                    stresspT  (:,:,iblk), stressmT  (:,:,iblk), &
                                    stress12U (:,:,iblk), strintyN  (:,:,iblk)  )
 
@@ -2194,14 +2194,14 @@
 ! elastic-viscous-plastic sea ice model formulated on Arakawa B and C grids.
 ! Ocean Model., 27, 174-184.
 
-      subroutine div_stress_Ex(nx_block, ny_block, &
-                                         icell   , &
-                               indxi   , indxj   , &
-                               dxE     , dyE     , &
-                               dxU     , dyT     , &
-                               arear   ,           &
-                               stressp , stressm , &
-                               stress12,           &
+      subroutine div_stress_Ex(nx_block, ny_block , &
+                                         icell    , &
+                               indxi   , indxj    , &
+                               dxE     , dyE      , &
+                               dxU     , dyT      , &
+                               arear   , rheofactE, &
+                               stressp , stressm  , &
+                               stress12,            &
                                strintx )
 
 
@@ -2218,7 +2218,8 @@
          dyE     , & ! height of E or N-cell through the middle (m)
          dxU     , & ! width of T or U-cell through the middle (m)
          dyT     , & ! height of T or U-cell through the middle (m)
-         arear       ! earear or narear
+         arear   , & ! earear or narear
+         rheofactE   ! mult. factor = 1, set to 0 if aiE <= rheo_area_min
 
       real (kind=dbl_kind), optional, dimension (nx_block,ny_block), intent(in) :: &
          stressp , & ! stressp  (U or T) used for strintx calculation
@@ -2238,7 +2239,7 @@
       do ij = 1, icell
          i = indxi(ij)
          j = indxj(ij)
-         strintx(i,j) = arear(i,j) * &
+         strintx(i,j) = rheofactE(i,j) * arear(i,j) * &
               ( p5 * dyE(i,j)  * ( stressp(i+1,j  )  - stressp (i  ,j  ) ) &
               + (p5/ dyE(i,j)) * ( (dyT(i+1,j  )**2) * stressm (i+1,j  )   &
                                   -(dyT(i  ,j  )**2) * stressm (i  ,j  ) ) &
@@ -2249,14 +2250,14 @@
       end subroutine div_stress_Ex
 
 !=======================================================================
-      subroutine div_stress_Ey(nx_block, ny_block, &
-                                         icell   , &
-                               indxi   , indxj   , &
-                               dxE     , dyE     , &
-                               dxU     , dyT     , &
-                               arear   ,           &
-                               stressp , stressm , &
-                               stress12,           &
+      subroutine div_stress_Ey(nx_block, ny_block , &
+                                         icell    , &
+                               indxi   , indxj    , &
+                               dxE     , dyE      , &
+                               dxU     , dyT      , &
+                               arear   , rheofactE, &
+                               stressp , stressm  , &
+                               stress12,            &
                                strinty )
 
       integer (kind=int_kind), intent(in) :: &
@@ -2272,7 +2273,8 @@
          dyE     , & ! height of E or N-cell through the middle (m)
          dxU     , & ! width of T or U-cell through the middle (m)
          dyT     , & ! height of T or U-cell through the middle (m)
-         arear         ! earear or narear
+         arear   , & ! earear or narear
+         rheofactE   ! mult. factor = 1, set to 0 if aiE <= rheo_area_min
 
       real (kind=dbl_kind), optional, dimension (nx_block,ny_block), intent(in) :: &
          stressp , & ! stressp  (U or T) used for strinty calculation
@@ -2292,7 +2294,7 @@
       do ij = 1, icell
          i = indxi(ij)
          j = indxj(ij)
-         strinty(i,j) = arear(i,j) * &
+         strinty(i,j) = rheofactE(i,j) * arear(i,j) * &
               ( p5 * dxE(i,j)  * ( stressp(i  ,j  )  - stressp (i  ,j-1) ) &
               - (p5/ dxE(i,j)) * ( (dxU(i  ,j  )**2) * stressm (i  ,j  )   &
                                   -(dxU(i  ,j-1)**2) * stressm (i  ,j-1) ) &
@@ -2303,14 +2305,14 @@
       end subroutine div_stress_Ey
 
 !=======================================================================
-      subroutine div_stress_Nx(nx_block, ny_block, &
-                                         icell   , &
-                               indxi   , indxj   , &
-                               dxN     , dyN     , &
-                               dxT     , dyU     , &
-                               arear   ,           &
-                               stressp , stressm , &
-                               stress12,           &
+      subroutine div_stress_Nx(nx_block, ny_block , &
+                                         icell    , &
+                               indxi   , indxj    , &
+                               dxN     , dyN      , &
+                               dxT     , dyU      , &
+                               arear   , rheofactN, &
+                               stressp , stressm  , &
+                               stress12,            &
                                strintx )
 
       integer (kind=int_kind), intent(in) :: &
@@ -2326,7 +2328,8 @@
          dyN     , & ! height of E or N-cell through the middle (m)
          dxT     , & ! width of T or U-cell through the middle (m)
          dyU     , & ! height of T or U-cell through the middle (m)
-         arear       ! earear or narear
+         arear   , & ! earear or narear
+         rheofactN   ! mult. factor = 1, set to 0 if aiN <= rheo_area_min
 
       real (kind=dbl_kind), optional, dimension (nx_block,ny_block), intent(in) :: &
          stressp , & ! stressp  (U or T) used for strintx calculation
@@ -2346,7 +2349,7 @@
       do ij = 1, icell
          i = indxi(ij)
          j = indxj(ij)
-         strintx(i,j) = arear(i,j) * &
+         strintx(i,j) = rheofactN(i,j) * arear(i,j) * &
               ( p5 * dyN(i,j)  * ( stressp(i  ,j  )  - stressp (i-1,j  ) ) &
               + (p5/ dyN(i,j)) * ( (dyU(i  ,j  )**2) * stressm (i  ,j  )   &
                                   -(dyU(i-1,j  )**2) * stressm (i-1,j  ) ) &
@@ -2357,14 +2360,14 @@
       end subroutine div_stress_Nx
 
 !=======================================================================
-      subroutine div_stress_Ny(nx_block, ny_block, &
-                                         icell   , &
-                               indxi   , indxj   , &
-                               dxN     , dyN     , &
-                               dxT     , dyU     , &
-                               arear   ,           &
-                               stressp , stressm , &
-                               stress12,           &
+      subroutine div_stress_Ny(nx_block, ny_block , &
+                                         icell    , &
+                               indxi   , indxj    , &
+                               dxN     , dyN      , &
+                               dxT     , dyU      , &
+                               arear   , rheofactN, &
+                               stressp , stressm  , &
+                               stress12,            &
                                strinty )
 
       integer (kind=int_kind), intent(in) :: &
@@ -2380,7 +2383,8 @@
          dyN     , & ! height of E or N-cell through the middle (m)
          dxT     , & ! width of T or U-cell through the middle (m)
          dyU     , & ! height of T or U-cell through the middle (m)
-         arear       ! earear or narear
+         arear   , & ! earear or narear
+         rheofactN   ! mult. factor = 1, set to 0 if aiN <= rheo_area_min
 
       real (kind=dbl_kind), optional, dimension (nx_block,ny_block), intent(in) :: &
          stressp , & ! stressp  (U or T) used for strinty calculation
@@ -2400,7 +2404,7 @@
       do ij = 1, icell
          i = indxi(ij)
          j = indxj(ij)
-         strinty(i,j) = arear(i,j) * &
+         strinty(i,j) = rheofactN(i,j) * arear(i,j) * &
               ( p5 * dxN(i,j)  * ( stressp(i  ,j+1)  - stressp (i  ,j  ) ) &
               - (p5/ dxN(i,j)) * ( (dxT(i  ,j+1)**2) * stressm (i  ,j+1)   &
                                   -(dxT(i  ,j  )**2) * stressm (i  ,j  ) ) &

--- a/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
@@ -515,7 +515,7 @@
                             indxUi      (:,iblk), indxUj      (:,iblk), &
                             aiU       (:,:,iblk), umass     (:,:,iblk), &
                             umassdti  (:,:,iblk), fcor_blk  (:,:,iblk), &
-                            umask     (:,:,iblk),                       &
+                            umask     (:,:,iblk), rheofactU (:,:,iblk), &
                             uocnU     (:,:,iblk), vocnU     (:,:,iblk), &
                             strairxU  (:,:,iblk), strairyU  (:,:,iblk), &
                             ss_tltxU  (:,:,iblk), ss_tltyU  (:,:,iblk), &
@@ -572,7 +572,7 @@
                             indxUi      (:,iblk), indxUj      (:,iblk), &
                             aiU       (:,:,iblk), umass     (:,:,iblk), &
                             umassdti  (:,:,iblk), fcor_blk  (:,:,iblk), &
-                            umaskCD   (:,:,iblk),                       &
+                            umaskCD   (:,:,iblk), rheofactU (:,:,iblk), &
                             uocnU     (:,:,iblk), vocnU     (:,:,iblk), &
                             strairxU  (:,:,iblk), strairyU  (:,:,iblk), &
                             ss_tltxU  (:,:,iblk), ss_tltyU  (:,:,iblk), &
@@ -622,7 +622,7 @@
                             indxNi      (:,iblk), indxNj      (:,iblk), &
                             aiN       (:,:,iblk), nmass     (:,:,iblk), &
                             nmassdti  (:,:,iblk), fcorN_blk (:,:,iblk), &
-                            nmask     (:,:,iblk),                       &
+                            nmask     (:,:,iblk), rheofactN (:,:,iblk), &
                             uocnN     (:,:,iblk), vocnN     (:,:,iblk), &
                             strairxN  (:,:,iblk), strairyN  (:,:,iblk), &
                             ss_tltxN  (:,:,iblk), ss_tltyN  (:,:,iblk), &
@@ -655,7 +655,7 @@
                             indxEi      (:,iblk), indxEj      (:,iblk), &
                             aiE       (:,:,iblk), emass     (:,:,iblk), &
                             emassdti  (:,:,iblk), fcorE_blk (:,:,iblk), &
-                            emask     (:,:,iblk),                       &
+                            emask     (:,:,iblk), rheofactE (:,:,iblk), &
                             uocnE     (:,:,iblk), vocnE     (:,:,iblk), &
                             strairxE  (:,:,iblk), strairyE  (:,:,iblk), &
                             ss_tltxE  (:,:,iblk), ss_tltyE  (:,:,iblk), &

--- a/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
@@ -67,7 +67,7 @@
          forcexN  (:,:,:) , & ! work array: combined atm stress and ocn tilt, x
          forceyN  (:,:,:) , & ! work array: combined atm stress and ocn tilt, y
          aiN      (:,:,:) , & ! ice fraction on N-grid
-         rheofactN(:,:,:) , & ! mult. factor = 1, set to 0 if aiN < rheo_area_min
+         rheofactN(:,:,:) , & ! mult. factor = 1, set to 0 if aiN <= rheo_area_min
          nmass    (:,:,:) , & ! total mass of ice and snow (N grid)
          nmassdti (:,:,:)     ! mass of N-cell/dte (kg/m^2 s)
 ! all c or d
@@ -82,7 +82,7 @@
          forcexE  (:,:,:) , & ! work array: combined atm stress and ocn tilt, x
          forceyE  (:,:,:) , & ! work array: combined atm stress and ocn tilt, y
          aiE      (:,:,:) , & ! ice fraction on E-grid
-         rheofactE(:,:,:) , & ! mult. factor = 1, set to 0 if aiE < rheo_area_min
+         rheofactE(:,:,:) , & ! mult. factor = 1, set to 0 if aiE <= rheo_area_min
          emass    (:,:,:) , & ! total mass of ice and snow (E grid)
          emassdti (:,:,:)     ! mass of E-cell/dte (kg/m^2 s)
 
@@ -102,7 +102,7 @@
          zetax2U  (:,:,:) , & ! zetax2T averaged to U points
          etax2T   (:,:,:) , & ! etax2  = 2*eta  (shear viscosity)
          etax2U   (:,:,:) , & ! etax2T averaged to U points
-         rheofactU(:,:,:)     ! mult. factor = 1, set to 0 if aiU < rheo_area_min
+         rheofactU(:,:,:)     ! mult. factor = 1, set to 0 if aiU <= rheo_area_min
                               ! rheofactU is not used but added for consistency with
                               ! C-grid rheofactN and rheofactE (for call dyn_prep2)
 

--- a/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
@@ -169,6 +169,7 @@
                 forceyU  (nx_block,ny_block,max_blocks), & ! work array: combined atm stress and ocn tilt, y
                 umass    (nx_block,ny_block,max_blocks), & ! total mass of ice and snow (u grid)
                 umassdti (nx_block,ny_block,max_blocks), & ! mass of U-cell/dte (kg/m^2 s)
+                rheofactU(nx_block,ny_block,max_blocks), & ! mult. factor = 1, set to 0 if aiU <= rheo_area_min
                 stat=ierr)
       if (ierr/=0) call abort_ice(subname//' ERROR: Out of memory B-Grid evp')
 
@@ -184,7 +185,6 @@
                    zetax2U  (nx_block,ny_block,max_blocks), &
                    etax2T   (nx_block,ny_block,max_blocks), &
                    etax2U   (nx_block,ny_block,max_blocks), &
-                   rheofactU(nx_block,ny_block,max_blocks), &
                    stat=ierr)
          if (ierr/=0) call abort_ice(subname//' ERROR: Out of memory U evp')
 

--- a/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_evp.F90
@@ -67,6 +67,7 @@
          forcexN  (:,:,:) , & ! work array: combined atm stress and ocn tilt, x
          forceyN  (:,:,:) , & ! work array: combined atm stress and ocn tilt, y
          aiN      (:,:,:) , & ! ice fraction on N-grid
+         rheofactN(:,:,:) , & ! mult. factor = 1, set to 0 if aiN < rheo_area_min
          nmass    (:,:,:) , & ! total mass of ice and snow (N grid)
          nmassdti (:,:,:)     ! mass of N-cell/dte (kg/m^2 s)
 ! all c or d
@@ -81,6 +82,7 @@
          forcexE  (:,:,:) , & ! work array: combined atm stress and ocn tilt, x
          forceyE  (:,:,:) , & ! work array: combined atm stress and ocn tilt, y
          aiE      (:,:,:) , & ! ice fraction on E-grid
+         rheofactE(:,:,:) , & ! mult. factor = 1, set to 0 if aiE < rheo_area_min
          emass    (:,:,:) , & ! total mass of ice and snow (E grid)
          emassdti (:,:,:)     ! mass of E-cell/dte (kg/m^2 s)
 
@@ -99,7 +101,10 @@
          zetax2T  (:,:,:) , & ! zetax2 = 2*zeta (bulk viscosity)
          zetax2U  (:,:,:) , & ! zetax2T averaged to U points
          etax2T   (:,:,:) , & ! etax2  = 2*eta  (shear viscosity)
-         etax2U   (:,:,:)     ! etax2T averaged to U points
+         etax2U   (:,:,:) , & ! etax2T averaged to U points
+         rheofactU(:,:,:)     ! mult. factor = 1, set to 0 if aiU < rheo_area_min
+                              ! rheofactU is not used but added for consistency with
+                              ! C-grid rheofactN and rheofactE (for call dyn_prep2)
 
       real (kind=dbl_kind), allocatable :: &
          uocnU    (:,:,:) , & ! i ocean current (m/s)
@@ -179,6 +184,7 @@
                    zetax2U  (nx_block,ny_block,max_blocks), &
                    etax2T   (nx_block,ny_block,max_blocks), &
                    etax2U   (nx_block,ny_block,max_blocks), &
+                   rheofactU(nx_block,ny_block,max_blocks), &
                    stat=ierr)
          if (ierr/=0) call abort_ice(subname//' ERROR: Out of memory U evp')
 
@@ -194,6 +200,7 @@
                    aiN      (nx_block,ny_block,max_blocks), &
                    nmass    (nx_block,ny_block,max_blocks), &
                    nmassdti (nx_block,ny_block,max_blocks), &
+                   rheofactN(nx_block,ny_block,max_blocks), &
                    stat=ierr)
          if (ierr/=0) call abort_ice(subname//' ERROR: Out of memory N evp')
 
@@ -209,6 +216,7 @@
                    aiE      (nx_block,ny_block,max_blocks), &
                    emass    (nx_block,ny_block,max_blocks), &
                    emassdti (nx_block,ny_block,max_blocks), &
+                   rheofactE(nx_block,ny_block,max_blocks), &
                    stat=ierr)
          if (ierr/=0) call abort_ice(subname//' ERROR: Out of memory E evp')
 

--- a/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
@@ -597,7 +597,7 @@
                             indxXi,     indxXj,     &
                             aiX,        Xmass,      &
                             Xmassdti,   fcor,       &
-                            Xmask,                  &
+                            Xmask,      rheofactX,  &
                             uocn,       vocn,       &
                             strairx,    strairy,    &
                             ss_tltx,    ss_tlty,    &
@@ -680,7 +680,9 @@
          strintx , & ! divergence of internal ice stress, x (N/m^2)
          strinty , & ! divergence of internal ice stress, y (N/m^2)
          taubx   , & ! seabed stress, x-direction (N/m^2)
-         tauby       ! seabed stress, y-direction (N/m^2)
+         tauby   , & ! seabed stress, y-direction (N/m^2)
+         rheofactX   ! mult. factor = 1, set to 0 if aiU < rheo_area_min
+         
 
       ! local variables
 

--- a/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
@@ -681,7 +681,7 @@
          strinty , & ! divergence of internal ice stress, y (N/m^2)
          taubx   , & ! seabed stress, x-direction (N/m^2)
          tauby   , & ! seabed stress, y-direction (N/m^2)
-         rheofactX   ! mult. factor = 1, set to 0 if aiU < rheo_area_min
+         rheofactX   ! mult. factor = 1, set to 0 if aiU <= rheo_area_min
          
 
       ! local variables
@@ -800,6 +800,12 @@
       do ij = 1, icellX
          i = indxXi(ij)
          j = indxXj(ij)
+
+         if ( aiX (i,j) > rheo_area_min ) then
+            rheofactX(i,j) = c1
+         else
+            rheofactX(i,j) = c0
+         endif
 
          Xmassdti(i,j) = Xmass(i,j)/dt ! kg/m^2 s
 

--- a/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
@@ -1086,7 +1086,7 @@
       subroutine stepu_C (nx_block,   ny_block, &
                           icell,      Cw,       &
                           indxi,      indxj,    &
-                                      aiX,      &
+                                      aiE,      &
                           uocn,       vocn,     &
                           waterx,     forcex,   &
                           massdti,    fm,       &
@@ -1106,7 +1106,7 @@
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
          Tb,       & ! seabed stress factor (N/m^2)
          uvel_init,& ! x-component of velocity (m/s), beginning of timestep
-         aiX     , & ! ice fraction on X-grid
+         aiE     , & ! ice fraction on E-grid
          waterx  , & ! for ocean stress calculation, x (m/s)
          forcex  , & ! work array: combined atm stress and ocn tilt, x
          massdti , & ! mass of e-cell/dt (kg/m^2 s)
@@ -1153,7 +1153,7 @@
          vold = vvel(i,j)
 
          ! (magnitude of relative ocean current)*rhow*drag*aice
-         vrel = aiX(i,j)*rhow*Cw(i,j)*sqrt((uocn(i,j) - uold)**2 + &
+         vrel = aiE(i,j)*rhow*Cw(i,j)*sqrt((uocn(i,j) - uold)**2 + &
                                            (vocn(i,j) - vold)**2)  ! m/s
          ! ice/ocean stress
          taux = vrel*waterx(i,j) ! NOTE this is not the entire
@@ -1185,7 +1185,7 @@
       subroutine stepv_C (nx_block,   ny_block, &
                           icell,      Cw,       &
                           indxi,      indxj,    &
-                                      aiX,      &
+                                      aiN,      &
                           uocn,       vocn,     &
                           watery,     forcey,   &
                           massdti,    fm,       &
@@ -1205,7 +1205,7 @@
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
          Tb,       & ! seabed stress factor (N/m^2)
          vvel_init,& ! y-component of velocity (m/s), beginning of timestep
-         aiX     , & ! ice fraction on X-grid
+         aiN     , & ! ice fraction on N-grid
          watery  , & ! for ocean stress calculation, y (m/s)
          forcey  , & ! work array: combined atm stress and ocn tilt, y
          massdti , & ! mass of n-cell/dt (kg/m^2 s)
@@ -1252,7 +1252,7 @@
          vold = vvel(i,j)
 
          ! (magnitude of relative ocean current)*rhow*drag*aice
-         vrel = aiX(i,j)*rhow*Cw(i,j)*sqrt((uocn(i,j) - uold)**2 + &
+         vrel = aiN(i,j)*rhow*Cw(i,j)*sqrt((uocn(i,j) - uold)**2 + &
                                            (vocn(i,j) - vold)**2)  ! m/s
          ! ice/ocean stress
          tauy = vrel*watery(i,j) ! NOTE this is not the entire ocn stress

--- a/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_shared.F90
@@ -35,7 +35,7 @@
       ! namelist parameters
 
       integer (kind=int_kind), public :: &
-         kdyn       , & ! type of dynamics ( -1, 0 = off, 1 = evp, 2 = eap )
+         kdyn       , & ! type of dynamics ( -1, 0 = off, 1 = evp, 2 = eap , 3 = vp)
          kridge     , & ! set to "-1" to turn off ridging
          ndte           ! number of subcycles
 
@@ -55,7 +55,7 @@
          dyn_mass_min,& ! minimum ice mass to activate dynamics (kg/m^2)
          elasticDamp    ! coefficient for calculating the parameter E, elastic damping parameter
 
-      ! other EVP parameters
+      ! other dynamics parameters
 
       character (len=char_len), public :: &
          yield_curve      , & ! 'ellipse' ('teardrop' needs further testing)
@@ -64,9 +64,10 @@
                               ! LKD: Lemieux et al. 2015, probabilistic: Dupont et al. 2022
 
       real (kind=dbl_kind), parameter, public :: &
-         u0    = 5e-5_dbl_kind, & ! residual velocity for seabed stress (m/s)
-         cosw  = c1           , & ! cos(ocean turning angle)  ! turning angle = 0
-         sinw  = c0               ! sin(ocean turning angle)  ! turning angle = 0
+         rheo_area_min = 1e-3_dbl_kind, & ! minimum ice area concentration to activate rheology
+         u0    = 5e-5_dbl_kind        , & ! residual velocity for seabed stress (m/s)
+         cosw  = c1                   , & ! cos(ocean turning angle)  ! turning angle = 0
+         sinw  = c0                       ! sin(ocean turning angle)  ! turning angle = 0
 
       real (kind=dbl_kind), public :: &
          revp        , & ! 0 for classic EVP, 1 for revised EVP

--- a/cicecore/cicedyn/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_vp.F90
@@ -204,7 +204,10 @@
          fpresx   , & ! fixed point residual vector, x components: fx = uvel - uprev_k
          fpresy   , & ! fixed point residual vector, y components: fy = vvel - vprev_k
          umass    , & ! total mass of ice and snow (u grid)
-         umassdti     ! mass of U-cell/dte (kg/m^2 s)
+         umassdti , & ! mass of U-cell/dte (kg/m^2 s)
+         rheofactU    ! mult. factor = 1, set to 0 if aiU < rheo_area_min
+                      ! rheofactU is not used but added for consistency with
+                      ! C-grid rheofactN and rheofactE (for call dyn_prep2)
 
       real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks,4):: &
          zetax2   , & ! zetax2 = 2*zeta (bulk viscosity)

--- a/cicecore/cicedyn/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_vp.F90
@@ -205,7 +205,7 @@
          fpresy   , & ! fixed point residual vector, y components: fy = vvel - vprev_k
          umass    , & ! total mass of ice and snow (u grid)
          umassdti , & ! mass of U-cell/dte (kg/m^2 s)
-         rheofactU    ! mult. factor = 1, set to 0 if aiU < rheo_area_min
+         rheofactU    ! mult. factor = 1, set to 0 if aiU <= rheo_area_min
                       ! rheofactU is not used but added for consistency with
                       ! C-grid rheofactN and rheofactE (for call dyn_prep2)
 

--- a/cicecore/cicedyn/dynamics/ice_dyn_vp.F90
+++ b/cicecore/cicedyn/dynamics/ice_dyn_vp.F90
@@ -352,7 +352,7 @@
                          indxUi      (:,iblk), indxUj      (:,iblk), &
                          aiU       (:,:,iblk), umass     (:,:,iblk), &
                          umassdti  (:,:,iblk), fcor_blk  (:,:,iblk), &
-                         umask     (:,:,iblk),                       &
+                         umask     (:,:,iblk), rheofactU (:,:,iblk), &
                          uocnU     (:,:,iblk), vocnU     (:,:,iblk), &
                          strairxU  (:,:,iblk), strairyU  (:,:,iblk), &
                          ss_tltxU  (:,:,iblk), ss_tltyU  (:,:,iblk), &

--- a/configuration/scripts/machines/env.ppp6_gnu
+++ b/configuration/scripts/machines/env.ppp6_gnu
@@ -19,7 +19,7 @@ setenv ICE_MACHINE_MACHNAME ppp6
 setenv ICE_MACHINE_ENVNAME gnu
 setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/site6/cice/runs/
-setenv ICE_MACHINE_INPUTDATA /space/hall6/sitestore/eccc/cmd/e/sice500/
+setenv ICE_MACHINE_INPUTDATA /space/hall5/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/site6/cice/baselines/
 setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT qsub

--- a/configuration/scripts/machines/env.ppp6_gnu-impi
+++ b/configuration/scripts/machines/env.ppp6_gnu-impi
@@ -34,7 +34,7 @@ setenv ICE_MACHINE_MACHNAME ppp6
 setenv ICE_MACHINE_ENVNAME gnu-impi
 setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/site6/cice/runs/
-setenv ICE_MACHINE_INPUTDATA /space/hall6/sitestore/eccc/cmd/e/sice500/
+setenv ICE_MACHINE_INPUTDATA /space/hall5/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/site6/cice/baselines/
 setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT qsub

--- a/configuration/scripts/machines/env.ppp6_intel
+++ b/configuration/scripts/machines/env.ppp6_intel
@@ -36,7 +36,7 @@ setenv ICE_MACHINE_MACHNAME ppp6
 setenv ICE_MACHINE_ENVNAME intel
 setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/ppp6/cice/runs/
-setenv ICE_MACHINE_INPUTDATA /space/hall6/sitestore/eccc/cmd/e/sice500/
+setenv ICE_MACHINE_INPUTDATA /space/hall5/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/ppp6/cice/baselines/
 setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT qsub

--- a/configuration/scripts/machines/env.ppp6_intel19
+++ b/configuration/scripts/machines/env.ppp6_intel19
@@ -35,7 +35,7 @@ setenv ICE_MACHINE_MACHNAME ppp6
 setenv ICE_MACHINE_ENVNAME intel19
 setenv ICE_MACHINE_MAKE make
 setenv ICE_MACHINE_WKDIR ~/data/site6/cice/runs/
-setenv ICE_MACHINE_INPUTDATA /space/hall6/sitestore/eccc/cmd/e/sice500/
+setenv ICE_MACHINE_INPUTDATA /space/hall5/sitestore/eccc/cmd/e/sice500/
 setenv ICE_MACHINE_BASELINE ~/data/site6/cice/baselines/
 setenv ICE_MACHINE_MAXRUNLENGTH 6
 setenv ICE_MACHINE_SUBMIT "qsub"

--- a/configuration/scripts/options/set_nml.gridc
+++ b/configuration/scripts/options/set_nml.gridc
@@ -1,4 +1,2 @@
 grid_ice = 'C'
-dyn_area_min    = 0.001d0
-dyn_mass_min    = 0.01d0
 

--- a/configuration/scripts/options/set_nml.gridcd
+++ b/configuration/scripts/options/set_nml.gridcd
@@ -1,6 +1,4 @@
 grid_ice = 'C_override_D'
-dyn_area_min    = 0.001d0
-dyn_mass_min    = 0.01d0
 # visc_method=avg_zeta causes some gridcd tests to abort, use avg_strength for now
 visc_method = 'avg_strength'
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>

THIS IS A DRAFT...I need to finalize some of the testing. 

## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Set rheology term to zero for the C-grid for low concentration values at the E and N points (<1e-3) 
- [x] Developer(s): 
    @JFLemieux73 
- [x] Suggest PR reviewers from list in the column to the right.
    @eclare108213 
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    385 measured results of 385 total results
    385 of 385 tests PASSED
    0 of 385 tests PENDING
    0 of 385 tests MISSING data
    0 of 385 tests FAILED

    note: this is for dyn_area_min    = 0.001d0 and dyn_mass_min    = 0.01d0

    with the same values as for the B-grid (i.e. dyn_area_min  = 1e-11 and dyn_mass_min  = 1e-10) the C-grid is now stable but the results are of course not BFB. I will add more info later. 

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [x] Yes
        - [ ] No 

   Do we need to write in the doc that rheology is set to zero for aice<1e-3 ?

- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Reducing dyn_area_min and dyn_mass_min (see PR https://github.com/CICE-Consortium/CICE/pull/1055) led to instability with the C-grid. The modifications to the code in this PR correct this problem by setting the rheology term to zero for small values of  concentration (<1e-3).

