### PR TITLE
plot output from box tests

### DIFF
--- a/configuration/scripts/ciceplots.csh
+++ b/configuration/scripts/ciceplots.csh
@@ -2,14 +2,14 @@
 
 # User defined stuff
 
-#source ${MODULESHOME}/init/csh
+source ${MODULESHOME}/init/csh
 
 # Set plot type (box, global, timeseries)
 # Set case and case directory
 # Set files, notes, fstr, and fields
 
-#set plotgrid = "global"
-set plotgrid = "box"
+set plotgrid = "global"
+#set plotgrid = "box"
 #set plotgrid = "none"
 echo "plotgrid = ${plotgrid}"
 

--- a/configuration/scripts/ciceplots.csh
+++ b/configuration/scripts/ciceplots.csh
@@ -1,6 +1,13 @@
 #!/bin/csh -f
 
-# User defined stuff
+# This script can be modified as needed.
+# By default, the script is set up to create March and September plots for the global case:
+#   ./cice.setup -m derecho -e intel -g gx1 -p 128x1 -s gx1prod,long,run8year --case casename
+# The script can be edited to plot output from box cases, e.g.
+#   ./cice.setup -m conda -e macos --test smoke -s boxslotcyl --grid gbox80 -p 1x1 --testid 52cb686_remap
+# Plots of daily box output are currently set up in the script below.
+
+#### User defined ########################################
 
 source ${MODULESHOME}/init/csh
 
@@ -82,7 +89,8 @@ set fields = ("aice" "hi")
 
 endif
 
-# End user defined stuff
+#### End user defined ########################################
+
 echo " "
 
 # Plot timeseries

--- a/configuration/scripts/ciceplots.csh
+++ b/configuration/scripts/ciceplots.csh
@@ -1,14 +1,41 @@
 #!/bin/csh -f
 
+# User defined stuff
+
 #source ${MODULESHOME}/init/csh
 
-# User defined stuff
+# Set plot type (box, global, timeseries)
 # Set case and case directory
 # Set files, notes, fstr, and fields
-# Set plot type (box, global, timeseries)
 
