### PR TITLE
Update Derecho intel and inteloneapi port.  Add mpif08 unit test.

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
@@ -169,6 +169,7 @@
          else
             ncfile = trim(history_dir)//ncfile
          endif
+         write(nu_diag,*) subname,' Writing ',trim(ncfile)
 
          ! create file
          if (history_format == 'cdf1') then
@@ -289,7 +290,8 @@
             endif
 
             ! Define coord time_bounds if hist_avg is true
-            if (hist_avg(ns) .and. .not. write_ic) then
+            ! History restarts are snapshots of accumulated data at current time, do not write time bounds
+            if (hist_avg(ns) .and. .not. write_ic .and. .not. write_histrest_now) then
                time_coord = coord_attributes('time_bounds', 'time interval endpoints', trim(cal_units), 'undefined')
 
                dimid(1) = boundid
@@ -741,7 +743,8 @@
 
             ! Some coupled models require the time axis "stamp" to be in the middle
             ! or even beginning of averaging interval.
-            if (hist_avg(ns)) then
+            ! history restarts are snapshots of accumulated data at current time
+            if (hist_avg(ns) .and. .not. write_histrest_now) then
                if (trim(hist_time_axis) == "begin" ) ltime2 = time_beg(ns)
                if (trim(hist_time_axis) == "middle") ltime2 = p5*(time_beg(ns)+time_end(ns))
             endif
@@ -753,7 +756,8 @@
             call ice_check_nc(status, subname// ' ERROR: writing time variable', &
                               file=__FILE__, line=__LINE__)
 
