### PR TITLE
Fix uninitialized fill values in ice_read_write.F90

### DIFF
--- a/cicecore/cicedyn/infrastructure/ice_read_write.F90
+++ b/cicecore/cicedyn/infrastructure/ice_read_write.F90
@@ -1416,10 +1416,10 @@
 !            write(nu_diag,*) subname,' Dim name = ',trim(dimname),', size = ',dimlen
 !         enddo
          ! optional
-         missingvalue = spval_dbl
          status = nf90_get_att(fid, varid, "_FillValue", missingvalue)
 !          call ice_check_nc(status, subname//' ERROR: Missing _FillValue', &
 !                            file=__FILE__, line=__LINE__)
+         if (status /= nf90_noerr) missingvalue = spval_dbl
          allocate(mask(nx,ny))
          do n=1,ncat
             if ( ieee_is_nan(missingvalue) ) then
@@ -1619,10 +1619,10 @@
             write(nu_diag,*) subname,' Dim name = ',trim(dimname),', size = ',dimlen
          enddo
          ! optional
-         missingvalue = spval_dbl
          status = nf90_get_att(fid, varid, "_FillValue", missingvalue)
 !          call ice_check_nc(status, subname//' ERROR: Missing _FillValue', &
 !                            file=__FILE__, line=__LINE__)
+         if (status /= nf90_noerr) missingvalue = spval_dbl
          allocate(mask(nx,ny))
          do n=1,ncat
             if ( ieee_is_nan(missingvalue) ) then

--- a/cicecore/cicedyn/infrastructure/ice_read_write.F90
+++ b/cicecore/cicedyn/infrastructure/ice_read_write.F90
@@ -1215,21 +1215,19 @@
       !-------------------------------------------------------------------
 
       if (my_task==master_task .and. diag) then
-           write(nu_diag,'(2a,i8,a,i8,2a)') &
-             subname,' fid= ',fid, ', lnrec = ',lnrec, &
-             ', varname = ',trim(varname)
-!          status = nf90_inquire(fid, nDimensions=ndim, nVariables=nvar)
-!          write(nu_diag,*) subname,' ndim= ',ndim,', nvar= ',nvar
-!          do id=1,ndim
+         write(nu_diag,'(2a,i8,a,i8,2a)') &
+            subname,' fid= ',fid, ', lnrec = ',lnrec, &
+            ', varname = ',trim(varname)
+!         status = nf90_inquire(fid, nDimensions=ndim, nVariables=nvar)
+!         write(nu_diag,*) subname,' ndim= ',ndim,', nvar= ',nvar
+!         do id=1,ndim
 !            status = nf90_inquire_dimension(fid,id,name=dimname,len=dimlen)
 !            write(nu_diag,*) subname,' Dim name = ',trim(dimname),', size = ',dimlen
 !         enddo
          ! optional
          status = nf90_get_att(fid, varid, "_FillValue", missingvalue)
-!          call ice_check_nc(status, subname//' ERROR: Missing _FillValue', &
-!                            file=__FILE__, line=__LINE__)
-!         write(nu_diag,*) subname,' missingvalue= ',missingvalue
          if (status /= nf90_noerr) missingvalue = spval_dbl
+!         write(nu_diag,*) subname,' missingvalue= ',missingvalue
          allocate(mask(nx,ny))
          if ( ieee_is_nan(missingvalue) ) then
             mask = ieee_is_nan(work_g1)
@@ -1406,20 +1404,19 @@
       !-------------------------------------------------------------------
 
       if (my_task==master_task .and. diag) then
-           write(nu_diag,'(2a,i8,a,i8,2a)') &
-              subname,' fid= ',fid, ', lnrec = ',lnrec, &
-             ', varname = ',trim(varname)
-!          status = nf90_inquire(fid, nDimensions=ndim, nVariables=nvar)
-!          write(nu_diag,*) subname,' ndim= ',ndim,', nvar= ',nvar
-!          do id=1,ndim
+         write(nu_diag,'(2a,i8,a,i8,2a)') &
+            subname,' fid= ',fid, ', lnrec = ',lnrec, &
+            ', varname = ',trim(varname)
+!         status = nf90_inquire(fid, nDimensions=ndim, nVariables=nvar)
+!         write(nu_diag,*) subname,' ndim= ',ndim,', nvar= ',nvar
+!         do id=1,ndim
 !            status = nf90_inquire_dimension(fid,id,name=dimname,len=dimlen)
 !            write(nu_diag,*) subname,' Dim name = ',trim(dimname),', size = ',dimlen
 !         enddo
          ! optional
          status = nf90_get_att(fid, varid, "_FillValue", missingvalue)
-!          call ice_check_nc(status, subname//' ERROR: Missing _FillValue', &
-!                            file=__FILE__, line=__LINE__)
          if (status /= nf90_noerr) missingvalue = spval_dbl
+!         write(nu_diag,*) subname,' missingvalue= ',missingvalue
          allocate(mask(nx,ny))
          do n=1,ncat
             if ( ieee_is_nan(missingvalue) ) then
@@ -1611,18 +1608,17 @@
       if (my_task==master_task .and. diag) then
          write(nu_diag,'(2a,i8,a,i8,2a)') &
             subname,' fid= ',fid, ', lnrec = ',lnrec, &
-           ', varname = ',trim(varname)
-         status = nf90_inquire(fid, nDimensions=ndim, nVariables=nvar)
-         write(nu_diag,*) subname,' ndim= ',ndim,', nvar= ',nvar
-         do id=1,ndim
-            status = nf90_inquire_dimension(fid,id,name=dimname,len=dimlen)
-            write(nu_diag,*) subname,' Dim name = ',trim(dimname),', size = ',dimlen
-         enddo
+            ', varname = ',trim(varname)
+!         status = nf90_inquire(fid, nDimensions=ndim, nVariables=nvar)
+!         write(nu_diag,*) subname,' ndim= ',ndim,', nvar= ',nvar
+!         do id=1,ndim
+!            status = nf90_inquire_dimension(fid,id,name=dimname,len=dimlen)
+!            write(nu_diag,*) subname,' Dim name = ',trim(dimname),', size = ',dimlen
+!         enddo
          ! optional
          status = nf90_get_att(fid, varid, "_FillValue", missingvalue)
-!          call ice_check_nc(status, subname//' ERROR: Missing _FillValue', &
-!                            file=__FILE__, line=__LINE__)
          if (status /= nf90_noerr) missingvalue = spval_dbl
+!         write(nu_diag,*) subname,' missingvalue= ',missingvalue
          allocate(mask(nx,ny))
          do n=1,ncat
             if ( ieee_is_nan(missingvalue) ) then


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix uninitialized fill values in ice_read_write.F90
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Testing on derecho with 4 compilers looks fine, https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#efbbbe2e0c2792ce5ebb5056bbe8c59a222f0ae6
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

Closes #1112 

This should complete the fixes to the uninitialized fill variables.  A first fix was applied with #1118.  This fixes a couple other instances.