-set case = "CICEv6"
-set casedir = "/Users/eclare/cice-dirs/runs/conda_macos_smoke_gbox80"
+#set plotgrid = "global"
+set plotgrid = "box"
+#set plotgrid = "none"
+echo "plotgrid = ${plotgrid}"
+
+set plottimeseries = "true"
+#set plottimeseries = "false"
+echo "plottimeseries = ${plottimeseries}"
+
+if ( ${plotgrid} == 'global' ) then
+
+set case = "CICE6.5.1"
+set casedir = "/glade/derecho/scratch/tcraig/CICE_RUNS/cgx1proda"
+set histdir = "${casedir}/history"
+
+set files = ("${histdir}/iceh.2012-03.nc" \
+             "${histdir}/iceh.2012-09.nc" )
+set notes = ("2012 March Mean" \
+             "2012 Sept Mean" )
+set fstrs = ("Mar12" \
+             "Sep12" )
+
+set fields = ("aice" "hi" "hs")
+
+else if ( ${plotgrid} == 'box' ) then
+
+set case = "52cb686_remap"
+set casedir = "/Users/eclare/cice-dirs/runs/conda_macos_smoke_gbox80_1x1_boxslotcyl.52cb686_remap"
 set histdir = "${casedir}/history"
 
 set files = ("${histdir}/iceh_ic.2005-01-01-00000.nc" \
@@ -51,20 +78,21 @@ set fstrs = ("ic" \
              "11days" \
              "12days" )
 
-set fields = ("aice" "hi" "hs")
+set fields = ("aice" "hi")
 
-set gridtype = "box"
-#set gridtype = "global"
-echo "gridtype = ${gridtype}"
+endif
 
-set plottimeseries = "false"
-#set plottimeseries = "true"
-echo "plottimeseries = ${plottimeseries}"
-
+# End user defined stuff
 echo " "
 
+# Plot timeseries
+if ( ${plottimeseries} == 'true' ) then
+    echo ./timeseries.py \"${casedir}\" --case \"${case}\" --grid
+    ./timeseries.py "${casedir}" --case "${case}" --grid
+endif
+
 # Plot global or box domain
-if ( ${gridtype} == 'global' ) then
+if ( ${plotgrid} == 'global' ) then
 
 #conda config --add channels conda-forge
 #conda config --set channel_priority strict
@@ -88,7 +116,7 @@ while ($cnt < ${#files})
   end
 end
 
-else if ( ${gridtype} == 'box' ) then
+else if ( ${plotgrid} == 'box' ) then
 
 set cnt = 0
 while ($cnt < ${#files})
@@ -105,12 +133,6 @@ end
 endif
 
 echo " "
-
-# Plot timeseries
-if ( ${plottimeseries} == 'true' ) then
-    echo ./timeseries.py \"${casedir}\" --case \"${case}\" --grid
-    ./timeseries.py "${casedir}" --case "${case}" --grid
-endif
 
 echo "DONE"
 

--- a/configuration/scripts/ciceplots.csh
+++ b/configuration/scripts/ciceplots.csh
@@ -1,26 +1,70 @@
 #!/bin/csh -f
 
-source ${MODULESHOME}/init/csh
+#source ${MODULESHOME}/init/csh
 
 # User defined stuff
 # Set case and case directory
 # Set files, notes, fstr, and fields
+# Set plot type (box, global, timeseries)
 
-set case = "CICE6.5.1"
-set casedir = "/glade/derecho/scratch/tcraig/CICE_RUNS/cgx1proda"
-
-# setup plots
-
+set case = "CICEv6"
+set casedir = "/Users/eclare/cice-dirs/runs/conda_macos_smoke_gbox80"
 set histdir = "${casedir}/history"
 
-set files = ("${histdir}/iceh.2012-03.nc" \
-             "${histdir}/iceh.2012-09.nc" )
-set notes = ("2012 March Mean" \
-             "2012 Sept Mean" )
-set fstrs = ("Mar12" \
-             "Sep12" )
+set files = ("${histdir}/iceh_ic.2005-01-01-00000.nc" \
+             "${histdir}/iceh_06h.2005-01-02-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-03-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-04-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-05-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-06-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-07-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-08-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-09-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-10-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-11-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-12-00000.nc"\
+             "${histdir}/iceh_06h.2005-01-13-00000.nc")
+set notes = ("initial condition" \
+             "after 1  day " \
+             "after 2  day " \
+             "after 3  day " \
+             "after 4  day " \
+             "after 5  day " \
+             "after 6  day " \
+             "after 7  day " \
+             "after 8  day " \
+             "after 9  day " \
+             "after 10 days" \
+             "after 11 days" \
+             "after 12 days" )
+set fstrs = ("ic" \
+             "1day" \
+             "2day" \
+             "3day" \
+             "4day" \
+             "5day" \
+             "6day" \
+             "7day" \
+             "8day" \
+             "9day" \
+             "10days" \
+             "11days" \
+             "12days" )
 
 set fields = ("aice" "hi" "hs")
+
+set gridtype = "box"
+#set gridtype = "global"
+echo "gridtype = ${gridtype}"
+
+set plottimeseries = "false"
+#set plottimeseries = "true"
+echo "plottimeseries = ${plottimeseries}"
+
+echo " "
+
+# Plot global or box domain
+if ( ${gridtype} == 'global' ) then
 
 #conda config --add channels conda-forge
 #conda config --set channel_priority strict
@@ -31,14 +75,6 @@ module load conda
 source ${NCAR_ROOT_CONDA}/etc/profile.d/conda.csh
 
 conda activate /glade/u/home/tcraig/conda/envs/basemap
-
-echo " "
-echo " "
-
-echo ./timeseries.py \"${casedir}\" --case \"${case}\" --grid
-./timeseries.py "${casedir}" --case "${case}" --grid
-
-echo " "
 
 set cnt = 0
 while ($cnt < ${#files})
@@ -51,6 +87,30 @@ while ($cnt < ${#files})
     ./ciceplots2d.py "$field" "$file" "$case" "$note" "$fstr"
   end
 end
+
+else if ( ${gridtype} == 'box' ) then
+
+set cnt = 0
+while ($cnt < ${#files})
+  @ cnt = $cnt + 1
+  set file = "${files[$cnt]}"
+  set note = "${notes[$cnt]}"
+  set fstr = "${fstrs[$cnt]}"
+  foreach field ($fields)
+    echo ./ciceplots2dbox.py \"$field\" \"$file\" \"$case\" \"$note\" \"$fstr\"
+    ./ciceplots2dbox.py "$field" "$file" "$case" "$note" "$fstr"
+  end
+end
+
+endif
+
+echo " "
+
+# Plot timeseries
+if ( ${plottimeseries} == 'true' ) then
+    echo ./timeseries.py \"${casedir}\" --case \"${case}\" --grid
+    ./timeseries.py "${casedir}" --case "${case}" --grid
+endif
 
 echo "DONE"
 

--- a/configuration/scripts/ciceplots2dbox.py
+++ b/configuration/scripts/ciceplots2dbox.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+#Importing the necessary libraries
+import sys
+import os
+import numpy as np
+from netCDF4 import Dataset
+import matplotlib.pyplot as plt
+
+if len(sys.argv) != 6:
+    print("ciceplots2d.py requires 5 arguments")
+    print("  1. field name in file, ie. \"aice\"")
+    print("  2. cice history file full path, ie. \"/glade/scratch/user/case/history/iceh.2012-03.nc\"")
+    print("  3. case name, used to annotate plot, ie. \"CICE6.5.1\"")
+    print("  4. notes, used to annotate plot, ie. 2012 \"March Mean\"")
+    print("  5. file string, use to create unique png filenames, ie. \"Mar12\"")
+    quit()
+
+field = sys.argv[1]
+pathf = sys.argv[2]
+casen = sys.argv[3]
+notes = sys.argv[4]
+fstr  = sys.argv[5]
+fname = os.path.basename(pathf)
+title = casen + " " + field + " " + notes
+cfnam = casen + "_" + fname
+#print("field = ",field)
+#print("pathf = ",pathf)
+#print("casen = ",casen)
+#print("notes = ",notes)
+#print("fname = ",fname)
+#print("title = ",title)
+#print("cfnam = ",cfnam)
+
+#Reading the netCDF file
+data = Dataset(pathf,'r')
+#print (data)
+
+#lons = data.variables['TLON'][:,:]
+#lats = data.variables['TLAT'][:,:]
+var1 = data.variables[field][:,:,:]
+var1 = var1[0,:,:]
+var1[ var1==0.00 ] = np.nan
+#mask = data.variables['tmask'][:,:]
+#mask[ mask>0.5 ] = np.nan
+
+#print("lons.shape = ",lons.shape)
+#print("var1.shape = ",var1.shape)
+
+# initialize the plot
+fig, ax = plt.subplots(figsize=(10, 6), dpi=300) # 300 DPI ensures crisp text and lines
+
+# generate the filled color contour map
+#contour_filled = ax.contourf(lons, lats, var1, levels=20, cmap='coolwarm')
+contour_filled = ax.contourf(var1, levels=20, cmap='coolwarm')
+
+# overlay black contour lines
+#contour_lines = ax.contour(lons, lats, var1, levels=20, colors='black', linewidths=0.3)
+contour_lines = ax.contour(var1, levels=20, colors='black', linewidths=0.3)
+ax.clabel(contour_lines, inline=True, fontsize=8, fmt='%.1f')
+
+# include a colorbar
+cmap = plt.get_cmap('jet')
+barticks = None
+fieldunits = ' '
+if field in ['hi']:
+    barticks=[0,0.5,1.0,1.5,2.0,2.5,3.0,3.5,4.0]
+    fieldunits='m'
+cbar = fig.colorbar(contour_filled, ax=ax, ticks=barticks)
+cbar.set_label(f"{field} ({fieldunits})")
+
+# define labels and layout
+ax.set_title(title)
+ax.set_xlabel('x')
+ax.set_ylabel('y')
+plt.tight_layout()
+
+# save as a .png image file
+# Use bbox_inches='tight' so labels do not get clipped out of the frame
+oname = casen + "_" + field + "_" + fstr + ".png"
+print('Saving file to ',oname)
+plt.savefig(oname, format='png', dpi=300, bbox_inches='tight')
+
+# finish
+plt.close(fig)
+print("Success: 'contour plot has been saved to your working directory.")
+
+quit()
+

--- a/configuration/scripts/options/set_nml.boxslotcyl
+++ b/configuration/scripts/options/set_nml.boxslotcyl
@@ -19,6 +19,7 @@ ktherm = -1
 kdyn   = -1
 kridge = -1
 ktransport = 1
+advection = 'remap'
 atm_data_type = 'box2001'
 ocn_data_type = 'box2001'
 ice_data_type = 'boxslotcyl'


### PR DESCRIPTION

- [x] Short (1 sentence) summary of your PR: 
script modifications for plotting output from box tests
- [x] Developer(s): 
    @eclare108213 
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ENTER INFORMATION HERE 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [x] Yes
        - [ ] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Added a python script to make simple 2-dimensional plots of output from box tests, in conjunction with the slotted cylinder tests shown in https://github.com/CICE-Consortium/CICE/issues/1072.  The new python script closely mimics the original one, which only made plots on global lat/lon grids.  I also altered the filenames and logic in `ciceplots.csh`.  The current version here shows what was needed for my box plots in the user-defined`files`, `notes`,  and `fstr` data.  I'd be happy to comment mine out in favor of the original, since (I think) it's used to create plots when we make a release, but there must be a better way to do this.  Suggestions are most welcome...

I added the `advection` namelist option to `set_nml.boxslotcyl`, since that test is aimed at advection and I wanted to check upwind too.  The code itself should still be BFB, including slotted cylinder tests.