### PR TITLE
Use /usr/bin/env -S csh -f instead of /bin/csh -f

### DIFF
--- a/.github/workflows/write_logfiles.csh
+++ b/.github/workflows/write_logfiles.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #echo "hello"
 

--- a/.github/workflows/write_logfiles.csh
+++ b/.github/workflows/write_logfiles.csh
@@ -1,4 +1,4 @@
-#!/bin/csh 
+#!/usr/bin/env csh -f
 
 #echo "hello"
 

--- a/cice.setup
+++ b/cice.setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #set pd0 = `date -u "+%s%N"`
 
@@ -501,7 +501,7 @@ else
   cp -f ${ICE_SCRIPTS}/tests/poll_queue.csh ${tsdir}
 
   cat >! ${tsdir}/suite.submit << EOF0
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 set nonomatch && rm -f ciceexe.* && unset nonomatch
 rm -f suite.jobs
@@ -536,7 +536,7 @@ endif
 EOF0
 
   cat >! ${tsdir}/results.csh << EOF0
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 rm -f results.log
 echo "#------- " >> results.log
 echo "#repo = ${remote}" >> results.log
@@ -555,7 +555,7 @@ echo "#------- " >> results.log
 EOF0
 
 cat >! ${tsdir}/report_codecov.csh << EOF0
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 source ${ICE_SCRIPTS}/machines/env.${machcomp}
 

--- a/cice.setup
+++ b/cice.setup
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 #set pd0 = `date -u "+%s%N"`
 
@@ -501,7 +501,7 @@ else
   cp -f ${ICE_SCRIPTS}/tests/poll_queue.csh ${tsdir}
 
   cat >! ${tsdir}/suite.submit << EOF0
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 set nonomatch && rm -f ciceexe.* && unset nonomatch
 rm -f suite.jobs
@@ -536,7 +536,7 @@ endif
 EOF0
 
   cat >! ${tsdir}/results.csh << EOF0
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 rm -f results.log
 echo "#------- " >> results.log
 echo "#repo = ${remote}" >> results.log
@@ -555,7 +555,7 @@ echo "#------- " >> results.log
 EOF0
 
 cat >! ${tsdir}/report_codecov.csh << EOF0
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 source ${ICE_SCRIPTS}/machines/env.${machcomp}
 

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 if ( $1 != "" ) then
   echo "running cice.batch.csh (creating ${1})"
@@ -16,7 +16,7 @@ source ${ICE_SCRIPTS}/setup_machparams.csh
 #==========================================
 
 cat >! ${jobfile} << EOF0
-#!/bin/csh -f 
+#!/usr/bin/env csh -f 
 EOF0
 
 #==========================================

--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 if ( $1 != "" ) then
   echo "running cice.batch.csh (creating ${1})"
@@ -16,7 +16,7 @@ source ${ICE_SCRIPTS}/setup_machparams.csh
 #==========================================
 
 cat >! ${jobfile} << EOF0
-#!/usr/bin/env csh -f 
+#!/usr/bin/env -S csh -f 
 EOF0
 
 #==========================================

--- a/configuration/scripts/cice.build
+++ b/configuration/scripts/cice.build
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 #====================================
 # If the cice binary is passed via the --exe argument and the file exists,

--- a/configuration/scripts/cice.build
+++ b/configuration/scripts/cice.build
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #====================================
 # If the cice binary is passed via the --exe argument and the file exists,

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 #echo ${0}
 echo "running cice.launch.csh"

--- a/configuration/scripts/cice.launch.csh
+++ b/configuration/scripts/cice.launch.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #echo ${0}
 echo "running cice.launch.csh"

--- a/configuration/scripts/cice.run.setup.csh
+++ b/configuration/scripts/cice.run.setup.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 #echo ${0}
 echo "running cice.run.setup.csh"
@@ -121,7 +121,7 @@ chmod +x ${jobfile}
 #==========================================
 
 cat >! ${subfile} << EOFS
-#!/bin/csh -f 
+#!/usr/bin/env csh -f 
 
 ${ICE_MACHINE_SUBMIT} ./${jobfile}
 echo "\`date\` \${0}: ${ICE_CASENAME} job submitted"  >> ${ICE_CASEDIR}/README.case

--- a/configuration/scripts/cice.run.setup.csh
+++ b/configuration/scripts/cice.run.setup.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #echo ${0}
 echo "running cice.run.setup.csh"
