### PR TITLE
Remove references to no-longer-used flds_wiso

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
@@ -116,7 +116,6 @@ contains
     integer             :: n
     character(char_len) :: stdname
     character(char_len) :: cvalue
-    logical             :: flds_wiso         ! use case
     logical             :: isPresent, isSet
     character(len=*), parameter :: subname='(ice_import_export:ice_advertise_fields)'
     !-------------------------------------------------------------------------------
@@ -139,18 +138,6 @@ contains
        if (allocated(fswthrun_ai)) then
           deallocate(fswthrun_ai)
        end if
-    end if
-
-    ! Determine if the following attributes are sent by the driver and if so read them in
-    flds_wiso = .false.
-    call NUOPC_CompAttributeGet(gcomp, name='flds_wiso', value=cvalue, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (isPresent .and. isSet) then
-       read(cvalue,*) flds_wiso
-    end if
-    if (my_task == master_task) then
-       write(nu_diag,*)'flds_wiso = ',flds_wiso
     end if
 
     flds_wave = .false.
@@ -178,9 +165,6 @@ contains
     call fldlist_add(fldsToIce_num, fldsToIce, 'So_u'    )
     call fldlist_add(fldsToIce_num, fldsToIce, 'So_v'    )
     call fldlist_add(fldsToIce_num, fldsToIce, 'Fioo_q'  )
-    if (flds_wiso) then
-       call fldlist_add(fldsToIce_num, fldsToIce, 'So_roce_wiso', ungridded_lbound=1, ungridded_ubound=3)
-    end if
 
     ! from atmosphere
     call fldlist_add(fldsToIce_num, fldsToIce, 'Sa_z'       )
@@ -288,15 +272,6 @@ contains
     call fldlist_add(fldsFrIce_num , fldsFrIce, 'Fioi_bcpho'  )
     call fldlist_add(fldsFrIce_num , fldsFrIce, 'Fioi_bcphi'  )
     call fldlist_add(fldsFrIce_num , fldsFrIce, 'Fioi_flxdst' )
-
-    if (flds_wiso) then
-       call fldlist_add(fldsFrIce_num, fldsFrIce, 'Fioi_meltw_wiso', &
-            ungridded_lbound=1, ungridded_ubound=3)
-       call fldlist_add(fldsFrIce_num, fldsFrIce, 'Faii_evap_wiso', &
-            ungridded_lbound=1, ungridded_ubound=3)
-       call fldlist_add(fldsFrIce_num, fldsFrIce, 'Si_qref_wiso', &
-            ungridded_lbound=1, ungridded_ubound=3)
-    end if
 
     do n = 1,fldsFrIce_num
        call NUOPC_Advertise(exportState, standardName=fldsFrIce(n)%stdname, &


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Remove references to no-longer-used flds_wiso
- [x] Developer(s): 
    Bill Sacks
- [x] Suggest PR reviewers from list in the column to the right.
    Dave Bailey
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    No testing yet
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

The handling of water tracers / isotopes is being overhauled and will look different moving forward. (See also https://github.com/ESCOMP/CMEPS/pull/638)