-            if (hist_avg(ns) .and. .not. write_ic) then
+            ! History restarts are snapshots of accumulated data at current time, do not write time bounds
+            if (hist_avg(ns) .and. .not. write_ic .and. .not. write_histrest_now) then
                status = nf90_inq_varid(ncid,'time_bounds',varid)
                call ice_check_nc(status, subname// ' ERROR: getting time_bounds id', &
                                  file=__FILE__, line=__LINE__)

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_history_write.F90
@@ -281,7 +281,8 @@
          call ice_hist_coord_def(File, time_coord, pio_double, (/timid/), varid)
          call ice_pio_check(pio_put_att(File,varid,'calendar',cal_att), &
                  subname//' ERROR: defining att calendar: '//cal_att,file=__FILE__,line=__LINE__)
-         if (hist_avg(ns) .and. .not. write_ic) then
+         ! History restarts are snapshots of accumulated data at current time, do not write time bounds
+         if (hist_avg(ns) .and. .not. write_ic .and. .not. write_histrest_now) then
             call ice_pio_check(pio_put_att(File,varid,'bounds','time_bounds'), &
                  subname//' ERROR: defining att bounds time_bounds',file=__FILE__,line=__LINE__)
          endif
@@ -723,7 +724,8 @@
 
          ! Some coupled models require the time axis "stamp" to be in the middle
          ! or even beginning of averaging interval.
-         if (hist_avg(ns)) then
+         ! history restarts are snapshots of accumulated data at current time
+         if (hist_avg(ns) .and. .not. write_histrest_now) then
             if (trim(hist_time_axis) == "begin" ) ltime2 = time_beg(ns)
             if (trim(hist_time_axis) == "middle") ltime2 = p5*(time_beg(ns)+time_end(ns))
          endif
@@ -733,7 +735,8 @@
          call ice_pio_check(pio_put_var(File,varid,(/1/),ltime2), &
               subname//' ERROR: setting var time',file=__FILE__,line=__LINE__)
 
-         if (hist_avg(ns) .and. .not. write_ic) then
+         ! History restarts are snapshots of accumulated data at current time, do not write time bounds
+         if (hist_avg(ns) .and. .not. write_ic .and. .not. write_histrest_now) then
             call ice_pio_check(pio_inq_varid(File,'time_bounds',varid), &
                  subname//' ERROR: getting time_bounds' ,file=__FILE__,line=__LINE__)
             time_bounds=(/time_beg(ns),time_end(ns)/)

--- a/cicecore/drivers/unittest/mpif08/mpif08.F90
+++ b/cicecore/drivers/unittest/mpif08/mpif08.F90
@@ -1,0 +1,205 @@
+
+      program mpif08
+
+      ! This tests the availability of mpi_f08 on porting platforms
+
+#define USE_MPI_F08
+#ifdef USE_MPI
+      use mpi
+#else
+      use mpi_f08
+#endif
+
+      implicit none
+
+      integer, parameter :: &
+                            int_kind  = selected_int_kind(6), &
+                            real_kind = selected_real_kind(6), &
+                            dbl_kind  = selected_real_kind(13)
+
+      integer(int_kind) :: i,j,k,n
+
+      integer(int_kind), parameter :: dsize = 8
+      integer(int_kind) :: arrayI(dsize,dsize)
+      real(real_kind)   :: array4(dsize,dsize)
+      real(dbl_kind)    :: array8(dsize,dsize)
+      real(dbl_kind)    :: carray8(dsize,dsize),rarray8(dsize,dsize)
+
+      integer(int_kind) :: my_task,master_task,npes
+      integer(int_kind) :: ierr,tag
+      integer(int_kind) :: sro ! send recv pe offset
+#ifdef USE_MPI
+      integer :: MPI_COMM_ICE
+      integer :: rrequest
+      integer :: rstatus(MPI_STATUS_SIZE)
+#else
+      type(MPI_COMM)    :: MPI_COMM_ICE
+      type(MPI_REQUEST) :: rrequest
+      type(MPI_STATUS)  :: rstatus
+#endif
+
+      integer(int_kind), parameter :: ntests1 = 4
+      integer(int_kind) :: iflag, gflag
+      integer(int_kind) :: cval,ival,sumi
+      real(real_kind)   :: sum4
+      real(dbl_kind)    :: sum8
+      character(len=8)  :: errorflag0
+      character(len=8)  :: errorflag1(ntests1)
+      character(len=32) :: stringflag1(ntests1)
+
+      character(len=*), parameter ::  &
+         passflag = 'PASS', &
+         failflag = 'FAIL'
+
+      character(len=*), parameter :: subname = '(mpif08)'
+
+      ! ---------------------------
+
+      call MPI_INIT(ierr)
+      if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_INIT'
+      call MPI_COMM_DUP(MPI_COMM_WORLD, MPI_COMM_ICE, ierr)
+      if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_COMM_DUP'
+
+      master_task = 0
+      call MPI_COMM_SIZE(MPI_COMM_ICE, npes, ierr)
+      if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_COMM_SIZE'
+      call MPI_COMM_RANK(MPI_COMM_ICE, my_task, ierr)
+      if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_COMM_RANK'
+      sro = max(npes/2,1)
+
+      if (my_task == master_task) then
+         write(6,*) ' '
+         write(6,*) '=========================================================='
+         write(6,*) ' '
+         write(6,*) 'RunningUnitTest MPIF08'
+#ifdef USE_MPI
+         write(6,*) ' with    use mpi'
+#else
+         write(6,*) ' with    use mpi_f08'
+#endif
+         write(6,*) ' '
+         write(6,*) ' npes         = ',npes
+         write(6,*) ' my_task      = ',my_task
+         write(6,*) ' sr pe offset = ',sro
+         write(6,*) ' '
+         flush(6)
+      endif
+
+      ! ---------------------------
+
+      errorflag0 = passflag
+      errorflag1 = passflag
+      stringflag1 = ' '
+
+      ival = 0
+      do k = 0,npes-1
+      do j = 1,dsize
+      do i = 1,dsize
+         cval = (k*100 + j*10 + i)
+         ival = ival + cval
+      enddo
+      enddo
+      enddo
+
+      do j = 1,dsize
+      do i = 1,dsize
+         cval = (my_task*100 + j*10 + i)
+         arrayI(i,j) = cval
+         array4(i,j) = real(cval,real_kind)
+         array8(i,j) = real(cval,dbl_kind)
+      enddo
+      enddo
+
+      ! for test 4, communicate array to neighbor task
+      do j = 1,dsize
+      do i = 1,dsize
+         cval = (mod(my_task+sro,npes)*100 + j*10 + i)
+         carray8(i,j) = real(cval,dbl_kind)
+      enddo
+      enddo
+
+!      if (my_task == master_task) write(6,*) 'ival = ',ival
+
+      do n = 1,ntests1
+         iflag = 0
+         gflag = 0
+         if (n == 1) then
+            stringflag1(n) = 'allreduce_int'
+            call MPI_ALLREDUCE(sum(arrayI), sumi, 1, MPI_INTEGER, MPI_SUM, MPI_COMM_ICE, ierr)
+            if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_ALLREDUCE arrayI'
+            if (sumi /= ival) iflag=1
+            if (my_task == master_task) write(6,*) ' Test ',n,ival,sumi
+            flush(6)
+         elseif (n == 2) then
+            stringflag1(n) = 'allreduce_r4'
+            call MPI_ALLREDUCE(sum(array4), sum4, 1, MPI_REAL, MPI_SUM, MPI_COMM_ICE, ierr)
+            if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_ALLREDUCE array4'
+            if (sum4 /= real(ival,real_kind)) iflag=1
+            if (my_task == master_task) write(6,*) ' Test ',n,ival,sum4
+            flush(6)
+         elseif (n == 3) then
+            stringflag1(n) = 'allreduce_r8'
+            call MPI_ALLREDUCE(sum(array8), sum8, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_ICE, ierr)
+            if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_ALLREDUCE array8'
+            if (sum8 /= real(ival,dbl_kind)) iflag=1
+            if (my_task == master_task) write(6,*) ' Test ',n,ival,sum8
+            flush(6)
+         elseif (n == 4) then
+            stringflag1(n) = 'irecv_send_r8'
+            tag = 1001
+            call MPI_IRECV(rarray8, dsize*dsize, MPI_DOUBLE, mod(my_task+sro,npes), tag, MPI_COMM_ICE, rrequest, ierr)
+            if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_IRECV'
+            call MPI_SEND(array8, dsize*dsize, MPI_DOUBLE, mod(my_task-sro+npes,npes), tag, MPI_COMM_ICE, ierr)
+            if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_SEND'
+            call MPI_WAIT(rrequest, rstatus, ierr)
+            if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_WAIT'
+            do j = 1,dsize
+            do i = 1,dsize
+               if (rarray8(i,j) /= carray8(i,j)) iflag=1
+            enddo
+            enddo
+            if (my_task == master_task) write(6,*) ' Test ',n,sum(carray8),sum(rarray8)
+            flush(6)
+         endif
+         call MPI_REDUCE(iflag, gflag, 1, MPI_INTEGER, MPI_MAX, master_task, MPI_COMM_ICE, ierr)
+         if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_REDUCE iflag'
+         if (my_task == master_task) then
+            if (gflag /= 0) then
+               write(6,*) '   **** ERROR test ',n
+               flush(6)
+               errorflag1(n) = failflag
+               errorflag0 = failflag
+            endif
+         endif
+      enddo
+
+      call MPI_BARRIER(MPI_COMM_ICE, ierr)
+      if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_BARRIER 2'
+
+      ! ---------------------------
+
+      if (my_task == master_task) then
+         write(6,*) ' '
+         do k = 1,ntests1
+            write(6,*) errorflag1(k),stringflag1(k)
+         enddo
+         write(6,*) ' '
+         write(6,*) 'MPIF08 COMPLETED SUCCESSFULLY'
+         if (errorflag0 == passflag) then
+            write(6,*) 'MPIF08 TEST COMPLETED SUCCESSFULLY'
+         else
+            write(6,*) 'MPIF08 TEST FAILED'
+         endif
+      endif
+
+      flush(6)
+
+      ! ---------------------------
+      ! exit gracefully
+
+      call MPI_FINALIZE(ierr)
+      if (ierr /= MPI_SUCCESS) write(6,*) ' ERROR MPI_FINALIZE'
+
+      end program mpif08
+
+!=======================================================================

--- a/configuration/scripts/Makefile
+++ b/configuration/scripts/Makefile
@@ -74,7 +74,7 @@ AR    := ar
 
 .SUFFIXES:
 
-.PHONY: all cice libcice targets target db_files db_flags clean realclean helloworld calchk sumchk bcstchk gridavgchk halochk optargs opticep
+.PHONY: all cice libcice targets target db_files db_flags clean realclean helloworld calchk sumchk bcstchk gridavgchk halochk optargs opticep mpif08
 all: $(EXEC)
 
 cice: $(EXEC)
@@ -93,7 +93,7 @@ targets:
 	@echo " "
 	@echo "Supported Makefile Targets are: cice, libcice, makdep, depends, clean, realclean"
 	@echo "                   Diagnostics: targets, db_files, db_flags"
-	@echo "                   Unit Tests : helloworld, calchk, sumchk, bcstchk, gridavgchk, halochk, optargs, opticep"
+	@echo "                   Unit Tests : helloworld, calchk, sumchk, bcstchk, gridavgchk, halochk, optargs, opticep mpif08"
 target: targets
 
 db_files:
@@ -164,6 +164,10 @@ helloworld: $(HWOBJS)
 OAOBJS := optargs.o optargs_subs.o
 optargs: $(OAOBJS)
 	$(LD) -o $(EXEC) $(LDFLAGS) $(OAOBJS) $(ULIBS) $(SLIBS)
+
+M8OBJS := mpif08.o
+mpif08: $(M8OBJS)
+	$(LD) -o $(EXEC) $(LDFLAGS) $(M8OBJS) $(ULIBS) $(SLIBS)
 
 #-------------------------------------------------------------------------------
 # build rules: MACFILE, cmd-line, or env vars must provide the needed macros

--- a/configuration/scripts/machines/Macros.derecho_intel
+++ b/configuration/scripts/machines/Macros.derecho_intel
@@ -12,7 +12,8 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
+#  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
+  FFLAGS     += -O0 -check all -check noarg_temp_created -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv -init=snan,arrays -link_mpi=dbg
 #  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -link_mpi=dbg -stand f08
 #  FFLAGS     += -O0 -g -check all -fpe0 -ftrapuv -fp-model except -check noarg_temp_created -init=snan,arrays -link_mpi=dbg
 else

--- a/configuration/scripts/machines/Macros.derecho_inteloneapi
+++ b/configuration/scripts/machines/Macros.derecho_inteloneapi
@@ -13,7 +13,9 @@ FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
 # -check uninit is needed on the ld step but it still throws errors in 2023.* and 2024.0.*, likely compiler bug
-  FFLAGS     += -O0 -g  -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
+#  FFLAGS     += -O0 -g  -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
+  FFLAGS     += -O0 -check all -check noarg_temp_created -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv -init=snan,arrays -link_mpi=dbg
+#  LDFLAGS    += -check all
 #  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
 #  LDFLAGS    += -check uninit
 else

--- a/configuration/scripts/machines/env.derecho_inteloneapi
+++ b/configuration/scripts/machines/env.derecho_inteloneapi
@@ -10,28 +10,28 @@ if ("$inp" != "-nomodules") then
 source ${MODULESHOME}/init/csh
 
 module --force purge
-module load ncarenv/23.09
+module load ncarenv/25.10
 module load craype
-module load intel-oneapi/2023.2.1
+module load intel/2025.2.1
 #module load mkl/2023.3.0
-module load ncarcompilers/1.0.0
-module load cray-mpich/8.1.27
-module load netcdf/4.9.2
+module load ncarcompilers/1.2.0
+module load cray-mpich/8.1.32
+module load netcdf/4.9.3
 #module load hdf5/1.12.2
 #module load netcdf-mpi/4.9.2
 
-module load cray-libsci/23.09.1.1
+module load cray-libsci/25.03.0
 module load nco
 
 if ($?ICE_IOTYPE) then
 if ($ICE_IOTYPE =~ pio*) then
   module unload	netcdf
-  module load netcdf-mpi/4.9.2
-  module load parallel-netcdf/1.12.3
+  module load netcdf-mpi/4.9.3
+  module load parallel-netcdf/1.14.1
   if ($ICE_IOTYPE == "pio1") then
     module load parallelio/1.10.1
   else
-    module load parallelio/2.6.2
+    module load parallelio/2.6.8
   endif
 endif
 endif
@@ -63,7 +63,7 @@ setenv OMP_STACKSIZE 64M
 setenv ICE_MACHINE_MACHNAME derecho
 setenv ICE_MACHINE_MACHINFO "HPE Cray EX Milan Slingshot 11"
 setenv ICE_MACHINE_ENVNAME inteloneapi
-setenv ICE_MACHINE_ENVINFO "oneAPI DPC++/C++/ifx 2023.2.0 20230721, cray-mpich 8.1.27, netcdf4.9.2, pnetcdf1.12.3, pio1.10.1, pio2.6.2"
+setenv ICE_MACHINE_ENVINFO "oneAPI DPC++/C++/ifx 2025.2.1 20250806, cray-mpich 8.1.32, netcdf4.9.3, pnetcdf1.14.1, pio1.10.1, pio2.6.8"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR /glade/derecho/scratch/$user/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /glade/campaign/cesm/development/pcwg

--- a/configuration/scripts/options/set_env.mpif08
+++ b/configuration/scripts/options/set_env.mpif08
@@ -1,0 +1,2 @@
+setenv ICE_DRVOPT     unittest/mpif08
+setenv ICE_TARGET     mpif08

--- a/configuration/scripts/tests/unittest_suite.ts
+++ b/configuration/scripts/tests/unittest_suite.ts
@@ -3,6 +3,7 @@ smoke          gx3     8x2           diag1,run5day
 smoke          gx3     4x2x25x29x4   debug,run2day,dslenderX2
 unittest       gx3     1x1           helloworld
 unittest       gx3     1x1           calchk,short
+unittest       gx3     8x1           mpif08,debug
 unittest       gx3     4x1x25x29x4   sumchk
 unittest       gx3     1x1x25x29x16  sumchk
 unittest       tx1     8x1           sumchk

--- a/doc/source/user_guide/ug_testing.rst
+++ b/doc/source/user_guide/ug_testing.rst
@@ -742,6 +742,7 @@ The following are brief descriptions of some of the current unit tests,
  - **helloworld** is a simple test that writes out helloworld and uses no CICE infrastructure.
    This tests exists to demonstrate how to build a unit test by specifying the object files directly
    in the Makefile
+ - **mpif08** is a simple standalone unit test that checks whether the mpi_f08 module is available.
  - **optargs** is a unit test that tests passing optional arguments down a calling tree and verifying
    that the optional attribute is preserved correctly.
  - **opticep** is a cice test that turns off the icepack optional arguments passed into icepack.  This


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update Derecho intel and inteloneapi port.  Add mpif08 unit test.
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Ran a partial test suite on derecho with 6 compilers.  Everything passed.  derecho inteloneapi changes answers.  https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#043120305a888970f93bbf9e7f731d62164f0881
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit, except derecho inteloneapi due to compiler upgrade
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [X] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update Derecho intel and inteloneapi port.  Add mpif08 unit test.

Update the inteloneapi compiler version on derecho to 2025.2.1.  This is not bit-for-bit for derecho inteloneapi because of the compiler upgrade.

Update the intel and inteloneapi compiler debug options on derecho to better trap and warn.  These changes are based on the UFS compiler settings and to help meet UFS requirements.  The new settings are

  FFLAGS     += -O0 -check all -check noarg_temp_created -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv -init=snan,arrays -link_mpi=dbg

Modify history restart capability, do not write the time bounds with the history restarts as the variable time_end is not defined.  This was trapped by the new debug compiler flags and then fixed.  Modified netcdf and pio io options.

Add mpif08 unit test to check availability of the mpi_f08 module as we consider an update from "use mpi" to "use mpi_f08" in CICE.