@@ -121,7 +121,7 @@ chmod +x ${jobfile}
 #==========================================
 
 cat >! ${subfile} << EOFS
-#!/usr/bin/env csh -f 
+#!/usr/bin/env -S csh -f 
 
 ${ICE_MACHINE_SUBMIT} ./${jobfile}
 echo "\`date\` \${0}: ${ICE_CASENAME} job submitted"  >> ${ICE_CASEDIR}/README.case

--- a/configuration/scripts/cice.settings
+++ b/configuration/scripts/cice.settings
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 setenv ICE_CASENAME   undefined
 setenv ICE_SANDBOX    undefined

--- a/configuration/scripts/cice.settings
+++ b/configuration/scripts/cice.settings
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 setenv ICE_CASENAME   undefined
 setenv ICE_SANDBOX    undefined

--- a/configuration/scripts/cice.test.setup.csh
+++ b/configuration/scripts/cice.test.setup.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 #source ./cice.settings
 #source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} || exit 2
@@ -61,7 +61,7 @@ cat >> ${jobfile} < ${ICE_SCRIPTS}/tests/baseline.script
 chmod +x ${jobfile}
 
 cat >! ${subfile} << EOFS
-#!/bin/csh -f 
+#!/usr/bin/env csh -f 
 
 ${ICE_MACHINE_SUBMIT} ./${jobfile}
 echo "\`date\` \${0}: ${ICE_CASENAME} job submitted"  >> ${ICE_CASEDIR}/README.case

--- a/configuration/scripts/cice.test.setup.csh
+++ b/configuration/scripts/cice.test.setup.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #source ./cice.settings
 #source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} || exit 2
@@ -61,7 +61,7 @@ cat >> ${jobfile} < ${ICE_SCRIPTS}/tests/baseline.script
 chmod +x ${jobfile}
 
 cat >! ${subfile} << EOFS
-#!/usr/bin/env csh -f 
+#!/usr/bin/env -S csh -f 
 
 ${ICE_MACHINE_SUBMIT} ./${jobfile}
 echo "\`date\` \${0}: ${ICE_CASENAME} job submitted"  >> ${ICE_CASEDIR}/README.case

--- a/configuration/scripts/cice_decomp.csh
+++ b/configuration/scripts/cice_decomp.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #--- inputs ---
 

--- a/configuration/scripts/cice_decomp.csh
+++ b/configuration/scripts/cice_decomp.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 #--- inputs ---
 

--- a/configuration/scripts/ciceplots.csh
+++ b/configuration/scripts/ciceplots.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 source ${MODULESHOME}/init/csh
 

--- a/configuration/scripts/ciceplots.csh
+++ b/configuration/scripts/ciceplots.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 source ${MODULESHOME}/init/csh
 

