### PR TITLE
Initialize worka for sifb history

### DIFF
--- a/cicecore/cicedyn/analysis/ice_history.F90
+++ b/cicecore/cicedyn/analysis/ice_history.F90
@@ -3064,6 +3064,7 @@
          endif
 
          if (f_sifb(1:1) /= 'x') then
+           worka(:,:) = c0
            do j = jlo, jhi
            do i = ilo, ihi
               if (aice(i,j,iblk) > puny) then


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Minor bug fix to initialize worka=0 for sifb history
- [x] Developer(s): 
    Nick Szapiro
- [ ] Suggest PR reviewers from list in the column to the right.
    I don't have permissions to do this (?)
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    ufs-weather-model regression testing 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit, for all variables except sifb history
    - [ ] different at roundoff level
    - [x] more substantial bug fixes for sifb history 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
Minor fix to initialize worka=0 for sifb history variable accumulation (like elsewhere in ice_history) so don't have uninitialized values being accumulated. This is needed to fix out-of-range history values for sifb (in UFS)