### PR TITLE
Update blueback port

### DIFF
--- a/configuration/scripts/machines/env.blueback_aocc
+++ b/configuration/scripts/machines/env.blueback_aocc
@@ -13,7 +13,7 @@ module unload PrgEnv-gnu
 module unload PrgEnv-intel
 module unload PrgEnv-nvhpc
 module unload PrgEnv-aocc
-module load PrgEnv-aocc/8.5.0
+module load PrgEnv-aocc/8.7.0
 
 module unload aocc
 module load aocc/4.1.0
@@ -21,7 +21,7 @@ module load aocc/4.1.0
 module unload cray-mpich
 module unload mpi
 module unload openmpi
-module load cray-mpich/8.1.30
+module load cray-mpich/9.1.0
 #module load mpi/2021.11
 #module load openmpi/4.1.6
 
@@ -30,8 +30,8 @@ module unload cray-hdf5-parallel
 module unload cray-netcdf-hdf5parallel
 module unload cray-parallel-netcdf
 module unload netcdf
-module load cray-netcdf/4.9.0.13
-module load cray-hdf5/1.14.3.1
+module load cray-netcdf/4.9.2.3
+module load cray-hdf5/1.14.3.9
 
 setenv NETCDF_PATH ${NETCDF_DIR}
 limit coredumpsize unlimited
@@ -45,7 +45,7 @@ endif
 setenv ICE_MACHINE_MACHNAME blueback
 setenv ICE_MACHINE_MACHINFO "Cray EX4000 AMD Genoa, Slingshot-11 Interconnect"
 setenv ICE_MACHINE_ENVNAME intel
-setenv ICE_MACHINE_ENVINFO "AMD clang version 16.0.3 (CLANG: AOCC_4.1.0-Build#270 2023_07_10, cray-mpich/8.1.30, netcdf/4.9.0.13"
+setenv ICE_MACHINE_ENVINFO "AMD clang version 16.0.3 (CLANG: AOCC_4.1.0-Build#270 2023_07_10, cray-mpich/9.1.0, netcdf/4.9.2.3"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/projects/RASM/cice_consortium

--- a/configuration/scripts/machines/env.blueback_cray
+++ b/configuration/scripts/machines/env.blueback_cray
@@ -13,15 +13,15 @@ module unload PrgEnv-gnu
 module unload PrgEnv-intel
 module unload PrgEnv-nvhpc
 module unload PrgEnv-aocc
-module load PrgEnv-cray/8.5.0
+module load PrgEnv-cray/8.7.0
 
 module unload cce
-module load cce/18.0.0
+module load cce/21.0.0
 
 module unload cray-mpich
 module unload mpi
 module unload openmpi
-module load cray-mpich/8.1.30
+module load cray-mpich/9.1.0
 #module load mpi/2021.11
 #module load openmpi/4.1.6
 
@@ -30,8 +30,8 @@ module unload cray-hdf5-parallel
 module unload cray-netcdf-hdf5parallel
 module unload cray-parallel-netcdf
 module unload netcdf
-module load cray-netcdf/4.9.0.13
-module load cray-hdf5/1.14.3.1
+module load cray-netcdf/4.9.2.3
+module load cray-hdf5/1.14.3.9
 
 setenv NETCDF_PATH ${NETCDF_DIR}
 limit coredumpsize unlimited
@@ -45,7 +45,7 @@ endif
 setenv ICE_MACHINE_MACHNAME blueback
 setenv ICE_MACHINE_MACHINFO "Cray EX4000 AMD Genoa, Slingshot-11 Interconnect"
 setenv ICE_MACHINE_ENVNAME intel
-setenv ICE_MACHINE_ENVINFO "Cray Fortran/Clang 18.0.0, cray-mpich/8.1.30, netcdf/4.9.0.13"
+setenv ICE_MACHINE_ENVINFO "Cray Fortran/Clang 21.0.0, cray-mpich/9.1.0, netcdf/4.9.2.3"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/projects/RASM/cice_consortium

--- a/configuration/scripts/machines/env.blueback_gnu
+++ b/configuration/scripts/machines/env.blueback_gnu
@@ -13,15 +13,15 @@ module unload PrgEnv-gnu
 module unload PrgEnv-intel
 module unload PrgEnv-nvhpc
 module unload PrgEnv-aocc
-module load PrgEnv-gnu/8.5.0
+module load PrgEnv-gnu/8.7.0
 
 module unload gcc
-module load gcc-native/13.2
+module load gcc-native/14
 
 module unload cray-mpich
 module unload mpi
 module unload openmpi
-module load cray-mpich/8.1.30
+module load cray-mpich/9.1.0
 #module load mpi/2021.11
 #module load openmpi/4.1.6
 
@@ -30,8 +30,8 @@ module unload cray-hdf5-parallel
 module unload cray-netcdf-hdf5parallel
 module unload cray-parallel-netcdf
 module unload netcdf
