### PR TITLE
Add ability to read an extended grid

### DIFF
--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -1259,7 +1259,8 @@
       if (trim(ice_data_type) == 'default') ice_data_type = 'latsst'
 
       ! For backward compatibility
-      if (grid_format ==  'nc') grid_format = 'pop_nc'
+      if (grid_format ==  'nc'    ) grid_format = 'pop_nc'
+      if (grid_format ==  'nc_ext') grid_format = 'pop_nc_ext'
 
       !-----------------------------------------------------------------
       ! verify inputs
@@ -2757,6 +2758,7 @@
       endif                     ! my_task = master_task
 
       if (grid_format /=  'pop_nc'        .and. &
+          grid_format /=  'pop_nc_ext'    .and. &
           grid_format /=  'mom_nc'        .and. &
           grid_format /=  'geosnc'        .and. &
           grid_format /=  'meshnc'        .and. &

--- a/cicecore/cicedyn/infrastructure/comm/serial/ice_boundary.F90
+++ b/cicecore/cicedyn/infrastructure/comm/serial/ice_boundary.F90
@@ -783,7 +783,7 @@ contains
 !-----------------------------------------------------------------------
 
    if (.not. ltripoleOnly) then
-      ! tripoleOnly skip fill, do not overwrite any values in interior as they may 
+      ! tripoleOnly skip fill, do not overwrite any values in interior as they may
       ! already be set and filling tripole is not necessary
 
       ! fill outer boundary as needed

--- a/cicecore/cicedyn/infrastructure/ice_blocks.F90
+++ b/cicecore/cicedyn/infrastructure/ice_blocks.F90
@@ -161,7 +161,7 @@ contains
 !  the global index will go from -nghost+1:0 on the lower boundary
 !  and n*_global+1:n*_global+nghost on the upper boundary and the
 !  haloUpdate and scatter, for instance, will not fill those values
-!  in those cases.  Other boundary condition methods will fill the 
+!  in those cases.  Other boundary condition methods will fill the
 !  outer halo values in cases where ice exists on those boundaries.
 !
 !----------------------------------------------------------------------

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -224,7 +224,7 @@
 
       ! write pointer (path/file)
       if (my_task == master_task) then
-#ifdef CESMCOUPLED 
+#ifdef CESMCOUPLED
             lpointer_file = 'rpointer.ice'//trim(inst_suffix)
 #else
             lpointer_file = pointer_file

--- a/cicecore/drivers/unittest/halochk/halochk.F90
+++ b/cicecore/drivers/unittest/halochk/halochk.F90
@@ -450,15 +450,15 @@
             k1m = 1
             k2m = 1
             halofld = '2DL1'
-            where (darrayi1 == fillval) 
+            where (darrayi1 == fillval)
                larrayi1 = .false.
             elsewhere
-               larrayi1 = (mod(nint(darrayi1),2) == 1) 
+               larrayi1 = (mod(nint(darrayi1),2) == 1)
             endwhere
-            where (darrayj1 == fillval) 
+            where (darrayj1 == fillval)
                larrayj1 = .true.
             elsewhere
-               larrayj1 = (mod(nint(darrayj1),2) == 1) 
+               larrayj1 = (mod(nint(darrayj1),2) == 1)
             endwhere
             if (halofill) then
                call ice_haloUpdate(larrayi1, halo_info, field_loc(nl), field_type(nt), fillvalue=0)

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -311,6 +311,7 @@ grid_nml
    "``grid_format``", "``bin``", "read direct access grid and kmt files", "``bin``"
    "", "``geosnc``", "read grid and kmt file in GEOS netcdf format", ""
    "", "``pop_nc``", "read grid and kmt files in POP netcdf format", ""
+   "", "``pop_nc_ext``", "read extended grid and kmt files in POP netcdf format", ""
    "", "``meshnc``", "coupled model grid option, no CICE code support", ""
    "", "``mom_nc``", "read grid in MOM (supergrid) format and kmt files", ""
    "``grid_ice``", "``B``", "use B grid structure with T at center and U at NE corner", "``B``"


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Add ability to read an extended grid
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Moderate test suite run on derecho with six compilers, tests pass and bit-for-bit as expected.  Tested the extended grid capability (no test cases exist yet) in a full + nest development testcase.  This test will be added in the future when full + nest capability is added to CICE.
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Add ability to read an extended grid (supported for pop netcdf file format)

- Add subroutine popgrid_nc_ext to read an extended grid pop netcdf file
- Add 'nc_ext' option to grid_format namelist
- The extended grid will apply to the kmt file as well as these are specified by the same grid_format namelist
- Modify gridbox_verts to operate on a local array instead of a global array, this should improve performance and removes redundant extrapolation calculations.  This approach also supports both regular and extended grid reads.

The implementation largely duplicates subroutine popgrid_nc but for an extended grid in subroutine popgrid_nc_ext.  The extended grid represents the active points plus the full halo.  As much as possible, the extended grid (LON, LAT, ANGLE, KMT) is read in on the halo instead of being computed.  For some grid metrics (DXT, DYT, DXU, DYU, etc), extrapolation is still required onto the halo.

Remove some trailing blanks is other places as needed.