--- a/configuration/scripts/set_version_number.csh
+++ b/configuration/scripts/set_version_number.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 if ( $#argv < 1 ) then
   echo "$0 requires one argument, none passed"

--- a/configuration/scripts/set_version_number.csh
+++ b/configuration/scripts/set_version_number.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 if ( $#argv < 1 ) then
   echo "$0 requires one argument, none passed"

--- a/configuration/scripts/setup_machparams.csh
+++ b/configuration/scripts/setup_machparams.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 # inputs
 # mpi tasks

--- a/configuration/scripts/setup_machparams.csh
+++ b/configuration/scripts/setup_machparams.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 # inputs
 # mpi tasks

--- a/configuration/scripts/setup_run_dirs.csh
+++ b/configuration/scripts/setup_run_dirs.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 source ./cice.settings
 source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} -nomodules || exit 2

--- a/configuration/scripts/setup_run_dirs.csh
+++ b/configuration/scripts/setup_run_dirs.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 source ./cice.settings
 source ${ICE_CASEDIR}/env.${ICE_MACHCOMP} -nomodules || exit 2

--- a/configuration/scripts/tests/QC/compare_qc_cases.csh
+++ b/configuration/scripts/tests/QC/compare_qc_cases.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 # Read in the case directories for the 4 different QC cases
 set QC_DIR = "./qc_logs"

--- a/configuration/scripts/tests/QC/compare_qc_cases.csh
+++ b/configuration/scripts/tests/QC/compare_qc_cases.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 # Read in the case directories for the 4 different QC cases
 set QC_DIR = "./qc_logs"

--- a/configuration/scripts/tests/QC/gen_qc_cases.csh
+++ b/configuration/scripts/tests/QC/gen_qc_cases.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 set initargv = ( $argv[*] )
 

--- a/configuration/scripts/tests/QC/gen_qc_cases.csh
+++ b/configuration/scripts/tests/QC/gen_qc_cases.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 set initargv = ( $argv[*] )
 

--- a/configuration/scripts/tests/cice.codecov.csh
+++ b/configuration/scripts/tests/cice.codecov.csh
@@ -1,3 +1,4 @@
+#!/usr/bin/env csh -f
 
 #--- cice.codecov.csh ---
 

--- a/configuration/scripts/tests/cice.codecov.csh
+++ b/configuration/scripts/tests/cice.codecov.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #--- cice.codecov.csh ---
 

--- a/configuration/scripts/tests/cice.lcov.csh
+++ b/configuration/scripts/tests/cice.lcov.csh
@@ -1,3 +1,4 @@
+#!/usr/bin/env csh -f
 
 #--- cice.lcov.csh ---
 

--- a/configuration/scripts/tests/cice.lcov.csh
+++ b/configuration/scripts/tests/cice.lcov.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #--- cice.lcov.csh ---
 

--- a/configuration/scripts/tests/cice.results.csh
+++ b/configuration/scripts/tests/cice.results.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 #--- cice.results.csh --- 
 

--- a/configuration/scripts/tests/cice.results.csh
+++ b/configuration/scripts/tests/cice.results.csh
@@ -1,3 +1,4 @@
+#!/usr/bin/env csh -f
 
 #--- cice.results.csh --- 
 

--- a/configuration/scripts/tests/cice_test_codecov.csh
+++ b/configuration/scripts/tests/cice_test_codecov.csh
@@ -1,4 +1,4 @@
-#!/bin/csh 
+#!/usr/bin/env csh -f
 
 # This was a script on gordon
 # This script should only be run on hardware with the gnu compiler

--- a/configuration/scripts/tests/cice_test_codecov.csh
+++ b/configuration/scripts/tests/cice_test_codecov.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 # This was a script on gordon
 # This script should only be run on hardware with the gnu compiler

--- a/configuration/scripts/tests/comparebfb.csh
+++ b/configuration/scripts/tests/comparebfb.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 # Compare the CICE files via binary cmp diff
 #-----------------------------------------------------------

--- a/configuration/scripts/tests/comparebfb.csh
+++ b/configuration/scripts/tests/comparebfb.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 # Compare the CICE files via binary cmp diff
 #-----------------------------------------------------------

--- a/configuration/scripts/tests/comparelog.csh
+++ b/configuration/scripts/tests/comparelog.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 # Compare prognostic output in two log files
 #-----------------------------------------------------------

--- a/configuration/scripts/tests/comparelog.csh
+++ b/configuration/scripts/tests/comparelog.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 # Compare prognostic output in two log files
 #-----------------------------------------------------------

--- a/configuration/scripts/tests/create_fails.csh
+++ b/configuration/scripts/tests/create_fails.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 echo " "
 set tmpfile = create_fails.tmp
@@ -30,7 +30,7 @@ rm $tmpfile
 cat results.log | grep ' run' | grep -v "#" | grep -v PASS | cut -f 2 -d " " | grep -v _decomp_ | sort -u >! $tmpfile
 cat results.log | grep ' run' | grep -v "#" | grep -v PASS | cut -f 2 -d " " | grep _decomp_  | rev | cut -d _ -f 2- | rev | sort -u >> $tmpfile
 
-echo "#/usr/bin/env csh -f" >! $runfile
+echo "#/usr/bin/env -S csh -f" >! $runfile
 foreach line ( "`cat $tmpfile`" )
   #echo $line
   echo "cd ${line}.${delim}; ./*.submit; cd ../; sleep 5" >> $runfile

--- a/configuration/scripts/tests/create_fails.csh
+++ b/configuration/scripts/tests/create_fails.csh
@@ -1,4 +1,4 @@
-#!/bin/csh
+#!/usr/bin/env csh -f
 
 echo " "
 set tmpfile = create_fails.tmp
@@ -30,7 +30,7 @@ rm $tmpfile
 cat results.log | grep ' run' | grep -v "#" | grep -v PASS | cut -f 2 -d " " | grep -v _decomp_ | sort -u >! $tmpfile
 cat results.log | grep ' run' | grep -v "#" | grep -v PASS | cut -f 2 -d " " | grep _decomp_  | rev | cut -d _ -f 2- | rev | sort -u >> $tmpfile
 
-echo "#/bin/csh" >! $runfile
+echo "#/usr/bin/env csh -f" >! $runfile
 foreach line ( "`cat $tmpfile`" )
   #echo $line
   echo "cd ${line}.${delim}; ./*.submit; cd ../; sleep 5" >> $runfile

--- a/configuration/scripts/tests/poll_queue.csh
+++ b/configuration/scripts/tests/poll_queue.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 if (-e poll_queue.env) then
   source poll_queue.env

--- a/configuration/scripts/tests/poll_queue.csh
+++ b/configuration/scripts/tests/poll_queue.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 if (-e poll_queue.env) then
   source poll_queue.env

--- a/configuration/scripts/tests/report_results.csh
+++ b/configuration/scripts/tests/report_results.csh
@@ -1,4 +1,4 @@
-#!/bin/csh -f
+#!/usr/bin/env csh -f
 
 if ($#argv == 0) then
   echo "${0}: Running results.csh"

--- a/configuration/scripts/tests/report_results.csh
+++ b/configuration/scripts/tests/report_results.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 
 if ($#argv == 0) then
   echo "${0}: Running results.csh"

--- a/configuration/tools/jra55_datasets/make_forcing.csh
+++ b/configuration/tools/jra55_datasets/make_forcing.csh
@@ -1,4 +1,4 @@
-#!/bin/csh
+#!/usr/bin/env csh -f
 # -----
 # This is a script that worked on NCAR's cheyenne in March, 2021.
 # It converts raw JRA55 datasets to a format that CICE can use.

--- a/configuration/tools/jra55_datasets/make_forcing.csh
+++ b/configuration/tools/jra55_datasets/make_forcing.csh
@@ -1,4 +1,4 @@
-#!/usr/bin/env csh -f
+#!/usr/bin/env -S csh -f
 # -----
 # This is a script that worked on NCAR's cheyenne in March, 2021.
 # It converts raw JRA55 datasets to a format that CICE can use.


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
    Use /usr/bin/env -S csh -f instead of /bin/csh -f
- [x] Developer(s): 
    @nsf-name
- [ ] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    (No need for a test, doesn't change any Fortran)
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [x] Yes
        - [ ] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

This commit changes the `csh` interpreter path from `/bin/csh` to `/usr/bin/env -S csh` in all cases where it's not unambiguously clear what machine CICE is running on. This makes all scripts more portable, as [`env` loads the first `csh` that appears in the path](https://en.wikipedia.org/wiki/Env), rather than assuming it exists at `/bin/csh` which might not be true on all systems. 

Note that `env -S` is not in POSIX; however, Linux, FreeBSD, and macOS have had the nonstandard `-S` option to `env` since it was added to the [GNU coreutils in July of 2018](https://savannah.gnu.org/forum/forum.php?forum_id=9187) and to [FreeBSD (and macOS, since they share coreutils) in November 2005](https://www.freebsd.org/releases/6.0R/relnotes-i386/). This breaks compatibility with systems shipping an old version of the coreutils, but Repology indicates that basically all systems with extant package repos [have this minimum version by now](https://repology.org/project/coreutils/versions). This also breaks out of the box compatibility with OpenBSD and Linux distributions that use BusyBox instead of the coreutils (like Alpine Linux), although users of those systems can install the GNU coreutils through a package or by compiling it themselves, and those OSes are likely rare in HPC environments where CICE is run. You'd also need the GNU coreutils for building `gfortran` anyways on those machines, so it's not an unreasonable dependency. Also, just in case any of the machines don't have this version, I didn't change any of the machine-specific scripts. 

Given that HPC environments don't let users install arbitrary system packages, I believe this change ensures forward compatibility for future distros that may not ship `csh` by default (for example, the AlmaLinux 10 HPC cluster at Williams College doesn't), as it is an uncommon shell for daily use. This change makes it easier for users to build their own version of `csh` and use it with CICE, without breaking backwards compatibility for existing callers (except in the case of old/uncommon systems like I mentioned above).