-module load cray-netcdf/4.9.0.13
-module load cray-hdf5/1.14.3.1
+module load cray-netcdf/4.9.2.3
+module load cray-hdf5/1.14.3.9
 
 setenv NETCDF_PATH ${NETCDF_DIR}
 limit coredumpsize unlimited
@@ -45,7 +45,7 @@ endif
 setenv ICE_MACHINE_MACHNAME blueback
 setenv ICE_MACHINE_MACHINFO "Cray EX4000 AMD Genoa, Slingshot-11 Interconnect"
 setenv ICE_MACHINE_ENVNAME intel
-setenv ICE_MACHINE_ENVINFO "gfortran/gcc 13.3.0, cray-mpich/8.1.30, netcdf/4.9.0.13"
+setenv ICE_MACHINE_ENVINFO "gfortran/gcc 14.3.0, cray-mpich/9.1.0, netcdf/4.9.2.3"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/projects/RASM/cice_consortium

--- a/configuration/scripts/machines/env.blueback_intel
+++ b/configuration/scripts/machines/env.blueback_intel
@@ -13,7 +13,7 @@ module unload PrgEnv-gnu
 module unload PrgEnv-intel
 module unload PrgEnv-nvhpc
 module unload PrgEnv-aocc
-module load PrgEnv-intel/8.5.0
+module load PrgEnv-intel/8.7.0
 
 module unload intel
 module load intel/2023.2.0
@@ -21,7 +21,7 @@ module load intel/2023.2.0
 module unload cray-mpich
 module unload mpi
 module unload openmpi
-module load cray-mpich/8.1.30
+module load cray-mpich/9.1.0
 #module load mpi/2021.11
 #module load openmpi/4.1.6
 
@@ -30,8 +30,8 @@ module unload cray-hdf5-parallel
 module unload cray-netcdf-hdf5parallel
 module unload cray-parallel-netcdf
 module unload netcdf
-module load cray-netcdf/4.9.0.13
-module load cray-hdf5/1.14.3.1
+module load cray-netcdf/4.9.2.3
+module load cray-hdf5/1.14.3.9
 
 setenv NETCDF_PATH ${NETCDF_DIR}
 limit coredumpsize unlimited
@@ -45,7 +45,7 @@ endif
 setenv ICE_MACHINE_MACHNAME blueback
 setenv ICE_MACHINE_MACHINFO "Cray EX4000 AMD Genoa, Slingshot-11 Interconnect"
 setenv ICE_MACHINE_ENVNAME intel
-setenv ICE_MACHINE_ENVINFO "ifort 2021.10.0 20230609, icx 2023.2.0.20230622, cray-mpich/8.1.30, netcdf/4.9.0.13"
+setenv ICE_MACHINE_ENVINFO "ifort 2021.10.0 20230609, icx 2023.2.0.20230622, cray-mpich/9.1.0, netcdf/4.9.2.3"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/projects/RASM/cice_consortium

--- a/configuration/scripts/machines/env.blueback_nvhpc
+++ b/configuration/scripts/machines/env.blueback_nvhpc
@@ -16,12 +16,12 @@ module unload PrgEnv-aocc
 module load PrgEnv-nvhpc/8.5.0
 
 module unload nvhpc
-module load nvhpc/24.3
+module load nvhpc/25.9
 
 module unload cray-mpich
 module unload mpi
 module unload openmpi
-module load cray-mpich/8.1.30
+module load cray-mpich/9.1.0
 #module load mpi/2021.11
 #module load openmpi/4.1.6
 
@@ -30,8 +30,8 @@ module unload cray-hdf5-parallel
 module unload cray-netcdf-hdf5parallel
 module unload cray-parallel-netcdf
 module unload netcdf
-module load cray-netcdf/4.9.0.13
-module load cray-hdf5/1.14.3.1
+module load cray-netcdf/4.9.2.3
+module load cray-hdf5/1.14.3.9
 
 setenv NETCDF_PATH ${NETCDF_DIR}
 limit coredumpsize unlimited
@@ -45,7 +45,7 @@ endif
 setenv ICE_MACHINE_MACHNAME blueback
 setenv ICE_MACHINE_MACHINFO "Cray EX4000 AMD Genoa, Slingshot-11 Interconnect"
 setenv ICE_MACHINE_ENVNAME intel
-setenv ICE_MACHINE_ENVINFO "nvfortran 24.3-0, cray-mpich/8.1.30, netcdf/4.9.0.13"
+setenv ICE_MACHINE_ENVINFO "nvfortran 24.3-0, cray-mpich/9.1.0, netcdf/4.9.2.3"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $WORKDIR/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /p/work1/projects/RASM/cice_consortium


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Update the blueback port
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    This should only affect blueback.  All blueback results are bit-for-bit except cray which changed answers and nvhpc which no longer works.  https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#52cb686ad3e0801f24ddabdc8ba2413efe24fa04
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Update the blueback port after an upgrade, old modules no longer working.  The updated setup supports intel, cray, gnu, and aocc.  But nvhpc is no longer supported and the new nvidia compiler option also does not seem to work.  All results are bit-for-bit with prior modules except cray which changed answers.